### PR TITLE
Rename search index directory in place when database is deleted

### DIFF
--- a/src/main/scala/com/cloudant/clouseau/ClouseauTypeFactory.scala
+++ b/src/main/scala/com/cloudant/clouseau/ClouseauTypeFactory.scala
@@ -30,6 +30,7 @@ case class SearchRequest(options: Map[Symbol, Any])
 
 case class OpenIndexMsg(peer: Pid, path: String, options: Any)
 case class CleanupPathMsg(path: String)
+case class RenamePathMsg(dbName: String)
 case class CleanupDbMsg(dbName: String, activeSigs: List[String])
 
 case class Group1Msg(query: String, field: String, refresh: Boolean, groupSort: Any, groupOffset: Int,
@@ -51,6 +52,8 @@ object ClouseauTypeFactory extends TypeFactory {
       Some(OpenIndexMsg(reader.readAs[Pid], reader.readAs[String], reader.readTerm))
     case ('cleanup, 2) =>
       Some(CleanupPathMsg(reader.readAs[String]))
+    case ('rename, 2) =>
+      Some(RenamePathMsg(reader.readAs[String]))
     case ('cleanup, 3) =>
       Some(CleanupDbMsg(reader.readAs[String], reader.readAs[List[String]]))
     case ('search, 2) =>

--- a/src/main/scala/com/cloudant/clouseau/IndexCleanupService.scala
+++ b/src/main/scala/com/cloudant/clouseau/IndexCleanupService.scala
@@ -15,6 +15,9 @@ package com.cloudant.clouseau
 import com.yammer.metrics.scala._
 import java.io.File
 import java.util.regex.Pattern
+import java.text.SimpleDateFormat
+import java.util.Calendar
+import java.util.TimeZone
 import org.apache.log4j.Logger
 import scalang._
 
@@ -28,6 +31,19 @@ class IndexCleanupService(ctx: ServiceContext[ConfigurationArgs]) extends Servic
       val dir = new File(rootDir, path)
       logger.info("Removing %s".format(path))
       recursivelyDelete(dir)
+    case RenamePathMsg(dbName: String) =>
+      val srcDir = new File(rootDir, dbName)
+      val sdf = new SimpleDateFormat("yyyyMMdd'.'HHmmss")
+      sdf.setTimeZone(TimeZone.getTimeZone("UTC"))
+      val sdfNow = sdf.format(Calendar.getInstance().getTime())
+      // move timestamp information in dbName to end of destination path
+      // for example, from foo.1234567890 to foo.20170912.092828.deleted.1234567890
+      val destPath = dbName.dropRight(10) + sdfNow + ".deleted." + dbName.takeRight(10)
+      val destDir = new File(rootDir, destPath)
+      logger.info("Renaming '%s' to '%s'".format(
+        srcDir.getAbsolutePath, destDir.getAbsolutePath)
+      )
+      rename(srcDir, destDir)
     case CleanupDbMsg(dbName: String, activeSigs: List[String]) =>
       logger.info("Cleaning up " + dbName)
       val pattern = Pattern.compile("shards/[0-9a-f]+-[0-9a-f]+/" + dbName + "\\.[0-9]+/([0-9a-f]+)$")
@@ -60,6 +76,16 @@ class IndexCleanupService(ctx: ServiceContext[ConfigurationArgs]) extends Servic
         recursivelyDelete(file)
     if (fileOrDir.isFile)
       fileOrDir.delete
+  }
+
+  private def rename(srcDir: File, destDir: File) {
+    if (!srcDir.isDirectory) {
+      return
+    }
+    if (!srcDir.renameTo(destDir)) {
+      logger.error("Failed to rename directory from '%s' to '%s'".format(
+        srcDir.getAbsolutePath, destDir.getAbsolutePath))
+    }
   }
 
 }

--- a/src/test/scala/com/cloudant/clouseau/IndexCleanupServiceSpec.scala
+++ b/src/test/scala/com/cloudant/clouseau/IndexCleanupServiceSpec.scala
@@ -1,0 +1,59 @@
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License. You may obtain a copy of
+// the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+
+package com.cloudant.clouseau
+
+import org.apache.commons.configuration.SystemConfiguration
+import org.specs2.mutable.SpecificationWithJUnit
+import java.io.File
+import concurrent._
+
+class IndexCleanupServiceSpec extends SpecificationWithJUnit {
+  sequential
+
+  "the index clean-up service" should {
+
+    "rename index when database is deleted" in new cleanup_service {
+      node.cast(service, RenamePathMsg("foo.1234567890")) must be equalTo 'ok
+      Thread.sleep(1000)
+      val indexdir = new File("target", "indexes")
+      var subdirlist = List[String]()
+
+      for (file <- indexdir.listFiles if file.getName contains ".deleted") {
+        subdirlist = file.getName() +: subdirlist
+      }
+      subdirlist.length > 0 must be equalTo true
+    }
+
+  }
+
+}
+
+trait cleanup_service extends RunningNode {
+  val config = new SystemConfiguration()
+  val args = new ConfigurationArgs(config)
+  val service = node.spawnService[IndexCleanupService, ConfigurationArgs](args)
+  val mbox = node.spawnMbox
+
+  val dir = new File("target", "indexes")
+  if (dir.exists) {
+    for (f <- dir.listFiles) {
+      f.delete
+    }
+  }
+
+  val foodir = new File(new File("target", "indexes"), "foo.1234567890")
+  if (!foodir.exists) {
+    foodir.mkdirs
+  }
+
+}


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview
Before change, the search index directories and files were directly deleted when database was deleted. This PR provides way of renaming search index in place, such as from `/srv/search_index/shard/60000000-7fffffff/<dbname.ts>/e66df316792ab411705e2741bba44371` to `/srv/search_index/shard/60000000-7fffffff/<dbname>.<yyyyMMdd.HHmmss>.deleted<.ts>/e66df316792ab411705e2741bba44371` when the corresponding database was deleted and "enable_database_recovery" configuration item is set to true. This allows search index files to be re-used if database is recovered. 

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->

## Testing recommendations
```
Running com.cloudant.clouseau.IndexCleanupServiceSpec
Running com.cloudant.clouseau.IndexCleanupServiceSpec
2017-09-12 17:41:06 clouseau.cleanup [INFO] Renaming '/Users/jiangph/couchdb/labs-clouseau3/clouseau/target/indexes/foo.1234567890' to '/Users/jiangph/couchdb/labs-clouseau3/clouseau/target/indexes/foo.20170912.094106.deleted.1234567890'
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.026 sec
Tests run: 0, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.042 sec

Results :

Tests run: 85, Failures: 0, Errors: 0, Skipped: 0

[INFO]
[INFO] --- maven-jar-plugin:2.2:jar (default-jar) @ clouseau ---
[INFO]
[INFO] --- maven-assembly-plugin:2.3:single (default) @ clouseau ---
[INFO] Reading assembly descriptor: src/main/assembly/distribution.xml
[INFO] Building zip: /Users/jiangph/couchdb/labs-clouseau3/clouseau/target/clouseau-2.10.0-SNAPSHOT.zip
[INFO] Building tar: /Users/jiangph/couchdb/labs-clouseau3/clouseau/target/clouseau-2.10.0-SNAPSHOT.tar.gz
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 11.425 s
[INFO] Finished at: 2017-09-12T17:41:10+08:00
[INFO] Final Memory: 22M/436M
[INFO] ------------------------------------------------------------------------
```
<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->

## GitHub issue number
Bugzid: 86318
<!-- If this is a significant change, please file a separate issue at:
     https://github.com/apache/couchdb/issues
     and include the number here and in commit message(s) using
     syntax like "Fixes #472" or "Fixes apache/couchdb#472".  -->

## Related Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those pull requests here.  -->
https://github.com/cloudant-labs/dreyfus/pull/22
https://github.com/cloudant-labs/clouseau/pull/15 was deprecated with this PR
## Checklist

- [X] Code is written and works correctly;
- [X] Changes are covered by tests;
- [ ] Documentation reflects the changes;
