### PR TITLE
remove remnants of previous log4j artifact filtering

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -272,7 +272,6 @@
               <artifactSet>
                 <includes>
                   <include>org.jboss.netty</include>
-                  <include>log4j</include>
                   <include>org.apache.lucene:lucene-queryparser</include>
                 </includes>
               </artifactSet>
@@ -282,12 +281,6 @@
                   <excludes>
                     <exclude>org/jboss/netty/channel/socket/http/</exclude>
                     <exclude>org/jboss/netty/handler/codec/http/</exclude>
-                  </excludes>
-                </filter>
-                <filter>
-                  <artifact>log4j</artifact>
-                  <excludes>
-                    <exclude>org/apache/log4j/net/SocketServer.class</exclude>
                   </excludes>
                 </filter>
                 <filter>

--- a/src/main/assembly/distribution.xml
+++ b/src/main/assembly/distribution.xml
@@ -24,7 +24,6 @@ the License.
       <scope>runtime</scope>
       <excludes>
         <exclude>org.jboss.netty</exclude>
-        <exclude>log4j:log4j</exclude>
         <exclude>org.apache.lucene:lucene-queryparser</exclude>
       </excludes>
     </dependencySet>


### PR DESCRIPTION
We addressed a previous log4j CVE by removing the unused SocketServer class. Now that we have no hard dependency on log4j this work is redundant (and causes a warning from the assembly plugin).