### PR TITLE
Return None for name field analyzer

### DIFF
--- a/src/main/scala/com/cloudant/clouseau/SupportedAnalyzers.scala
+++ b/src/main/scala/com/cloudant/clouseau/SupportedAnalyzers.scala
@@ -100,7 +100,7 @@ object SupportedAnalyzers {
       map.get("name") match {
         case Some(name: String) =>
           createAnalyzerInt(name, map)
-        case None =>
+        case _ =>
           None
       }
     case _ =>
@@ -379,7 +379,7 @@ object SupportedAnalyzers {
               case Some(fieldAnalyzer) =>
                 (kv._1, fieldAnalyzer)
               case None =>
-                (kv._1, defaultAnalyzer)
+                throw new IllegalArgumentException("no_such_analyzer")
             }
           } toMap
         case _ =>

--- a/src/test/scala/com/cloudant/clouseau/SupportedAnalyzersSpec.scala
+++ b/src/test/scala/com/cloudant/clouseau/SupportedAnalyzersSpec.scala
@@ -93,9 +93,9 @@ class SupportedAnalyzersSpec extends SpecificationWithJUnit {
       createAnalyzer(Map("name" -> "perfield", "fields" -> List("foo" -> "english"))).toString must
         contain("foo -> org.apache.lucene.analysis.en.EnglishAnalyzer")
 
-      // unrecognized per-field becomes default
-      createAnalyzer(Map("name" -> "perfield", "default" -> "english", "fields" -> List("foo" -> "foo"))).toString must
-        contain("foo -> org.apache.lucene.analysis.en.EnglishAnalyzer")
+      // unrecognized per-field throws an IllegalArgumentException("no_such_analyzer")
+      createAnalyzer(Map("name" -> "perfield", "default" -> "english", "fields" -> List("foo" -> "foo"))) must
+        throwAn[IllegalArgumentException]
     }
     "arabic" in {
       createAnalyzer("arabic") must haveClass[Some[ArabicAnalyzer]]


### PR DESCRIPTION
When a user incorrectly creates an analyzer with an object instead of a string,
we don't have a matching clause for it which causes match exception to be thrown.
We return None in any case where the analyzer is not a string.

*Testing*:

Without this fix, Clouseau cannot start as it will always crash with the matching clause
```
[actor:19] ERROR overlock.threadpool.ErrorLoggedThread - Exception was thrown in thread actor:19
scala.MatchError: Some(List((name,standard))) (of class scala.Some)
	at com.cloudant.clouseau.SupportedAnalyzers$.createAnalyzerInt(SupportedAnalyzers.scala:100)
```
With this change, I tried creating mango text indexes with invalid search analyzers and they no longer crashed clouseau. Interestingly, we can still query that particular index, despite having an invalid analyzer. 

```
curl -X POST http://adm:pass@localhost:5984/movies/_find -H 'Content-Type: application/json' -d '{"selector": {"generator": "ok"},"use_index": "text_object_started"}'
{"docs":[
],
"bookmark": "g2o"}
```

I don't think this is the right behavior unless we are defaulting to a specific analyzer. We should be crashing here:

https://github.com/cloudant/clouseau/blob/master/src/main/scala/com/cloudant/clouseau/IndexService.scala#L888-L889

given that the analyzer return is None. But clouseau prints no errors and nothing is printed from Dreyfus either.  Keeping invalid indexes that return results is incorrect behavior even though clouseau does not crash. It seems we broadcast that the analyzer is invalid here:

https://github.com/cloudant-labs/clouseau/blob/master/src/main/scala/com/cloudant/clouseau/IndexManagerService.scala#L201-L205

but since it is a cast, dreyfus I'm assuming silently ignores it.

This fix is to prevent Clouseau from crashing. Returning None has been the default for invalid Analyzers since the inception of Clouseau, so I don't think it's within the scope of this PR modify behavior when the analyzer is invalid.