### PR TITLE
Remove CVE-implicated xml parser class

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -266,6 +266,7 @@
                 <includes>
                   <include>org.jboss.netty</include>
                   <include>log4j</include>
+                  <include>org.apache.lucene:lucene-queryparser</include>
                 </includes>
               </artifactSet>
               <filters>
@@ -280,6 +281,12 @@
                   <artifact>log4j</artifact>
                   <excludes>
                     <exclude>org/apache/log4j/net/SocketServer.class</exclude>
+                  </excludes>
+                </filter>
+                <filter>
+                  <artifact>org.apache.lucene:lucene-queryparser</artifact>
+                  <excludes>
+                    <exclude>org/apache/lucene/queryparser/xml/</exclude>
                   </excludes>
                 </filter>
               </filters>

--- a/src/main/assembly/distribution.xml
+++ b/src/main/assembly/distribution.xml
@@ -25,6 +25,7 @@ the License.
       <excludes>
         <exclude>org.jboss.netty</exclude>
         <exclude>log4j:log4j</exclude>
+        <exclude>org.apache.lucene:lucene-queryparser</exclude>
       </excludes>
     </dependencySet>
   </dependencySets>


### PR DESCRIPTION
The CoreParser class of lucene-queryparser's xml parser has an open
CVE (CVE-2017-12629). This code is unreachable and unexploitable
unless someone were to change Clouseau to permit users to submit
queries in XML form.

We're removing the class anyway as we don't use it and never intend to.