### PR TITLE
Add release workflow

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,14 @@
+changelog:
+  exclude:
+    labels:
+      - ignore-for-release
+  categories:
+    - title: What's New
+      labels:
+        - feature
+    - title: Bug fixes
+      labels:
+        - bug
+    - title: What's Changed
+      labels:
+        - "*"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,36 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  release:
+    name: Release of clouseau-{version}-dist.zip
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set ENV for github-release
+        run: |
+          echo "RELEASE_TAG=${GITHUB_REF:10}" >> $GITHUB_ENV
+          echo "RELEASE_NAME=$GITHUB_WORKFLOW" >> $GITHUB_ENV
+      - name: Set up JDK 7
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.7
+      - name: Set up Erlang
+        uses: gleam-lang/setup-erlang@v1.1.2
+        with:
+          otp-version: 22.3.2
+      - name: Start epmd daemon
+        run: epmd -daemon
+      - name: Build with Maven
+        run: mvn -B package --file pom.xml
+      - name: Copy the release artifacts
+        run: mv target/clouseau-${{ env.RELEASE_TAG }}.zip target/clouseau-${{ env.RELEASE_TAG }}-dist.zip
+      - name: Create release
+        run: |
+          gh release create '${{ env.RELEASE_TAG }}' --title 'Release ${{ env.RELEASE_TAG }}' --generate-notes target/clouseau-${{ env.RELEASE_TAG }}-dist.zip
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR adds a github workflow to create a release which includes a `clouseau-${TAG }-dist.zip` artifact. 

The release notes generation is not yet working due to https://github.com/cli/cli/issues/6159

The approach was tested on a personal fork. [Here is](https://github.com/iilyak/clouseau/actions/runs/2957726049) a log of a successful build

The workflow is modeled after [`maven.yml`](https://github.com/cloudant-labs/clouseau/blob/master/.github/workflows/maven.yml) workflow. The actual changes are:

```diff
< name: Java CI with Maven and Erlang
---
> name: Release
8,10c5,6
<     branches: [ master ]
<   pull_request:
<     branches: [ master ]
---
>     tags:
>       - '*'
13,14c9,10
<   build:
<
---
>   release:
>     name: Release of clouseau-{version}-dist.zip
16d11
<
18a14,17
>       - name: Set ENV for github-release
>         run: |
>           echo "RELEASE_TAG=${GITHUB_REF:10}" >> $GITHUB_ENV
>           echo "RELEASE_NAME=$GITHUB_WORKFLOW" >> $GITHUB_ENV
30a30,36
>       - name: Copy the release artifacts
>         run: mv target/clouseau-${{ env.RELEASE_TAG }}.zip target/clouseau-${{ env.RELEASE_TAG }}-dist.zip
>       - name: Create release
>         run: |
>           gh release create '${{ env.RELEASE_TAG }}' --title 'Release ${{ env.RELEASE_TAG }}' --generate-notes target/clouseau-${{ env.RELEASE_TAG }}-dist.zip
>         env:
>           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
```
