### PR TITLE
fix: wildcards in numeric range queries

### DIFF
--- a/src/main/scala/com/cloudant/clouseau/ClouseauQueryParser.scala
+++ b/src/main/scala/com/cloudant/clouseau/ClouseauQueryParser.scala
@@ -61,12 +61,14 @@ class ClouseauQueryParser(version: Version,
                              upper: String,
                              startInclusive: Boolean,
                              endInclusive: Boolean): Query = {
-    if (isNumber(lower) && isNumber(upper)) {
-      NumericRangeQuery.newDoubleRange(field, 8, lower.toDouble,
-        upper.toDouble, startInclusive, endInclusive)
+    val lb = Option(lower).getOrElse("-Infinity")
+    val ub = Option(upper).getOrElse("Infinity")
+    if (isNumber(lb) && isNumber(ub)) {
+      NumericRangeQuery.newDoubleRange(
+        field, 8, lb.toDouble, ub.toDouble, startInclusive, endInclusive)
     } else {
       setLowercaseExpandedTerms(field)
-      super.getRangeQuery(field, lower, upper, startInclusive, endInclusive)
+      super.getRangeQuery(field, lb, ub, startInclusive, endInclusive)
     }
   }
 

--- a/src/test/scala/com/cloudant/clouseau/ClouseauQueryParserSpec.scala
+++ b/src/test/scala/com/cloudant/clouseau/ClouseauQueryParserSpec.scala
@@ -41,6 +41,14 @@ class ClouseauQueryParserSpec extends SpecificationWithJUnit {
       parser.parse("foo:[1.0 TO 2.0]") must haveClass[NumericRangeQuery[JDouble]]
     }
 
+    "support open-ended numeric range queries (*)" in new parser {
+      parser.parse("foo:[0.0 TO *]") must haveClass[NumericRangeQuery[JDouble]]
+    }
+
+    "support open-ended numeric range queries (Infinity)" in new parser {
+      parser.parse("foo:[-Infinity TO 0]") must haveClass[NumericRangeQuery[JDouble]]
+    }
+
     "support numeric term queries (integer)" in new parser {
       val query = parser.parse("foo:12")
       query must haveClass[TermQuery]


### PR DESCRIPTION
When the `*` (wildcard) symbol is used in ranges, the parsing dies with a `NullPointerException`.  That is because input strings with the `null` value are not handled -- they should be treated as infinity with the respective sign (depending on the side of range where the wildcard is used).