### PR TITLE
close writer before soft deletion of searchindex

### DIFF
--- a/src/main/scala/com/cloudant/clouseau/IndexCleanupService.scala
+++ b/src/main/scala/com/cloudant/clouseau/IndexCleanupService.scala
@@ -15,9 +15,6 @@ package com.cloudant.clouseau
 import com.yammer.metrics.scala._
 import java.io.File
 import java.util.regex.Pattern
-import java.text.SimpleDateFormat
-import java.util.Calendar
-import java.util.TimeZone
 import org.apache.log4j.Logger
 import scalang._
 
@@ -31,19 +28,10 @@ class IndexCleanupService(ctx: ServiceContext[ConfigurationArgs]) extends Servic
       val dir = new File(rootDir, path)
       logger.info("Removing %s".format(path))
       recursivelyDelete(dir)
-    case RenamePathMsg(dbName: String) =>
-      val srcDir = new File(rootDir, dbName)
-      val sdf = new SimpleDateFormat("yyyyMMdd'.'HHmmss")
-      sdf.setTimeZone(TimeZone.getTimeZone("UTC"))
-      val sdfNow = sdf.format(Calendar.getInstance().getTime())
-      // move timestamp information in dbName to end of destination path
-      // for example, from foo.1234567890 to foo.20170912.092828.deleted.1234567890
-      val destPath = dbName.dropRight(10) + sdfNow + ".deleted." + dbName.takeRight(10)
-      val destDir = new File(rootDir, destPath)
-      logger.info("Renaming '%s' to '%s'".format(
-        srcDir.getAbsolutePath, destDir.getAbsolutePath)
-      )
-      rename(srcDir, destDir)
+    case RenamePathMsg(path: String) =>
+      logger.info("Soft-deleting " + path)
+      val pattern = Pattern.compile(path + "/([0-9a-f]+)$")
+      rename(rootDir, path, pattern)
     case CleanupDbMsg(dbName: String, activeSigs: List[String]) =>
       logger.info("Cleaning up " + dbName)
       val pattern = Pattern.compile("shards/[0-9a-f]+-[0-9a-f]+/" + dbName + "\\.[0-9]+/([0-9a-f]+)$")
@@ -78,13 +66,23 @@ class IndexCleanupService(ctx: ServiceContext[ConfigurationArgs]) extends Servic
       fileOrDir.delete
   }
 
-  private def rename(srcDir: File, destDir: File) {
-    if (!srcDir.isDirectory) {
+  private def rename(fileOrDir: File, path: String, includePattern: Pattern) {
+    if (!fileOrDir.isDirectory) {
       return
     }
-    if (!srcDir.renameTo(destDir)) {
-      logger.error("Failed to rename directory from '%s' to '%s'".format(
-        srcDir.getAbsolutePath, destDir.getAbsolutePath))
+    for (file <- fileOrDir.listFiles) {
+      rename(file, path, includePattern)
+    }
+
+    val m = includePattern.matcher(fileOrDir.getAbsolutePath)
+    if (m.find) {
+      logger.info("Soft-deleting index " + m.group)
+      call('main, ('rename, m.group)) match {
+        case 'ok =>
+          'ok
+        case ('error, 'not_found) =>
+          Utils.rename(rootDir, path, fileOrDir.getName)
+      }
     }
   }
 

--- a/src/main/scala/com/cloudant/clouseau/IndexManagerService.scala
+++ b/src/main/scala/com/cloudant/clouseau/IndexManagerService.scala
@@ -119,6 +119,18 @@ class IndexManagerService(ctx: ServiceContext[ConfigurationArgs]) extends Servic
           pid ! 'delete
           'ok
       }
+    case ('rename, path: String) =>
+      lru.get(path) match {
+        case null =>
+          ('error, 'not_found)
+        case pid: Pid =>
+          call('pid, ('close_writer))
+          val dbpath = path.substring(0, path.lastIndexOf('/'))
+          val sig = path.substring(path.lastIndexOf('/') + 1)
+          Utils.rename(rootDir, dbpath, sig)
+          call('pid, ('exit_with_deleted))
+          'ok
+      }
     case DiskSizeMsg(path: String) =>
       getDiskSize(path)
     case 'close_lru =>


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->
This fix is to refactor the logic for soft-deletion of search index. In the past, there is case where write.lock was stayed in search index directory and can't be moved. It is due to the fact that the index was not closed gracefully before moving/renaming search index. With this fix, the search index writer can be closed, and then search index can be moved to .deleted directory smoothly.


## Testing recommendations

<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->
```
-------------------------------------------------------
 T E S T S
-------------------------------------------------------
Running com.cloudant.clouseau.AnalyzerServiceSpec
Running com.cloudant.clouseau.AnalyzerServiceSpec
Tests run: 0, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.024 sec
Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.238 sec
Running com.cloudant.clouseau.ClouseauTypeFactorySpec
Running com.cloudant.clouseau.ClouseauTypeFactorySpec
Tests run: 0, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 sec
Tests run: 12, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.022 sec
Running com.cloudant.clouseau.IndexManagerServiceSpec
Running com.cloudant.clouseau.IndexManagerServiceSpec
2019-11-21 15:26:30 clouseau [INFO] foo.5432109876 Renaming '/Users/jiangph/couchdb/clouseau.dreyfus/clouseau/target/indexes/foo.5432109876' to '/Users/jiangph/couchdb/clouseau.dreyfus/clouseau/target/indexes/foo.20191121.072630.deleted.5432109876'
Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.445 sec
Tests run: 0, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.465 sec
Running com.cloudant.clouseau.ClouseauQueryParserSpec
Running com.cloudant.clouseau.ClouseauQueryParserSpec
Tests run: 0, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 sec
Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.018 sec
Running com.cloudant.clouseau.IndexServiceSpec
Running com.cloudant.clouseau.IndexServiceSpec
Tests run: 23, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 23.937 sec
Tests run: 0, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 23.954 sec
Running com.cloudant.clouseau.SupportedAnalyzersSpec
Running com.cloudant.clouseau.SupportedAnalyzersSpec
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.003 sec
Tests run: 42, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.109 sec

Results :

Tests run: 95, Failures: 0, Errors: 0, Skipped: 0
```
## Related Issues or Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those issues or pull requests here.  -->
https://github.com/apache/couchdb/pull/2130

## Checklist

- [x] Code is written and works correctly
- [X] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
