### PR TITLE
release: 2.23.0 release candidate 1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.cloudant</groupId>
   <artifactId>clouseau</artifactId>
-  <version>2.22.1-SNAPSHOT</version>
+  <version>2.23.0-RC1</version>
   <name>${project.artifactId}</name>
   <description>Full-text indexing for Cloudant</description>
   <inceptionYear>2012</inceptionYear>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.cloudant</groupId>
   <artifactId>clouseau</artifactId>
-  <version>2.23.0-RC1</version>
+  <version>2.23.0-RC2-SNAPSHOT</version>
   <name>${project.artifactId}</name>
   <description>Full-text indexing for Cloudant</description>
   <inceptionYear>2012</inceptionYear>


### PR DESCRIPTION
Create the commit for tagging version 2.23.0-RC1 and open the next snapshot version for RC2.

It is a minor version bump mainly due to [@iilyak's risky changes](https://github.com/cloudant-labs/clouseau/compare/2.22.0...cloudant-labs:clouseau:master?expand=1), though it should cause no change in the service either internally or externally.  The API got somewhat stricter but it was not fully documented so any unexpected use might be a bug actually.

This is also augmented with an RC suffix to make it possible for receiving internal testing first and do the actual release with greater confidence later on.

Served with _"rebase and merge"_.