### PR TITLE
Replace deprecated JavaConversions with JavaConverters

### DIFF
--- a/src/main/scala/com/cloudant/clouseau/ClouseauTypeFactory.scala
+++ b/src/main/scala/com/cloudant/clouseau/ClouseauTypeFactory.scala
@@ -19,7 +19,7 @@ import org.apache.lucene.document.Field._
 import org.apache.lucene.document._
 import org.apache.lucene.search._
 import scala.collection.immutable.Map
-import scala.collection.JavaConversions._
+import scala.collection.JavaConverters._
 import scalang._
 import org.jboss.netty.buffer.ChannelBuffer
 import org.apache.lucene.util.BytesRef
@@ -137,7 +137,7 @@ object ClouseauTypeFactory extends TypeFactory {
             val delim = fp.getFacetDelimChar
             if (!name.contains(delim) && !value.contains(delim)) {
               val facets = new SortedSetDocValuesFacetFields(fp)
-              facets.addFields(doc, List(new CategoryPath(name, value)))
+              facets.addFields(doc, List(new CategoryPath(name, value)).asJava)
             }
           }
         case None =>

--- a/src/main/scala/com/cloudant/clouseau/ExternalSnapshotDeletionPolicy.scala
+++ b/src/main/scala/com/cloudant/clouseau/ExternalSnapshotDeletionPolicy.scala
@@ -5,11 +5,12 @@ import java.io.IOException
 import java.nio.file.StandardCopyOption.ATOMIC_MOVE
 import java.nio.file.Files
 import java.util.List
+import java.util.Collection
 import java.util.UUID
 import org.apache.lucene.index.IndexCommit
 import org.apache.lucene.index.IndexDeletionPolicy
 import org.apache.lucene.store.FSDirectory
-import scala.collection.JavaConversions._
+import scala.collection.JavaConverters._
 
 class ExternalSnapshotDeletionPolicy(dir: FSDirectory) extends IndexDeletionPolicy {
 
@@ -37,10 +38,10 @@ class ExternalSnapshotDeletionPolicy(dir: FSDirectory) extends IndexDeletionPoli
 
   private def keepOnlyLastCommit(commits: List[_ <: IndexCommit]): Unit = {
     synchronized {
-      for (commit <- commits.reverse.drop(1)) {
+      for (commit <- commits.asScala.reverse.drop(1)) {
         commit.delete
       }
-      lastCommit = commits.lastOption
+      lastCommit = commits.asScala.lastOption
     }
   }
 
@@ -72,7 +73,7 @@ object ExternalSnapshotDeletionPolicy {
     }
     var success = false
     try {
-      for (filename <- files) {
+      for (filename <- files.asScala) {
         Files.createLink(new File(tmpDir, filename).toPath, new File(originDir, filename).toPath);
       }
       Files.move(tmpDir.toPath, snapshotDir.toPath, ATOMIC_MOVE)

--- a/src/main/scala/com/cloudant/clouseau/SupportedAnalyzers.scala
+++ b/src/main/scala/com/cloudant/clouseau/SupportedAnalyzers.scala
@@ -21,7 +21,7 @@ import org.apache.lucene.analysis.Tokenizer
 import org.apache.lucene.analysis.TokenStream
 import org.apache.lucene.analysis.Analyzer.TokenStreamComponents
 import org.apache.lucene.analysis.util.CharArraySet
-import scala.collection.JavaConversions._
+import scala.collection.JavaConverters._
 
 import org.apache.lucene.analysis.core.KeywordAnalyzer
 import org.apache.lucene.analysis.core.SimpleAnalyzer
@@ -424,11 +424,11 @@ object SupportedAnalyzers {
     options.get("stopwords").collect { case list: List[_] => list.collect { case word: String => word } }
 
   implicit def listToJavaSet(list: List[String]): JSet[String] = {
-    Set() ++ list
+    (Set() ++ list).asJava
   }
 
   implicit def listToCharArraySet(list: List[String]): CharArraySet = {
-    CharArraySet.unmodifiableSet(CharArraySet.copy(IndexService.version, Set() ++ list))
+    CharArraySet.unmodifiableSet(CharArraySet.copy(IndexService.version, (Set() ++ list).asJava))
   }
 
 }

--- a/src/test/scala/com/cloudant/clouseau/IndexServiceSpec.scala
+++ b/src/test/scala/com/cloudant/clouseau/IndexServiceSpec.scala
@@ -24,7 +24,7 @@ import org.apache.lucene.facet.taxonomy.CategoryPath
 import scalang.Pid
 import scala.Some
 import java.io.File
-import scala.collection.JavaConversions._
+import scala.collection.JavaConverters._
 
 class IndexServiceSpec extends SpecificationWithJUnit {
   sequential
@@ -240,17 +240,17 @@ class IndexServiceSpec extends SpecificationWithJUnit {
       val doc1 = new Document()
       doc1.add(new StringField("_id", "foo", Field.Store.YES))
       doc1.add(new StringField("ffield", "f1", Field.Store.YES))
-      facets.addFields(doc1, List(new CategoryPath("ffield", "f1")))
+      facets.addFields(doc1, List(new CategoryPath("ffield", "f1")).asJava)
 
       val doc2 = new Document()
       doc2.add(new StringField("_id", "foo2", Field.Store.YES))
       doc2.add(new StringField("ffield", "f1", Field.Store.YES))
-      facets.addFields(doc2, List(new CategoryPath("ffield", "f1")))
+      facets.addFields(doc2, List(new CategoryPath("ffield", "f1")).asJava)
 
       val doc3 = new Document()
       doc3.add(new StringField("_id", "foo3", Field.Store.YES))
       doc3.add(new StringField("ffield", "f3", Field.Store.YES))
-      facets.addFields(doc3, List(new CategoryPath("ffield", "f3")))
+      facets.addFields(doc3, List(new CategoryPath("ffield", "f3")).asJava)
 
       node.call(service, UpdateDocMsg("foo", doc1)) must be equalTo 'ok
       node.call(service, UpdateDocMsg("foo2", doc2)) must be equalTo 'ok


### PR DESCRIPTION
The `JavaConversions` are [deprecated in 2.12.0](https://www.scala-lang.org/api/2.12.1/scala/collection/JavaConversions$.html) (in favor of `JavaConverters`) and removed in 2.13.x.

The `JavaConverters` still is a temporary solution because it is also [deprecated](https://www.scala-lang.org/api/2.13.8/scala/collection/JavaConverters$.html) since 2.13.0 (in favor of `scala.jdk.CollectionConverters` ).

However we cannot go directly to `scala.jdk.CollectionConverters` because it is not available in 2.9.1.

 