### PR TITLE
Unlock IndexWriter when IndexService process exits

### DIFF
--- a/src/main/scala/com/cloudant/clouseau/IndexService.scala
+++ b/src/main/scala/com/cloudant/clouseau/IndexService.scala
@@ -222,7 +222,10 @@ class IndexService(ctx: ServiceContext[IndexServiceArgs]) extends Service(ctx) w
       case e: AlreadyClosedException => 'ignored
       case e: IOException =>
         warn("Error while closing writer", e)
-        ctx.args.writer.close()
+        val dir = ctx.args.writer.getDirectory
+        if (IndexWriter.isLocked(dir)) {
+          IndexWriter.unlock(dir);
+        }
     } finally {
       super.exit(msg)
     }


### PR DESCRIPTION

<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->
The problem was originally exposed when updating search index with the following error:
```
{error, "*** eval: {'EXIT',{{badmatch,{error,<<"Lock obtain timed out: NativeFSLock@/srv/search_index/shards/20000000-3fffffff/user1/db1.1509715496/ec8bc1dc690a15d795e65f7dce409e2c/write.lock">>}},\n                   [{erl_eval,expr,3,[]}]}}"}
```
The scenario that triggered problem is that we enable soft-deletion, create database, and then build search index. When database is deleted, the search index was renamed. Later on, the same search index is restored and replaced into the same place.  

@theburge mentioned that ` The issue is that the files are removed but the lock is held; when attempting to move a shard back to the same place as it was moved from, we get “lock obtain failed” from somewhere in Javaland.`

Thanks to @rnewson and @theburge for deep investigation and valuable suggestion, the current proposed solution is to unlock IndexWriter under the situation where IndexService process exits. To do so, this can avoid the holding of IndexWriter lock.

## Testing recommendations

<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->
@theburge made excellent troubleshooting and analysis, and also wrote below script to reproduce problem.

[repro2.sh.txt](https://github.com/apache/couchdb/files/3797041/repro2.sh.txt)

The problem doesn't occur after using the fix.

```
Dec 12 06:57:02 db1.testy026 local5: 2019-12-12 06:57:02,547 clouseau.main [INFO] Clouseau running as clouseau@127.0.0.1
Dec 12 06:57:11 db1.testy026 local5: 2019-12-12 06:57:11,528 clouseau.cleanup [INFO] Removing shards/00000000-ffffffff/test-user/test-db.1576133831
Dec 12 06:57:40 db1.testy026 local5: 2019-12-12 06:57:40,360 clouseau.cleanup [INFO] Renaming '/srv/search_index/shards/00000000-ffffffff/test-user/test-db.1576133831' to '/srv/search_index/shards/00000000-ffffffff/test-user/test-db.20191212.065740.deleted.1576133831'
Dec 12 06:57:49 db1.testy026 local5: 2019-12-12 06:57:49,196 clouseau.cleanup [INFO] Removing shards/00000000-ffffffff/test-user/test-db.1576133831
Dec 12 06:58:28 db1.testy026 local5: 2019-12-12 06:58:28,651 clouseau.cleanup [INFO] Renaming '/srv/search_index/shards/00000000-ffffffff/test-user/test-db.1576133831' to '/srv/search_index/shards/00000000-ffffffff/test-user/test-db.20191212.065828.deleted.1576133831'
```
## Related Issues or Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [x] Code is written and works correctly
- [] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
