### PR TITLE
Add "neutral" launcher target with no overrides

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -157,6 +157,10 @@ the License.
         <configuration>
           <launchers>
             <launcher>
+              <id>clouseau</id>
+              <mainClass>com.cloudant.clouseau.Main</mainClass>
+            </launcher>
+            <launcher>
               <id>clouseau1</id>
               <mainClass>com.cloudant.clouseau.Main</mainClass>
               <jvmArgs>


### PR DESCRIPTION
@rnewson I hope I'm wrong here - but I can't find any other way to do what I'm trying to do easily.

Right now the `pom.xml` file offers 3 launcher configurations, designed to be used alongside the `dev/run` script.

Generally in production I'd expect to see clouseau configured by the `clouseau.ini` file. However, because the `pom.xml` file specifies `-D` overrides as jvmArgs, these override values contained in `clouseau.ini`. (I tested this empirically.) That means you can't use a `mvn scala:run` line without being forced into one of the 3 predefined launch configurations. (You can still launch clouseau with a complex `java` launch line that includes the correct classpath for scala+lucene and all dependencies if you want to. I don't want to.)

This PR adds a simple unconfigured option, `mvn scala:run -Dlauncher=clouseau`. This, plus a suitable `clouseau.ini` allows for full configuration of clouseau as desired. In fact, you can even pass the path to your `clouseau.ini` file on the command line via `mvn scala:run -Dlauncher=clouseau -DaddArgs=/path/to/my/clouseau.ini`