### PR TITLE
fix: switch to the Cloudant fork of Lucene 4.6.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 
   <properties>
     <encoding>UTF-8</encoding>
-    <lucene-version>4.6.1</lucene-version>
+    <lucene-version>4.6.1-cloudant1</lucene-version>
     <maven.compiler.source>1.6</maven.compiler.source>
     <maven.compiler.target>1.6</maven.compiler.target>
     <scala.version>2.9.1</scala.version>


### PR DESCRIPTION
This PR is to use the Cloudant-custom version of Apache Lucene to address problems with leaking resources (locks and files) on abrupt termination of the `IndexWriter` rollback.  The following changes are backported to make work on top of version 4.6.1:

- [LUCENE-5228](https://issues.apache.org/jira/browse/LUCENE-5228)
- [LUCENE-5544](https://issues.apache.org/jira/browse/LUCENE-5544)
