### PR TITLE
Make Erlang cookie parametric

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -156,30 +156,20 @@
         <configuration>
           <launchers>
             <launcher>
-              <id>clouseau1</id>
+              <id>standard</id>
               <mainClass>com.cloudant.clouseau.Main</mainClass>
               <jvmArgs>
-                <jvmArg>-Dclouseau.name=clouseau1@127.0.0.1</jvmArg>
-                <jvmArg>-Dclouseau.cookie=monster</jvmArg>
-                <jvmArg>-Dclouseau.dir=${basedir}/target/clouseau1</jvmArg>
+                <jvmArg>-Dclouseau.name=${name}@127.0.0.1</jvmArg>
+                <jvmArg>-Dclouseau.dir=${basedir}/target/${name}</jvmArg>
               </jvmArgs>
             </launcher>
             <launcher>
-              <id>clouseau2</id>
+              <id>with-cookie</id>
               <mainClass>com.cloudant.clouseau.Main</mainClass>
               <jvmArgs>
-                <jvmArg>-Dclouseau.name=clouseau2@127.0.0.1</jvmArg>
-                <jvmArg>-Dclouseau.cookie=monster</jvmArg>
-                <jvmArg>-Dclouseau.dir=${basedir}/target/clouseau2</jvmArg>
-              </jvmArgs>
-            </launcher>
-            <launcher>
-              <id>clouseau3</id>
-              <mainClass>com.cloudant.clouseau.Main</mainClass>
-              <jvmArgs>
-                <jvmArg>-Dclouseau.name=clouseau3@127.0.0.1</jvmArg>
-                <jvmArg>-Dclouseau.cookie=monster</jvmArg>
-                <jvmArg>-Dclouseau.dir=${basedir}/target/clouseau3</jvmArg>
+                <jvmArg>-Dclouseau.name=${name}@127.0.0.1</jvmArg>
+                <jvmArg>-Dclouseau.dir=${basedir}/target/${name}</jvmArg>
+                <jvmArg>-Dclouseau.cookie=${cookie}</jvmArg>
               </jvmArgs>
             </launcher>
           </launchers>

--- a/pom.xml
+++ b/pom.xml
@@ -101,7 +101,7 @@
     <dependency>
       <groupId>com.boundary</groupId>
       <artifactId>scalang-scala_2.9.1</artifactId>
-      <version>1.0.0</version>
+      <version>1.0.1</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/src/main/scala/com/cloudant/clouseau/Main.scala
+++ b/src/main/scala/com/cloudant/clouseau/Main.scala
@@ -42,7 +42,7 @@ object Main extends App {
   config.addConfiguration(reloadableConfig)
 
   val name = config.getString("clouseau.name", "clouseau@127.0.0.1")
-  val cookie = config.getString("clouseau.cookie", "monster")
+  val cookie = config.getString("clouseau.cookie")
   val closeIfIdleEnabled = config.getBoolean("clouseau.close_if_idle", false)
   val idleTimeout = config.getInt("clouseau.idle_check_interval_secs", 300)
   if (closeIfIdleEnabled) {
@@ -52,7 +52,7 @@ object Main extends App {
     typeFactory = ClouseauTypeFactory,
     typeEncoder = ClouseauTypeEncoder,
     typeDecoder = ClouseauTypeDecoder)
-  val node = Node(name, cookie, nodeconfig)
+  val node = if (cookie != null) Node(name, cookie, nodeconfig) else Node(name, nodeconfig)
 
   ClouseauSupervisor.start(node, config)
   logger.info("Clouseau running as " + name)

--- a/src/test/resources/clouseau.ini
+++ b/src/test/resources/clouseau.ini
@@ -1,2 +1,1 @@
 [clouseau]
-cookie=monster


### PR DESCRIPTION
When linked to CouchDB nodes, the Erlang cookie might be different from the one that is originally assumed.  Make it work with `~/.erlang.cookie` on launching the instance to facilitate smoother integration.