### PR TITLE
[deprecated]Move search index to .recovery directory when database is deleted

### DIFF
--- a/src/main/scala/com/cloudant/clouseau/ClouseauTypeFactory.scala
+++ b/src/main/scala/com/cloudant/clouseau/ClouseauTypeFactory.scala
@@ -30,7 +30,7 @@ case class SearchRequest(options: Map[Symbol, Any])
 
 case class OpenIndexMsg(peer: Pid, path: String, options: Any)
 case class CleanupPathMsg(path: String)
-case class MovePathMsg(srcPath: String, destPath: String)
+case class MovePathMsg(dbName: String)
 case class CleanupDbMsg(dbName: String, activeSigs: List[String])
 
 case class Group1Msg(query: String, field: String, refresh: Boolean, groupSort: Any, groupOffset: Int,
@@ -52,8 +52,8 @@ object ClouseauTypeFactory extends TypeFactory {
       Some(OpenIndexMsg(reader.readAs[Pid], reader.readAs[String], reader.readTerm))
     case ('cleanup, 2) =>
       Some(CleanupPathMsg(reader.readAs[String]))
-    case ('move, 3) =>
-      Some(MovePathMsg(reader.readAs[String], reader.readAs[String]))
+    case ('move, 2) =>
+      Some(MovePathMsg(reader.readAs[String]))
     case ('cleanup, 3) =>
       Some(CleanupDbMsg(reader.readAs[String], reader.readAs[List[String]]))
     case ('search, 2) =>

--- a/src/main/scala/com/cloudant/clouseau/ClouseauTypeFactory.scala
+++ b/src/main/scala/com/cloudant/clouseau/ClouseauTypeFactory.scala
@@ -30,6 +30,7 @@ case class SearchRequest(options: Map[Symbol, Any])
 
 case class OpenIndexMsg(peer: Pid, path: String, options: Any)
 case class CleanupPathMsg(path: String)
+case class MovePathMsg(path: String)
 case class CleanupDbMsg(dbName: String, activeSigs: List[String])
 
 case class Group1Msg(query: String, field: String, refresh: Boolean, groupSort: Any, groupOffset: Int,
@@ -51,6 +52,8 @@ object ClouseauTypeFactory extends TypeFactory {
       Some(OpenIndexMsg(reader.readAs[Pid], reader.readAs[String], reader.readTerm))
     case ('cleanup, 2) =>
       Some(CleanupPathMsg(reader.readAs[String]))
+    case ('move, 2) =>
+      Some(MovePathMsg(reader.readAs[String]))
     case ('cleanup, 3) =>
       Some(CleanupDbMsg(reader.readAs[String], reader.readAs[List[String]]))
     case ('search, 2) =>

--- a/src/main/scala/com/cloudant/clouseau/ClouseauTypeFactory.scala
+++ b/src/main/scala/com/cloudant/clouseau/ClouseauTypeFactory.scala
@@ -30,7 +30,7 @@ case class SearchRequest(options: Map[Symbol, Any])
 
 case class OpenIndexMsg(peer: Pid, path: String, options: Any)
 case class CleanupPathMsg(path: String)
-case class MovePathMsg(path: String)
+case class MovePathMsg(srcPath: String, destPath: String)
 case class CleanupDbMsg(dbName: String, activeSigs: List[String])
 
 case class Group1Msg(query: String, field: String, refresh: Boolean, groupSort: Any, groupOffset: Int,
@@ -52,8 +52,8 @@ object ClouseauTypeFactory extends TypeFactory {
       Some(OpenIndexMsg(reader.readAs[Pid], reader.readAs[String], reader.readTerm))
     case ('cleanup, 2) =>
       Some(CleanupPathMsg(reader.readAs[String]))
-    case ('move, 2) =>
-      Some(MovePathMsg(reader.readAs[String]))
+    case ('move, 3) =>
+      Some(MovePathMsg(reader.readAs[String], reader.readAs[String]))
     case ('cleanup, 3) =>
       Some(CleanupDbMsg(reader.readAs[String], reader.readAs[List[String]]))
     case ('search, 2) =>

--- a/src/main/scala/com/cloudant/clouseau/IndexCleanupService.scala
+++ b/src/main/scala/com/cloudant/clouseau/IndexCleanupService.scala
@@ -30,8 +30,8 @@ class IndexCleanupService(ctx: ServiceContext[ConfigurationArgs]) extends Servic
       recursivelyDelete(dir)
     case MovePathMsg(srcPath: String, destPath: String) =>
       logger.info("Moving '%s' to '%s'".format(srcPath, destPath))
-      val srcDir = new File(rootDir, srcPath)
-      val destDir = new File(rootDir, destPath)
+      val srcDir = new File(srcPath)
+      val destDir = new File(destPath)
       move(srcDir, destDir)
     case CleanupDbMsg(dbName: String, activeSigs: List[String]) =>
       logger.info("Cleaning up " + dbName)

--- a/src/main/scala/com/cloudant/clouseau/IndexCleanupService.scala
+++ b/src/main/scala/com/cloudant/clouseau/IndexCleanupService.scala
@@ -28,12 +28,11 @@ class IndexCleanupService(ctx: ServiceContext[ConfigurationArgs]) extends Servic
       val dir = new File(rootDir, path)
       logger.info("Removing %s".format(path))
       recursivelyDelete(dir)
-    case MovePathMsg(path: String) =>
-      val srcDir = new File(rootDir, path)
-      val recoveryDir = new File(rootDir, ".recovery")
-      val targetDir = new File(recoveryDir, path)
-      logger.info("Moving '%s' to '%s'".format(srcDir.getAbsolutePath, targetDir.getAbsolutePath))
-      move(srcDir, targetDir)
+    case MovePathMsg(srcPath: String, destPath: String) =>
+      logger.info("Moving '%s' to '%s'".format(srcPath, destPath))
+      val srcDir = new File(rootDir, srcPath)
+      val destDir = new File(rootDir, destPath)
+      move(srcDir, destDir)
     case CleanupDbMsg(dbName: String, activeSigs: List[String]) =>
       logger.info("Cleaning up " + dbName)
       val pattern = Pattern.compile("shards/[0-9a-f]+-[0-9a-f]+/" + dbName + "\\.[0-9]+/([0-9a-f]+)$")
@@ -68,13 +67,13 @@ class IndexCleanupService(ctx: ServiceContext[ConfigurationArgs]) extends Servic
       fileOrDir.delete
   }
 
-  private def move(srcDir: File, targetDir: File) {
-    if (!targetDir.exists) {
-      targetDir.mkdirs
+  private def move(srcDir: File, destDir: File) {
+    if (!destDir.exists) {
+      destDir.mkdirs
     }
-    if (!srcDir.renameTo(targetDir)) {
+    if (!srcDir.renameTo(destDir)) {
       logger.error("Failed to move directory from '%s' to '%s'".format(
-        srcDir.getAbsolutePath, targetDir.getAbsolutePath))
+        srcDir.getAbsolutePath, destDir.getAbsolutePath))
     }
   }
 

--- a/src/main/scala/com/cloudant/clouseau/IndexCleanupService.scala
+++ b/src/main/scala/com/cloudant/clouseau/IndexCleanupService.scala
@@ -28,10 +28,11 @@ class IndexCleanupService(ctx: ServiceContext[ConfigurationArgs]) extends Servic
       val dir = new File(rootDir, path)
       logger.info("Removing %s".format(path))
       recursivelyDelete(dir)
-    case MovePathMsg(srcPath: String, destPath: String) =>
-      logger.info("Moving '%s' to '%s'".format(srcPath, destPath))
-      val srcDir = new File(srcPath)
-      val destDir = new File(destPath)
+    case MovePathMsg(dbName: String) =>
+      val recoveryDir = new File(ctx.args.config.getString("clouseau.recovery_dir", "target/indexes/.recovery"))
+      val srcDir = new File(rootDir, dbName)
+      val destDir = new File(recoveryDir, dbName)
+      logger.info("Moving '%s' to '%s'".format(srcDir.getAbsolutePath, destDir.getAbsolutePath))
       move(srcDir, destDir)
     case CleanupDbMsg(dbName: String, activeSigs: List[String]) =>
       logger.info("Cleaning up " + dbName)

--- a/src/main/scala/com/cloudant/clouseau/IndexCleanupService.scala
+++ b/src/main/scala/com/cloudant/clouseau/IndexCleanupService.scala
@@ -28,6 +28,8 @@ class IndexCleanupService(ctx: ServiceContext[ConfigurationArgs]) extends Servic
       val dir = new File(rootDir, path)
       logger.info("Removing %s".format(path))
       recursivelyDelete(dir)
+    case MovePathMsg(path: String) =>
+      move(path)
     case CleanupDbMsg(dbName: String, activeSigs: List[String]) =>
       logger.info("Cleaning up " + dbName)
       val pattern = Pattern.compile("shards/[0-9a-f]+-[0-9a-f]+/" + dbName + "\\.[0-9]+/([0-9a-f]+)$")
@@ -60,6 +62,19 @@ class IndexCleanupService(ctx: ServiceContext[ConfigurationArgs]) extends Servic
         recursivelyDelete(file)
     if (fileOrDir.isFile)
       fileOrDir.delete
+  }
+
+  private def move(path: String) {
+    val orgDir = new File(rootDir, path)
+    val targetPath = ".recovery" + File.separator + path
+    val targetDir = new File(rootDir, targetPath)
+    logger.info("Moving '%s' to '%s'".format(path, targetPath))
+    if (!targetDir.exists) {
+      targetDir.mkdirs
+    }
+    if (!orgDir.renameTo(targetDir)) {
+      logger.error("Failed to move directory from '%s' to '%s'".format(path, targetPath))
+    }
   }
 
 }

--- a/src/test/scala/com/cloudant/clouseau/IndexCleanupServiceSpec.scala
+++ b/src/test/scala/com/cloudant/clouseau/IndexCleanupServiceSpec.scala
@@ -23,8 +23,7 @@ class IndexCleanupServiceSpec extends SpecificationWithJUnit {
   "the index clean-up service" should {
 
     "move index when database is deleted" in new cleanup_service {
-      node.cast(service, MovePathMsg("target" + File.separator + "indexes" + File.separator + "foo",
-        "target" + File.separator + "indexes" + File.separator + ".recovery" + File.separator + "foo")) must be equalTo 'ok
+      node.cast(service, MovePathMsg("foo")) must be equalTo 'ok
       Thread.sleep(1000)
       val indexdir = new File(new File(new File("target", "indexes"), ".recovery"), "foo")
       indexdir.exists must be equalTo true

--- a/src/test/scala/com/cloudant/clouseau/IndexCleanupServiceSpec.scala
+++ b/src/test/scala/com/cloudant/clouseau/IndexCleanupServiceSpec.scala
@@ -23,7 +23,7 @@ class IndexCleanupServiceSpec extends SpecificationWithJUnit {
   "the index clean-up service" should {
 
     "move index when database is deleted" in new cleanup_service {
-      node.cast(service, MovePathMsg("foo")) must be equalTo 'ok
+      node.cast(service, MovePathMsg("foo", ".recovery" + File.separator + "foo")) must be equalTo 'ok
       Thread.sleep(1000)
       val indexdir = new File(new File(new File("target", "indexes"), ".recovery"), "foo")
       indexdir.exists must be equalTo true

--- a/src/test/scala/com/cloudant/clouseau/IndexCleanupServiceSpec.scala
+++ b/src/test/scala/com/cloudant/clouseau/IndexCleanupServiceSpec.scala
@@ -1,0 +1,53 @@
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License. You may obtain a copy of
+// the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+
+package com.cloudant.clouseau
+
+import org.apache.commons.configuration.SystemConfiguration
+import org.specs2.mutable.SpecificationWithJUnit
+import java.io.File
+import concurrent._
+
+class IndexCleanupServiceSpec extends SpecificationWithJUnit {
+  sequential
+
+  "the index clean-up service" should {
+
+    "move index when database is deleted" in new cleanup_service {
+      node.cast(service, MovePathMsg("foo")) must be equalTo 'ok
+      Thread.sleep(1000)
+      val indexdir = new File(new File(new File("target", "indexes"), ".recovery"), "foo")
+      indexdir.exists must be equalTo true
+    }
+
+  }
+
+}
+
+trait cleanup_service extends RunningNode {
+  val config = new SystemConfiguration()
+  val args = new ConfigurationArgs(config)
+  val service = node.spawnService[IndexCleanupService, ConfigurationArgs](args)
+  val mbox = node.spawnMbox
+
+  val dir = new File(new File("target", "indexes"), ".recovery")
+  if (dir.exists) {
+    for (f <- dir.listFiles) {
+      f.delete
+    }
+  }
+
+  override def after {
+    super.after
+  }
+
+}

--- a/src/test/scala/com/cloudant/clouseau/IndexCleanupServiceSpec.scala
+++ b/src/test/scala/com/cloudant/clouseau/IndexCleanupServiceSpec.scala
@@ -46,8 +46,4 @@ trait cleanup_service extends RunningNode {
     }
   }
 
-  override def after {
-    super.after
-  }
-
 }

--- a/src/test/scala/com/cloudant/clouseau/IndexCleanupServiceSpec.scala
+++ b/src/test/scala/com/cloudant/clouseau/IndexCleanupServiceSpec.scala
@@ -23,7 +23,8 @@ class IndexCleanupServiceSpec extends SpecificationWithJUnit {
   "the index clean-up service" should {
 
     "move index when database is deleted" in new cleanup_service {
-      node.cast(service, MovePathMsg("foo", ".recovery" + File.separator + "foo")) must be equalTo 'ok
+      node.cast(service, MovePathMsg("target" + File.separator + "indexes" + File.separator + "foo",
+        "target" + File.separator + "indexes" + File.separator + ".recovery" + File.separator + "foo")) must be equalTo 'ok
       Thread.sleep(1000)
       val indexdir = new File(new File(new File("target", "indexes"), ".recovery"), "foo")
       indexdir.exists must be equalTo true


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview
Before change, the search index directories and files were directly deleted when database was deleted. This PR provides way of moving search index to directory like `/srv/search_index/.recovery/shard/60000000-7fffffff/<dbname.ts>/e66df316792ab411705e2741bba44371` when the corresponding database was deleted and "enable_database_recovery" configuration item is set to true. This allows search index files to be re-used if database is recovered. 

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->

## Testing recommendations
```
Running com.cloudant.clouseau.IndexCleanupServiceSpec
Running com.cloudant.clouseau.IndexCleanupServiceSpec
2017-07-28 17:12:06 clouseau.cleanup [INFO] Moving 'foo' to '.recovery/foo'
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.02 sec
Tests run: 0, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.033 sec

Results :

Tests run: 85, Failures: 0, Errors: 0, Skipped: 0

[INFO]
[INFO] --- maven-jar-plugin:2.2:jar (default-jar) @ clouseau ---
[INFO]
[INFO] --- maven-assembly-plugin:2.3:single (default) @ clouseau ---
[INFO] Reading assembly descriptor: src/main/assembly/distribution.xml
[INFO] Building zip: /Users/jiangph/couchdb/labs-clouseau3/clouseau/target/clouseau-2.10.0-SNAPSHOT.zip
[INFO] Building tar: /Users/jiangph/couchdb/labs-clouseau3/clouseau/target/clouseau-2.10.0-SNAPSHOT.tar.gz
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 24.148 s
[INFO] Finished at: 2017-07-28T17:12:10+08:00
[INFO] Final Memory: 15M/299M
[INFO] -----------------------------------------------------------------------
```
<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->

## GitHub issue number
Bugzid: 86318
<!-- If this is a significant change, please file a separate issue at:
     https://github.com/apache/couchdb/issues
     and include the number here and in commit message(s) using
     syntax like "Fixes #472" or "Fixes apache/couchdb#472".  -->

## Related Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those pull requests here.  -->
https://github.com/cloudant-labs/dreyfus/pull/19
https://github.com/cloudant/chef-repo/pull/7456
## Checklist

- [X] Code is written and works correctly;
- [X] Changes are covered by tests;
- [ ] Documentation reflects the changes;
