### PR TITLE
Close LRU by database path for deleted database/index

### DIFF
--- a/src/main/scala/com/cloudant/clouseau/ClouseauTypeFactory.scala
+++ b/src/main/scala/com/cloudant/clouseau/ClouseauTypeFactory.scala
@@ -33,6 +33,7 @@ case class CleanupPathMsg(path: String)
 case class RenamePathMsg(dbName: String)
 case class CleanupDbMsg(dbName: String, activeSigs: List[String])
 case class DiskSizeMsg(path: String)
+case class CloseLRUByPathMsg(path: String)
 
 case class Group1Msg(query: String, field: String, refresh: Boolean, groupSort: Any, groupOffset: Int,
                      groupLimit: Int)
@@ -92,6 +93,8 @@ object ClouseauTypeFactory extends TypeFactory {
       Some(DeleteDocMsg(reader.readAs[String]))
     case ('disk_size, 2) =>
       Some(DiskSizeMsg(reader.readAs[String]))
+    case ('close_lru_by_path, 2) =>
+      Some(CloseLRUByPathMsg(reader.readAs[String]))
     case ('commit, 2) =>
       Some(CommitMsg(toLong(reader.readTerm)))
     case ('set_update_seq, 2) =>

--- a/src/main/scala/com/cloudant/clouseau/IndexManagerService.scala
+++ b/src/main/scala/com/cloudant/clouseau/IndexManagerService.scala
@@ -76,6 +76,15 @@ class IndexManagerService(ctx: ServiceContext[ConfigurationArgs]) extends Servic
       }
     }
 
+    def closeByPath(path: String) {
+      pidToPath foreach {
+        kv =>
+          if (kv._2.startsWith(path)) {
+            logger.info("closing lru for " + path)
+            kv._1 ! ('close, 'closing)
+          }
+      }
+    }
   }
 
   val logger = Logger.getLogger("clouseau.main")
@@ -123,6 +132,9 @@ class IndexManagerService(ctx: ServiceContext[ConfigurationArgs]) extends Servic
       getDiskSize(path)
     case 'close_lru =>
       lru.close()
+      'ok
+    case CloseLRUByPathMsg(path: String) =>
+      lru.closeByPath(path)
       'ok
     case 'version =>
       ('ok, getClass.getPackage.getImplementationVersion)

--- a/src/main/scala/com/cloudant/clouseau/IndexService.scala
+++ b/src/main/scala/com/cloudant/clouseau/IndexService.scala
@@ -220,7 +220,9 @@ class IndexService(ctx: ServiceContext[IndexServiceArgs]) extends Service(ctx) w
       ctx.args.writer.rollback()
     } catch {
       case e: AlreadyClosedException => 'ignored
-      case e: IOException => warn("Error while closing writer", e)
+      case e: IOException =>
+        warn("Error while closing writer", e)
+        ctx.args.writer.close()
     } finally {
       super.exit(msg)
     }


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->
The problem was originally exposed when updating search index with the following error:
```
{error, "*** eval: {'EXIT',{{badmatch,{error,<<"Lock obtain timed out: NativeFSLock@/srv/search_index/shards/20000000-3fffffff/user1/db1.1509715496/ec8bc1dc690a15d795e65f7dce409e2c/write.lock">>}},\n                   [{erl_eval,expr,3,[]}]}}"}
```

Finally, it turns out that the soft-deletion path is missing a call to evict the shard from LRU (and therefore release the associated locks). This causes that lock file was left in working directory and search index failed to be updated.

To address this, the fix is to close the corresponding index in LRU before index is to be renamed/deleted.


## Testing recommendations

<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->
@theburge made excellent troubleshooting and analysis, and also wrote below script to reproduce problem.

[repro2.sh.txt](https://github.com/apache/couchdb/files/3797041/repro2.sh.txt)

The problem doesn't occur after using the fix here and https://github.com/apache/couchdb/pull/2130
## Related Issues or Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those issues or pull requests here.  -->
https://github.com/apache/couchdb/pull/2130

## Checklist

- [x] Code is written and works correctly
- [X] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
