### PR TITLE
fix: race condition between index close and clean-up

### DIFF
--- a/src/main/scala/com/cloudant/clouseau/IndexManagerService.scala
+++ b/src/main/scala/com/cloudant/clouseau/IndexManagerService.scala
@@ -122,12 +122,12 @@ class IndexManagerService(ctx: ServiceContext[ConfigurationArgs]) extends Servic
       }
     case ('get_root_dir) =>
       ('ok, rootDir.getAbsolutePath())
-    case ('delete, path: String) =>
+    case ('delete, path: String, parentCleaner: Option[Pid]) =>
       lru.get(path) match {
         case null =>
           ('error, 'not_found)
         case pid: Pid =>
-          pid ! 'delete
+          pid ! ('delete, parentCleaner)
           'ok
       }
     case DiskSizeMsg(path: String) =>


### PR DESCRIPTION
When a database is deleted, the corresponding directory structure is removed entirely, even if the index writer has not yet been closed.  Due to the missing files, both attemps of closing the index and then rolling it back fail, which eventually leads to leak of resources, more specificially locks, due to [a known bug in Lucene versions prior to 4.7.1](https://issues.apache.org/jira/browse/LUCENE-5544).  In result, the subsequent search requests to the same index will fail when recreated.

The reason for this is that the clean-up service might be triggered earlier than the index service is killed off and the order of removal (first the lock, then the rest of the files) may become reversed.  Adjust the services to handle the situation gracefully.