### PR TITLE
Add vscode produced files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,7 @@ dependency-reduced-pom.xml
 # direnv & asdf
 .asdf
 .envrc.local
+
+# vscode & metals
+.vscode
+.metals


### PR DESCRIPTION
Reduce noise in the `git status` by ignoring the files related to vscode editor.