### PR TITLE
81816 clouseau for clustered purge improvements

### DIFF
--- a/src/main/scala/com/cloudant/clouseau/ClouseauTypeFactory.scala
+++ b/src/main/scala/com/cloudant/clouseau/ClouseauTypeFactory.scala
@@ -41,6 +41,7 @@ case class UpdateDocMsg(id: String, doc: Document)
 case class DeleteDocMsg(id: String)
 case class CommitMsg(seq: Long)
 case class SetUpdateSeqMsg(seq: Long)
+case class SetPurgeSeqMsg(seq: Long)
 
 object ClouseauTypeFactory extends TypeFactory {
 
@@ -89,6 +90,8 @@ object ClouseauTypeFactory extends TypeFactory {
       Some(CommitMsg(toLong(reader.readTerm)))
     case ('set_update_seq, 2) =>
       Some(SetUpdateSeqMsg(toLong(reader.readTerm)))
+    case ('set_purge_seq, 2) =>
+      Some(SetPurgeSeqMsg(toLong(reader.readTerm)))
     case _ =>
       None
   }

--- a/src/main/scala/com/cloudant/clouseau/IndexManagerService.scala
+++ b/src/main/scala/com/cloudant/clouseau/IndexManagerService.scala
@@ -109,6 +109,8 @@ class IndexManagerService(ctx: ServiceContext[ConfigurationArgs]) extends Servic
         case pid =>
           ('ok, pid)
       }
+    case ('get_root_dir) =>
+      ('ok, rootDir.getAbsolutePath())
     case ('delete, path: String) =>
       lru.get(path) match {
         case null =>

--- a/src/test/scala/com/cloudant/clouseau/IndexServiceSpec.scala
+++ b/src/test/scala/com/cloudant/clouseau/IndexServiceSpec.scala
@@ -399,13 +399,23 @@ class IndexServiceSpec extends SpecificationWithJUnit {
       node.call(service, UpdateDocMsg("bar", doc2)) must be equalTo 'ok
       node.call(service, UpdateDocMsg("zzz", doc3)) must be equalTo 'ok
 
-      node.call(service, Group1Msg("*:*", "_id", true,"<distance,lon,lat,0.2,57.15,km>", 0, 10)) must beLike {
+      node.call(service, Group1Msg("*:*", "_id", true, "<distance,lon,lat,0.2,57.15,km>", 0, 10)) must beLike {
         case ('ok, List((foo, _), (zzz, _), (bar, _))) => ok
       }
 
-      node.call(service, Group1Msg("*:*", "_id", true,"<distance,lon,lat,12,57.15,km>", 0, 10)) must beLike {
+      node.call(service, Group1Msg("*:*", "_id", true, "<distance,lon,lat,12,57.15,km>", 0, 10)) must beLike {
         case ('ok, List((bar, _), (zzz, _), (foo, _))) => ok
       }
+    }
+
+    "support set/get purge seq" in new index_service {
+      node.call(service, 'get_purge_seq) must be equalTo ('ok, 0)
+      node.call(service, SetPurgeSeqMsg(1)) must be equalTo 'ok
+      Thread.sleep(100)
+      node.call(service, 'get_purge_seq) must be equalTo ('ok, 1)
+      node.call(service, SetPurgeSeqMsg(2)) must be equalTo 'ok
+      Thread.sleep(100)
+      node.call(service, 'get_purge_seq) must be equalTo ('ok, 2)
     }
 
   }

--- a/src/test/scala/com/cloudant/clouseau/IndexServiceSpec.scala
+++ b/src/test/scala/com/cloudant/clouseau/IndexServiceSpec.scala
@@ -399,23 +399,13 @@ class IndexServiceSpec extends SpecificationWithJUnit {
       node.call(service, UpdateDocMsg("bar", doc2)) must be equalTo 'ok
       node.call(service, UpdateDocMsg("zzz", doc3)) must be equalTo 'ok
 
-      node.call(service, Group1Msg("*:*", "_id", true, "<distance,lon,lat,0.2,57.15,km>", 0, 10)) must beLike {
+      node.call(service, Group1Msg("*:*", "_id", true,"<distance,lon,lat,0.2,57.15,km>", 0, 10)) must beLike {
         case ('ok, List((foo, _), (zzz, _), (bar, _))) => ok
       }
 
-      node.call(service, Group1Msg("*:*", "_id", true, "<distance,lon,lat,12,57.15,km>", 0, 10)) must beLike {
+      node.call(service, Group1Msg("*:*", "_id", true,"<distance,lon,lat,12,57.15,km>", 0, 10)) must beLike {
         case ('ok, List((bar, _), (zzz, _), (foo, _))) => ok
       }
-    }
-
-    "support set/get purge seq" in new index_service {
-      node.call(service, 'get_purge_seq) must be equalTo ('ok, 0)
-      node.call(service, SetPurgeSeqMsg(1)) must be equalTo 'ok
-      Thread.sleep(100)
-      node.call(service, 'get_purge_seq) must be equalTo ('ok, 1)
-      node.call(service, SetPurgeSeqMsg(2)) must be equalTo 'ok
-      Thread.sleep(100)
-      node.call(service, 'get_purge_seq) must be equalTo ('ok, 2)
     }
 
   }


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->

The primary purpose of clustered purge is to clean databases that have multiple deleted tombstones or single documents that contain large numbers of conflicts. But it can also be used to purge any document (deleted or non-deleted) with any number of revisions.

With PR https://github.com/apache/couchdb/pull/1187, the purge API and update on secondary index are implemented. The current PR is in charge of updating search index according to purge tree and record purge history in local purge document to make sure that the search index update is not out of date.

## Testing recommendations

<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->

## JIRA issue number
https://issues.apache.org/jira/browse/COUCHDB-3326

## Related Issues or Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those issues or pull requests here.  -->

https://github.com/apache/couchdb/pull/1186
https://github.com/apache/couchdb/pull/1187

## Checklist

- [X] Code is written and works correctly;
- [X] Changes are covered by tests;
- [X] Documentation reflects the changes;

