### PR TITLE
Make sure we start epmd for tests to pass

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -24,5 +24,7 @@ jobs:
       uses: gleam-lang/setup-erlang@v1.1.2
       with:
         otp-version: 22.3.2
+    - name: Start epmd daemon
+      run: epmd -daemon
     - name: Build with Maven
       run: mvn -B package --file pom.xml


### PR DESCRIPTION
I've noticed that the github workflow builds are failing with 

```
Running com.cloudant.clouseau.IndexServiceSpec
Running com.cloudant.clouseau.IndexServiceSpec
Tests run: 24, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 25.133 sec <<< FAILURE!
an index should::perform sorting(com.cloudant.clouseau.IndexServiceSpec)  Time elapsed: 0.027 sec  <<< ERROR!
java.net.ConnectException: Connection refused
	at sun.nio.ch.SocketChannelImpl.checkConnect(Native Method)
	at sun.nio.ch.SocketChannelImpl.finishConnect(SocketChannelImpl.java:741)
	at org.jboss.netty.channel.socket.nio.NioClientSocketPipelineSink$Boss.connect(NioClientSocketPipelineSink.java:401)
```

The error goes away when `epmd` is started prior to running the tests.