### PR TITLE
feat: add simple_asciifolding analyzer

### DIFF
--- a/src/main/scala/com/cloudant/clouseau/SupportedAnalyzers.scala
+++ b/src/main/scala/com/cloudant/clouseau/SupportedAnalyzers.scala
@@ -12,9 +12,13 @@
 
 package com.cloudant.clouseau
 
+import java.io.Reader
 import java.util.{ Set => JSet }
 import org.apache.log4j.Logger
 import org.apache.lucene.analysis.Analyzer
+import org.apache.lucene.analysis.Tokenizer
+import org.apache.lucene.analysis.TokenStream
+import org.apache.lucene.analysis.Analyzer.TokenStreamComponents
 import org.apache.lucene.analysis.util.CharArraySet
 import scala.collection.JavaConversions._
 
@@ -61,6 +65,9 @@ import org.apache.lucene.analysis.tr.TurkishAnalyzer
 
 // Extras
 import org.apache.lucene.analysis.ja.JapaneseTokenizer
+import org.apache.lucene.analysis.miscellaneous.ASCIIFoldingFilter
+import org.apache.lucene.analysis.core.LowerCaseFilter
+import org.apache.lucene.analysis.core.LetterTokenizer
 
 object SupportedAnalyzers {
 
@@ -106,6 +113,13 @@ object SupportedAnalyzers {
       Some(new SimpleAnalyzer(IndexService.version))
     case "whitespace" =>
       Some(new WhitespaceAnalyzer(IndexService.version))
+    case "simple_asciifolding" =>
+      Some(new Analyzer() {
+         def createComponents(fieldName: String, reader: Reader): TokenStreamComponents = {
+            val tokenizer: Tokenizer = new LetterTokenizer(IndexService.version, reader);
+            new TokenStreamComponents(tokenizer, new ASCIIFoldingFilter(new LowerCaseFilter(IndexService.version, tokenizer)))
+         }
+       })
     case "arabic" =>
       options.get("stopwords") match {
         case Some(stopwords: List[String]) =>

--- a/src/test/scala/com/cloudant/clouseau/AnalyzerServiceSpec.scala
+++ b/src/test/scala/com/cloudant/clouseau/AnalyzerServiceSpec.scala
@@ -26,6 +26,10 @@ class AnalyzerServiceSpec extends SpecificationWithJUnit {
     "demonstrate keyword tokenization" in new analyzer_service {
       service.handleCall(null, ('analyze, "keyword", "foo bar baz")) must be equalTo (('ok, List("foo bar baz")))
     }
+
+    "demonstrate simple_asciifolding tokenization" in new analyzer_service {
+      service.handleCall(null, ('analyze, "simple_asciifolding", "Ayşegül Özbayır")) must be equalTo (('ok, List("aysegul", "ozbayir")))
+    }
   }
 }
 

--- a/src/test/scala/com/cloudant/clouseau/SupportedAnalyzersSpec.scala
+++ b/src/test/scala/com/cloudant/clouseau/SupportedAnalyzersSpec.scala
@@ -12,6 +12,7 @@
 
 package com.cloudant.clouseau
 
+import org.apache.lucene.analysis.Analyzer
 import org.apache.lucene.analysis.core.KeywordAnalyzer
 import org.apache.lucene.analysis.core.SimpleAnalyzer
 import org.apache.lucene.analysis.core.WhitespaceAnalyzer
@@ -73,6 +74,9 @@ class SupportedAnalyzersSpec extends SpecificationWithJUnit {
     }
     "whitespace" in {
       createAnalyzer("whitespace") must haveClass[Some[WhitespaceAnalyzer]]
+    }
+    "simple_asciifolding" in {
+      createAnalyzer("simple_asciifolding") must haveClass[Some[Analyzer]]
     }
     "email" in {
       createAnalyzer("email") must haveClass[Some[UAX29URLEmailAnalyzer]]


### PR DESCRIPTION
As discussed on the CouchDB slack I have the need for some ASCII folding, so I added new analyzer called `simple_asciifolding`.

- it is the same as the `simple` analyzer + the [ASCIIFoldingFilter](https://lucene.apache.org/core/4_6_0/analyzers-common/org/apache/lucene/analysis/miscellaneous/ASCIIFoldingFilter.html)
- the name is inspired by the [same analyzer in ElasticSearch](https://www.elastic.co/guide/en/elasticsearch/reference/current/analysis-asciifolding-tokenfilter.html)
- I tried to add the minimum viable tests, the failure also happens on `master`

On Slack someone mentioned a more advanced filter called [ICUFoldingFilter](https://lucene.apache.org/core/4_6_0/analyzers-icu/org/apache/lucene/analysis/icu/ICUFoldingFilter.html). I don't know if it would be worth it to use that one instead?