### PR TITLE
fix(`IndexWriter`): work around resource leak on failure of `rollback()`

### DIFF
--- a/src/main/scala/com/cloudant/clouseau/IndexService.scala
+++ b/src/main/scala/com/cloudant/clouseau/IndexService.scala
@@ -219,7 +219,7 @@ class IndexService(ctx: ServiceContext[IndexServiceArgs]) extends Service(ctx) w
       case e: IOException => warn("Error while closing reader", e)
     }
     try {
-      ctx.args.writer.rollback()
+      ctx.args.writer.close()
     } catch {
       case e: AlreadyClosedException => 'ignored
       case e: IOException =>


### PR DESCRIPTION
The `rollback()` method of Lucene's `IndexWriter` is prone to leak resources on being hit by an exception (see [LUCENE-5544](https://issues.apache.org/jira/browse/LUCENE-5544)).  This causes locks to left behind and makes the subsequent queries fail for the impacted index until restart.

That bug has been hiding here for a while now, and it was fixed in 2014, in Lucene 4.7.1.  Recently it cropped up actively when the upgrade to OTP 25 was tested on Apple Silicon (ARM64) and there is the worry that it may show up in production later.

For the record, the bug could be triggered by running CouchDB's Mango integration test suite in the following way:

```shell
make mango-test \
  MANGO_TEST_OPTS="10-disable-array-length-field-test.DisableIndexArrayLengthsTest.test_enable_index_array_length"
```

Per @rnewson's suggestion, replace `rollback()` for `close()` to work this problem around.  The `rollback()` method is faster/cheaper but using `close()` does not seem to have problems with releasing the locks.
