### PR TITLE
Introduce types to supported analyzers

### DIFF
--- a/src/main/scala/com/cloudant/clouseau/AnalyzerService.scala
+++ b/src/main/scala/com/cloudant/clouseau/AnalyzerService.scala
@@ -25,8 +25,8 @@ class AnalyzerService(ctx: ServiceContext[ConfigurationArgs]) extends Service(ct
   val logger = LoggerFactory.getLogger("clouseau.analyzer")
 
   override def handleCall(tag: (Pid, Any), msg: Any): Any = msg match {
-    case ('analyze, analyzerConfig: Any, text: String) =>
-      SupportedAnalyzers.createAnalyzer(analyzerConfig) match {
+    case ('analyze, analyzerName: String, text: String) =>
+      SupportedAnalyzers.createAnalyzerFromString(analyzerName) match {
         case Some(analyzer) =>
           ('ok, tokenize(text, analyzer))
         case None =>

--- a/src/main/scala/com/cloudant/clouseau/IndexManagerService.scala
+++ b/src/main/scala/com/cloudant/clouseau/IndexManagerService.scala
@@ -109,7 +109,7 @@ class IndexManagerService(ctx: ServiceContext[ConfigurationArgs]) extends Servic
   }
 
   override def handleCall(tag: (Pid, Any), msg: Any): Any = msg match {
-    case OpenIndexMsg(peer: Pid, path: String, options: Any) =>
+    case OpenIndexMsg(peer: Pid, path: String, options: OpenIndexMsg.Options) =>
       lru.get(path) match {
         case null =>
           waiters.get(path) match {

--- a/src/main/scala/com/cloudant/clouseau/IndexService.scala
+++ b/src/main/scala/com/cloudant/clouseau/IndexService.scala
@@ -899,7 +899,7 @@ object IndexService {
   val FP = """([-+]?[0-9]+(?:\.[0-9]+)?)"""
   val DISTANCE_RE = "^([-+])?<distance,([\\.\\w]+),([\\.\\w]+),%s,%s,(mi|km)>$".format(FP, FP).r
 
-  def start(node: Node, config: Configuration, path: String, options: Any): Any = {
+  def start(node: Node, config: Configuration, path: String, options: OpenIndexMsg.Options): Any = {
     val rootDir = new File(config.getString("clouseau.dir", "target/indexes"))
     val dir = newDirectory(config, new File(rootDir, path))
     try {

--- a/src/main/scala/com/cloudant/clouseau/SupportedAnalyzers.scala
+++ b/src/main/scala/com/cloudant/clouseau/SupportedAnalyzers.scala
@@ -367,16 +367,19 @@ object SupportedAnalyzers {
         case None =>
           fallbackAnalyzer
       }
+      // The Per-field analyzers are always strings
       var fieldMap: Map[String, Analyzer] = options.get("fields") match {
-        case Some(fields: List[(String, Any)]) =>
-          fields map { kv =>
-            createAnalyzerInt(kv._2) match {
-              case Some(fieldAnalyzer) =>
-                (kv._1, fieldAnalyzer)
-              case None =>
-                (kv._1, defaultAnalyzer)
-            }
-          } toMap
+        case Some(fields: List[_]) =>
+          // ignore all fields of non string type
+          fields.collect {
+            case (field: String, analyzerName: String) =>
+              createAnalyzerFromStringInt(analyzerName) match {
+                case Some(fieldAnalyzer) =>
+                  (field, fieldAnalyzer)
+                case None =>
+                  (field, defaultAnalyzer)
+              }
+          }.toMap
         case _ =>
           Map.empty
       }

--- a/src/main/scala/com/cloudant/clouseau/SupportedAnalyzers.scala
+++ b/src/main/scala/com/cloudant/clouseau/SupportedAnalyzers.scala
@@ -116,241 +116,241 @@ object SupportedAnalyzers {
         }
       })
     case "arabic" =>
-      options.get("stopwords") match {
-        case Some(stopwords: List[String]) =>
+      getStopWords(options) match {
+        case Some(stopwords) =>
           Some(new ArabicAnalyzer(IndexService.version, stopwords))
-        case _ =>
+        case None =>
           Some(new ArabicAnalyzer(IndexService.version))
       }
     case "bulgarian" =>
-      options.get("stopwords") match {
-        case Some(stopwords: List[String]) =>
+      getStopWords(options) match {
+        case Some(stopwords) =>
           Some(new BulgarianAnalyzer(IndexService.version, stopwords))
-        case _ =>
+        case None =>
           Some(new BulgarianAnalyzer(IndexService.version))
       }
     case "brazilian" =>
-      options.get("stopwords") match {
-        case Some(stopwords: List[String]) =>
+      getStopWords(options) match {
+        case Some(stopwords) =>
           Some(new BrazilianAnalyzer(IndexService.version, stopwords))
-        case _ =>
+        case None =>
           Some(new BrazilianAnalyzer(IndexService.version))
       }
     case "catalan" =>
-      options.get("stopwords") match {
-        case Some(stopwords: List[String]) =>
+      getStopWords(options) match {
+        case Some(stopwords) =>
           Some(new CatalanAnalyzer(IndexService.version, stopwords))
-        case _ =>
+        case None =>
           Some(new CatalanAnalyzer(IndexService.version))
       }
     case "cjk" =>
-      options.get("stopwords") match {
-        case Some(stopwords: List[String]) =>
+      getStopWords(options) match {
+        case Some(stopwords) =>
           Some(new CJKAnalyzer(IndexService.version, stopwords))
-        case _ =>
+        case None =>
           Some(new CJKAnalyzer(IndexService.version))
       }
     case "chinese" =>
-      options.get("stopwords") match {
-        case Some(stopwords: List[String]) =>
+      getStopWords(options) match {
+        case Some(stopwords) =>
           Some(new SmartChineseAnalyzer(IndexService.version, stopwords))
-        case _ =>
+        case None =>
           Some(new SmartChineseAnalyzer(IndexService.version))
       }
     case "czech" =>
-      options.get("stopwords") match {
-        case Some(stopwords: List[String]) =>
+      getStopWords(options) match {
+        case Some(stopwords) =>
           Some(new CzechAnalyzer(IndexService.version, stopwords))
-        case _ =>
+        case None =>
           Some(new CzechAnalyzer(IndexService.version))
       }
     case "danish" =>
-      options.get("stopwords") match {
-        case Some(stopwords: List[String]) =>
+      getStopWords(options) match {
+        case Some(stopwords) =>
           Some(new DanishAnalyzer(IndexService.version, stopwords))
-        case _ =>
+        case None =>
           Some(new DanishAnalyzer(IndexService.version))
       }
     case "german" =>
-      options.get("stopwords") match {
-        case Some(stopwords: List[String]) =>
+      getStopWords(options) match {
+        case Some(stopwords) =>
           Some(new GermanAnalyzer(IndexService.version, stopwords))
-        case _ =>
+        case None =>
           Some(new GermanAnalyzer(IndexService.version))
       }
     case "greek" =>
-      options.get("stopwords") match {
-        case Some(stopwords: List[String]) =>
+      getStopWords(options) match {
+        case Some(stopwords) =>
           Some(new GreekAnalyzer(IndexService.version, stopwords))
-        case _ =>
+        case None =>
           Some(new GreekAnalyzer(IndexService.version))
       }
     case "english" =>
-      options.get("stopwords") match {
-        case Some(stopwords: List[String]) =>
+      getStopWords(options) match {
+        case Some(stopwords) =>
           Some(new EnglishAnalyzer(IndexService.version, stopwords))
-        case _ =>
+        case None =>
           Some(new EnglishAnalyzer(IndexService.version))
       }
     case "spanish" =>
-      options.get("stopwords") match {
-        case Some(stopwords: List[String]) =>
+      getStopWords(options) match {
+        case Some(stopwords) =>
           Some(new SpanishAnalyzer(IndexService.version, stopwords))
-        case _ =>
+        case None =>
           Some(new SpanishAnalyzer(IndexService.version))
       }
     case "basque" =>
-      options.get("stopwords") match {
-        case Some(stopwords: List[String]) =>
+      getStopWords(options) match {
+        case Some(stopwords) =>
           Some(new BasqueAnalyzer(IndexService.version, stopwords))
-        case _ =>
+        case None =>
           Some(new BasqueAnalyzer(IndexService.version))
       }
     case "persian" =>
-      options.get("stopwords") match {
-        case Some(stopwords: List[String]) =>
+      getStopWords(options) match {
+        case Some(stopwords) =>
           Some(new PersianAnalyzer(IndexService.version, stopwords))
-        case _ =>
+        case None =>
           Some(new PersianAnalyzer(IndexService.version))
       }
     case "finnish" =>
-      options.get("stopwords") match {
-        case Some(stopwords: List[String]) =>
+      getStopWords(options) match {
+        case Some(stopwords) =>
           Some(new FinnishAnalyzer(IndexService.version, stopwords))
-        case _ =>
+        case None =>
           Some(new FinnishAnalyzer(IndexService.version))
       }
     case "french" =>
-      options.get("stopwords") match {
-        case Some(stopwords: List[String]) =>
+      getStopWords(options) match {
+        case Some(stopwords) =>
           Some(new FrenchAnalyzer(IndexService.version, stopwords))
-        case _ =>
+        case None =>
           Some(new FrenchAnalyzer(IndexService.version))
       }
     case "irish" =>
-      options.get("stopwords") match {
-        case Some(stopwords: List[String]) =>
+      getStopWords(options) match {
+        case Some(stopwords) =>
           Some(new IrishAnalyzer(IndexService.version, stopwords))
-        case _ =>
+        case None =>
           Some(new IrishAnalyzer(IndexService.version))
       }
     case "galician" =>
-      options.get("stopwords") match {
-        case Some(stopwords: List[String]) =>
+      getStopWords(options) match {
+        case Some(stopwords) =>
           Some(new GalicianAnalyzer(IndexService.version, stopwords))
-        case _ =>
+        case None =>
           Some(new GalicianAnalyzer(IndexService.version))
       }
     case "hindi" =>
-      options.get("stopwords") match {
-        case Some(stopwords: List[String]) =>
+      getStopWords(options) match {
+        case Some(stopwords) =>
           Some(new HindiAnalyzer(IndexService.version, stopwords))
-        case _ =>
+        case None =>
           Some(new HindiAnalyzer(IndexService.version))
       }
     case "hungarian" =>
-      options.get("stopwords") match {
-        case Some(stopwords: List[String]) =>
+      getStopWords(options) match {
+        case Some(stopwords) =>
           Some(new HungarianAnalyzer(IndexService.version, stopwords))
-        case _ =>
+        case None =>
           Some(new HungarianAnalyzer(IndexService.version))
       }
     case "armenian" =>
-      options.get("stopwords") match {
-        case Some(stopwords: List[String]) =>
+      getStopWords(options) match {
+        case Some(stopwords) =>
           Some(new ArmenianAnalyzer(IndexService.version, stopwords))
-        case _ =>
+        case None =>
           Some(new ArmenianAnalyzer(IndexService.version))
       }
     case "indonesian" =>
-      options.get("stopwords") match {
-        case Some(stopwords: List[String]) =>
+      getStopWords(options) match {
+        case Some(stopwords) =>
           Some(new IndonesianAnalyzer(IndexService.version, stopwords))
-        case _ =>
+        case None =>
           Some(new IndonesianAnalyzer(IndexService.version))
       }
     case "italian" =>
-      options.get("stopwords") match {
-        case Some(stopwords: List[String]) =>
+      getStopWords(options) match {
+        case Some(stopwords) =>
           Some(new ItalianAnalyzer(IndexService.version, stopwords))
-        case _ =>
+        case None =>
           Some(new ItalianAnalyzer(IndexService.version))
       }
     case "japanese" =>
-      options.get("stopwords") match {
-        case Some(stopwords: List[String]) =>
+      getStopWords(options) match {
+        case Some(stopwords) =>
           Some(new JapaneseAnalyzer(IndexService.version, null, JapaneseTokenizer.DEFAULT_MODE, stopwords, JapaneseAnalyzer.getDefaultStopTags))
-        case _ =>
+        case None =>
           Some(new JapaneseAnalyzer(IndexService.version))
       }
     case "latvian" =>
-      options.get("stopwords") match {
-        case Some(stopwords: List[String]) =>
+      getStopWords(options) match {
+        case Some(stopwords) =>
           Some(new LatvianAnalyzer(IndexService.version, stopwords))
-        case _ =>
+        case None =>
           Some(new LatvianAnalyzer(IndexService.version))
       }
     case "dutch" =>
-      options.get("stopwords") match {
-        case Some(stopwords: List[String]) =>
+      getStopWords(options) match {
+        case Some(stopwords) =>
           Some(new DutchAnalyzer(IndexService.version, stopwords))
-        case _ =>
+        case None =>
           Some(new DutchAnalyzer(IndexService.version))
       }
     case "norwegian" =>
-      options.get("stopwords") match {
-        case Some(stopwords: List[String]) =>
+      getStopWords(options) match {
+        case Some(stopwords) =>
           Some(new NorwegianAnalyzer(IndexService.version, stopwords))
-        case _ =>
+        case None =>
           Some(new NorwegianAnalyzer(IndexService.version))
       }
     case "polish" =>
-      options.get("stopwords") match {
-        case Some(stopwords: List[String]) =>
+      getStopWords(options) match {
+        case Some(stopwords) =>
           Some(new PolishAnalyzer(IndexService.version, stopwords))
-        case _ =>
+        case None =>
           Some(new PolishAnalyzer(IndexService.version))
       }
     case "portuguese" =>
-      options.get("stopwords") match {
-        case Some(stopwords: List[String]) =>
+      getStopWords(options) match {
+        case Some(stopwords) =>
           Some(new PortugueseAnalyzer(IndexService.version, stopwords))
-        case _ =>
+        case None =>
           Some(new PortugueseAnalyzer(IndexService.version))
       }
     case "romanian" =>
-      options.get("stopwords") match {
-        case Some(stopwords: List[String]) =>
+      getStopWords(options) match {
+        case Some(stopwords) =>
           Some(new RomanianAnalyzer(IndexService.version, stopwords))
-        case _ =>
+        case None =>
           Some(new RomanianAnalyzer(IndexService.version))
       }
     case "russian" =>
-      options.get("stopwords") match {
-        case Some(stopwords: List[String]) =>
+      getStopWords(options) match {
+        case Some(stopwords) =>
           Some(new RussianAnalyzer(IndexService.version, stopwords))
-        case _ =>
+        case None =>
           Some(new RussianAnalyzer(IndexService.version))
       }
     case "classic" =>
-      options.get("stopwords") match {
-        case Some(stopwords: List[String]) =>
+      getStopWords(options) match {
+        case Some(stopwords) =>
           Some(new ClassicAnalyzer(IndexService.version, stopwords))
-        case _ =>
+        case None =>
           Some(new ClassicAnalyzer(IndexService.version))
       }
     case "standard" =>
-      options.get("stopwords") match {
-        case Some(stopwords: List[String]) =>
+      getStopWords(options) match {
+        case Some(stopwords) =>
           Some(new StandardAnalyzer(IndexService.version, stopwords))
-        case _ =>
+        case None =>
           Some(new StandardAnalyzer(IndexService.version))
       }
     case "email" =>
-      options.get("stopwords") match {
-        case Some(stopwords: List[String]) =>
+      getStopWords(options) match {
+        case Some(stopwords) =>
           Some(new UAX29URLEmailAnalyzer(IndexService.version, stopwords))
-        case _ =>
+        case None =>
           Some(new UAX29URLEmailAnalyzer(IndexService.version))
       }
     case "perfield" =>
@@ -384,24 +384,24 @@ object SupportedAnalyzers {
       fieldMap += ("_partition" -> new KeywordAnalyzer())
       Some(new PerFieldAnalyzer(defaultAnalyzer, fieldMap))
     case "swedish" =>
-      options.get("stopwords") match {
-        case Some(stopwords: List[String]) =>
+      getStopWords(options) match {
+        case Some(stopwords) =>
           Some(new SwedishAnalyzer(IndexService.version, stopwords))
-        case _ =>
+        case None =>
           Some(new SwedishAnalyzer(IndexService.version))
       }
     case "thai" =>
-      options.get("stopwords") match {
-        case Some(stopwords: List[String]) =>
+      getStopWords(options) match {
+        case Some(stopwords) =>
           Some(new ThaiAnalyzer(IndexService.version, stopwords))
-        case _ =>
+        case None =>
           Some(new ThaiAnalyzer(IndexService.version))
       }
     case "turkish" =>
-      options.get("stopwords") match {
-        case Some(stopwords: List[String]) =>
+      getStopWords(options) match {
+        case Some(stopwords) =>
           Some(new TurkishAnalyzer(IndexService.version, stopwords))
-        case _ =>
+        case None =>
           Some(new TurkishAnalyzer(IndexService.version))
       }
     case _ =>
@@ -416,4 +416,6 @@ object SupportedAnalyzers {
     CharArraySet.unmodifiableSet(CharArraySet.copy(IndexService.version, Set() ++ list))
   }
 
+  def getStopWords(options: Map[String, Any]): Option[CharArraySet] =
+    options.get("stopwords").collect { case list: List[_] => list.collect { case word: String => word } }
 }

--- a/src/test/scala/com/cloudant/clouseau/IndexManagerServiceSpec.scala
+++ b/src/test/scala/com/cloudant/clouseau/IndexManagerServiceSpec.scala
@@ -23,13 +23,13 @@ class IndexManagerServiceSpec extends SpecificationWithJUnit {
   "the index manager" should {
 
     "open an index when asked" in new manager_service {
-      node.call(service, OpenIndexMsg(mbox.self, "foo", "standard")) must beLike { case ('ok, pid: Pid) => ok }
+      node.call(service, OpenIndexMsg.fromAnalyzerName(mbox.self, "foo", "standard")) must beLike { case ('ok, pid: Pid) => ok }
     }
 
     "return the same index if it's already open" in new manager_service {
-      node.call(service, OpenIndexMsg(mbox.self, "foo", "standard")) match {
+      node.call(service, OpenIndexMsg.fromAnalyzerName(mbox.self, "foo", "standard")) match {
         case ('ok, pid) =>
-          node.call(service, OpenIndexMsg(mbox.self, "foo", "standard")) must be equalTo ('ok, pid)
+          node.call(service, OpenIndexMsg.fromAnalyzerName(mbox.self, "foo", "standard")) must be equalTo ('ok, pid)
       }
     }
 

--- a/src/test/scala/com/cloudant/clouseau/IndexServiceSpec.scala
+++ b/src/test/scala/com/cloudant/clouseau/IndexServiceSpec.scala
@@ -596,8 +596,8 @@ trait index_service extends RunningNode {
     service = pid
   }
 
-  def options(): Any = {
-    "standard"
+  def options(): Map[String, Any] = {
+    Map("name" -> "standard")
   }
 
   override def after {
@@ -611,7 +611,7 @@ trait index_service extends RunningNode {
 
 trait index_service_perfield extends index_service {
 
-  override def options(): Any = {
+  override def options(): Map[String, Any] = {
     Map("name" -> "perfield", "default" -> "english")
   }
 

--- a/src/test/scala/com/cloudant/clouseau/SupportedAnalyzersSpec.scala
+++ b/src/test/scala/com/cloudant/clouseau/SupportedAnalyzersSpec.scala
@@ -61,29 +61,26 @@ class SupportedAnalyzersSpec extends SpecificationWithJUnit {
   "SupportedAnalyzers" should {
 
     "ignore unsupported analyzers" in {
-      createAnalyzer("foo") must beNone
-    }
-    "List of non-tuples yields no analyzer" in {
-      createAnalyzer(List("foo")) must beNone
+      createAnalyzerFromString("foo") must beNone
     }
     "keyword" in {
-      createAnalyzer("keyword") must haveClass[Some[KeywordAnalyzer]]
+      createAnalyzerFromString("keyword") must haveClass[Some[KeywordAnalyzer]]
     }
     "simple" in {
-      createAnalyzer("simple") must haveClass[Some[SimpleAnalyzer]]
+      createAnalyzerFromString("simple") must haveClass[Some[SimpleAnalyzer]]
     }
     "whitespace" in {
-      createAnalyzer("whitespace") must haveClass[Some[WhitespaceAnalyzer]]
+      createAnalyzerFromString("whitespace") must haveClass[Some[WhitespaceAnalyzer]]
     }
     "simple_asciifolding" in {
-      createAnalyzer("simple_asciifolding") must haveClass[Some[Analyzer]]
+      createAnalyzerFromString("simple_asciifolding") must haveClass[Some[Analyzer]]
     }
     "email" in {
-      createAnalyzer("email") must haveClass[Some[UAX29URLEmailAnalyzer]]
+      createAnalyzerFromString("email") must haveClass[Some[UAX29URLEmailAnalyzer]]
     }
     "perfield" in {
       // basic
-      createAnalyzer("perfield") must haveClass[Some[PerFieldAnalyzer]]
+      createAnalyzerFromString("perfield") must haveClass[Some[PerFieldAnalyzer]]
 
       // override default
       createAnalyzer(Map("name" -> "perfield", "default" -> "english")).toString must
@@ -98,112 +95,112 @@ class SupportedAnalyzersSpec extends SpecificationWithJUnit {
         contain("foo -> org.apache.lucene.analysis.en.EnglishAnalyzer")
     }
     "arabic" in {
-      createAnalyzer("arabic") must haveClass[Some[ArabicAnalyzer]]
+      createAnalyzerFromString("arabic") must haveClass[Some[ArabicAnalyzer]]
     }
     "bulgarian" in {
-      createAnalyzer("bulgarian") must haveClass[Some[BulgarianAnalyzer]]
+      createAnalyzerFromString("bulgarian") must haveClass[Some[BulgarianAnalyzer]]
     }
     "brazilian" in {
-      createAnalyzer("brazilian") must haveClass[Some[BrazilianAnalyzer]]
+      createAnalyzerFromString("brazilian") must haveClass[Some[BrazilianAnalyzer]]
     }
     "catalan" in {
-      createAnalyzer("catalan") must haveClass[Some[CatalanAnalyzer]]
+      createAnalyzerFromString("catalan") must haveClass[Some[CatalanAnalyzer]]
     }
     "cjk" in {
-      createAnalyzer("cjk") must haveClass[Some[CJKAnalyzer]]
+      createAnalyzerFromString("cjk") must haveClass[Some[CJKAnalyzer]]
     }
     "chinese" in {
-      createAnalyzer("chinese") must haveClass[Some[SmartChineseAnalyzer]]
+      createAnalyzerFromString("chinese") must haveClass[Some[SmartChineseAnalyzer]]
     }
     "czech" in {
-      createAnalyzer("czech") must haveClass[Some[CzechAnalyzer]]
+      createAnalyzerFromString("czech") must haveClass[Some[CzechAnalyzer]]
     }
     "danish" in {
-      createAnalyzer("danish") must haveClass[Some[DanishAnalyzer]]
+      createAnalyzerFromString("danish") must haveClass[Some[DanishAnalyzer]]
     }
     "german" in {
-      createAnalyzer("german") must haveClass[Some[GermanAnalyzer]]
+      createAnalyzerFromString("german") must haveClass[Some[GermanAnalyzer]]
     }
     "greek" in {
-      createAnalyzer("greek") must haveClass[Some[GreekAnalyzer]]
+      createAnalyzerFromString("greek") must haveClass[Some[GreekAnalyzer]]
     }
     "english" in {
-      createAnalyzer("english") must haveClass[Some[EnglishAnalyzer]]
+      createAnalyzerFromString("english") must haveClass[Some[EnglishAnalyzer]]
     }
     "spanish" in {
-      createAnalyzer("spanish") must haveClass[Some[SpanishAnalyzer]]
+      createAnalyzerFromString("spanish") must haveClass[Some[SpanishAnalyzer]]
     }
     "basque" in {
-      createAnalyzer("basque") must haveClass[Some[BasqueAnalyzer]]
+      createAnalyzerFromString("basque") must haveClass[Some[BasqueAnalyzer]]
     }
     "persian" in {
-      createAnalyzer("persian") must haveClass[Some[PersianAnalyzer]]
+      createAnalyzerFromString("persian") must haveClass[Some[PersianAnalyzer]]
     }
     "finnish" in {
-      createAnalyzer("finnish") must haveClass[Some[FinnishAnalyzer]]
+      createAnalyzerFromString("finnish") must haveClass[Some[FinnishAnalyzer]]
     }
     "french" in {
-      createAnalyzer("french") must haveClass[Some[FrenchAnalyzer]]
+      createAnalyzerFromString("french") must haveClass[Some[FrenchAnalyzer]]
     }
     "irish" in {
-      createAnalyzer("irish") must haveClass[Some[IrishAnalyzer]]
+      createAnalyzerFromString("irish") must haveClass[Some[IrishAnalyzer]]
     }
     "galician" in {
-      createAnalyzer("galician") must haveClass[Some[GalicianAnalyzer]]
+      createAnalyzerFromString("galician") must haveClass[Some[GalicianAnalyzer]]
     }
     "hindi" in {
-      createAnalyzer("hindi") must haveClass[Some[HindiAnalyzer]]
+      createAnalyzerFromString("hindi") must haveClass[Some[HindiAnalyzer]]
     }
     "hungarian" in {
-      createAnalyzer("hungarian") must haveClass[Some[HungarianAnalyzer]]
+      createAnalyzerFromString("hungarian") must haveClass[Some[HungarianAnalyzer]]
     }
     "armenian" in {
-      createAnalyzer("armenian") must haveClass[Some[ArmenianAnalyzer]]
+      createAnalyzerFromString("armenian") must haveClass[Some[ArmenianAnalyzer]]
     }
     "indonesian" in {
-      createAnalyzer("indonesian") must haveClass[Some[IndonesianAnalyzer]]
+      createAnalyzerFromString("indonesian") must haveClass[Some[IndonesianAnalyzer]]
     }
     "italian" in {
-      createAnalyzer("italian") must haveClass[Some[ItalianAnalyzer]]
+      createAnalyzerFromString("italian") must haveClass[Some[ItalianAnalyzer]]
     }
     "japanese" in {
-      createAnalyzer("japanese") must haveClass[Some[JapaneseAnalyzer]]
+      createAnalyzerFromString("japanese") must haveClass[Some[JapaneseAnalyzer]]
     }
     "latvian" in {
-      createAnalyzer("latvian") must haveClass[Some[LatvianAnalyzer]]
+      createAnalyzerFromString("latvian") must haveClass[Some[LatvianAnalyzer]]
     }
     "dutch" in {
-      createAnalyzer("dutch") must haveClass[Some[DutchAnalyzer]]
+      createAnalyzerFromString("dutch") must haveClass[Some[DutchAnalyzer]]
     }
     "norwegian" in {
-      createAnalyzer("norwegian") must haveClass[Some[NorwegianAnalyzer]]
+      createAnalyzerFromString("norwegian") must haveClass[Some[NorwegianAnalyzer]]
     }
     "polish" in {
-      createAnalyzer("polish") must haveClass[Some[PolishAnalyzer]]
+      createAnalyzerFromString("polish") must haveClass[Some[PolishAnalyzer]]
     }
     "portuguese" in {
-      createAnalyzer("portuguese") must haveClass[Some[PortugueseAnalyzer]]
+      createAnalyzerFromString("portuguese") must haveClass[Some[PortugueseAnalyzer]]
     }
     "romanian" in {
-      createAnalyzer("romanian") must haveClass[Some[RomanianAnalyzer]]
+      createAnalyzerFromString("romanian") must haveClass[Some[RomanianAnalyzer]]
     }
     "russian" in {
-      createAnalyzer("russian") must haveClass[Some[RussianAnalyzer]]
+      createAnalyzerFromString("russian") must haveClass[Some[RussianAnalyzer]]
     }
     "classic" in {
-      createAnalyzer("classic") must haveClass[Some[ClassicAnalyzer]]
+      createAnalyzerFromString("classic") must haveClass[Some[ClassicAnalyzer]]
     }
     "standard" in {
-      createAnalyzer("standard") must haveClass[Some[StandardAnalyzer]]
+      createAnalyzerFromString("standard") must haveClass[Some[StandardAnalyzer]]
     }
     "swedish" in {
-      createAnalyzer("swedish") must haveClass[Some[SwedishAnalyzer]]
+      createAnalyzerFromString("swedish") must haveClass[Some[SwedishAnalyzer]]
     }
     "thai" in {
-      createAnalyzer("thai") must haveClass[Some[ThaiAnalyzer]]
+      createAnalyzerFromString("thai") must haveClass[Some[ThaiAnalyzer]]
     }
     "turkish" in {
-      createAnalyzer("turkish") must haveClass[Some[TurkishAnalyzer]]
+      createAnalyzerFromString("turkish") must haveClass[Some[TurkishAnalyzer]]
     }
 
   }


### PR DESCRIPTION
Refactor `createAnalyzer` to remove polymorphic arguments and use `Map[String, Any]`

The polymorphism makes it harder to introduce types. Because it requires union types. Which are not natively supported by the version of Scala we use. Elimination of the polymorphism would allow us to introduce types.

The introduction of types is the vehicle to solve type erasure problem we would have to deal with when we upgrade Scala to the next version.

The refactoring is done using following steps

1. Add type specific constructors for `Analyzer`
   - `createAnalyzerFromString(name: String)`
   - `createAnalyzer(options: Map[String, Any])`
   - `createAnalyzerFromStringInt(name: String)`
   - `createAnalyzerInt(options: Map[String, Any])`
2. Add type specific constructors for `OpenIndexMsg`
   - `fromMap(peer: Pid, path: String, map: Map[_, _])`
   - `fromAnalyzerName(peer: Pid, path: String, name: String)`
   - `fromKVsList(peer: Pid, path: String, options: List[_])`
3. Make sure we correctly go from `Any` to the concrete type
   - ```scala
      def collectKVs(list: List[_]): List[(String, Any)] =
          list.collect {
              case t @ (_: String, _: Any) => t
          }.asInstanceOf[List[(String, Any)]]
     ```
   - `options.get("name").map(_.asInstanceOf[String])`

# Assumptions

1. The keys of `options` passed to `OpenIndexMsg` are strings
2. It is ok to just ignore all non-string keys in `options`
3. The analyzer name is always a `String`
4. The `stopwords` is a list
5. The elements of a `stopwords` are strings
6. It is ok to skip non-strings elements of `stopwords`
7. The `fields` value is a list
8. The elements of a `fields` list are tuples `(String, String)`
9. It is ok to skip elements which do not match the `(String, String)` pattern
10. The `config` is a String in `('analyze, config, text)` message in AnalyzerService.handleCall and it should really be named `('analyze, analyzerName, text)`.