### PR TITLE
update scalang to 0.28-cloudant6 for erl 23 upgrade

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -100,7 +100,7 @@
     <dependency>
       <groupId>com.boundary</groupId>
       <artifactId>scalang-scala_2.9.1</artifactId>
-      <version>0.28-cloudant5</version>
+      <version>0.28-cloudant6</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>


### PR DESCRIPTION
We upgrade clouseau to use scalang 0.28-cloudant6:
https://github.com/cloudant/scalang/pull/9

Two important commits were added:

- Erlang 23 and above requires support for DFLAG_BIG_CREATION.
The node understands big node creation tags NEW_PID_EXT, NEW_PORT_EXT
and NEWER_REFERENCE_EXT. So that means we need to be able to decode
and encode those new formats.

- According to erlang docs, the message for a monitor exit is:
MONITOR_P_EXIT
{21, FromProc, ToPid, Ref, Reason}, where FromProc = monitored process
pid or name (atom), ToPid = monitoring process, and Reason = exit reason
for the monitored process. The encoder switched the FromProc and ToPid.
This commit reverses the switch
