### PR TITLE
chore: switch to `erlef/setup-beam`

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -21,7 +21,7 @@ jobs:
       with:
         java-version: 1.7
     - name: Set up Erlang
-      uses: gleam-lang/setup-erlang@v1.1.2
+      uses: erlef/setup-beam@v1.16.0
       with:
         otp-version: '23.3.1'
     - name: Start epmd daemon

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           java-version: 1.7
       - name: Set up Erlang
-        uses: gleam-lang/setup-erlang@v1.1.2
+        uses: erlef/setup-beam@v1.16.0
         with:
           otp-version: '23.3.1'
       - name: Start epmd daemon


### PR DESCRIPTION
Fix the recent breakage of the GitHub workflow PR build at the Erlang step by switching to [`erlef/setup-beam`](https://github.com/erlef/setup-beam/).  Thanks @rnewson for the suggestion!