### PR TITLE
Update LRU when index is used

### DIFF
--- a/src/main/scala/com/cloudant/clouseau/IndexManagerService.scala
+++ b/src/main/scala/com/cloudant/clouseau/IndexManagerService.scala
@@ -134,6 +134,9 @@ class IndexManagerService(ctx: ServiceContext[ConfigurationArgs]) extends Servic
     case ('open_error, path: String, error: Any) =>
       replyAll(path, error)
       'noreply
+    case ('touch_lru, path: String) =>
+      lru.get(path)
+      'noreply
   }
 
   override def trapMonitorExit(monitored: Any, ref: Reference, reason: Any) = monitored match {


### PR DESCRIPTION
Prior to this commit only index opening/lookup would update the
LRU. This commit updates the LRU on index activity, as it should
always have done. The effect is that we will close the least-recently
used index from now on.

BugzID: 75594
