### PR TITLE
release: 2.23.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.cloudant</groupId>
   <artifactId>clouseau</artifactId>
-  <version>2.23.0</version>
+  <version>2.23.1-SNAPSHOT</version>
   <name>${project.artifactId}</name>
   <description>Full-text indexing for Cloudant</description>
   <inceptionYear>2012</inceptionYear>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.cloudant</groupId>
   <artifactId>clouseau</artifactId>
-  <version>2.23.0-RC2-SNAPSHOT</version>
+  <version>2.23.0</version>
   <name>${project.artifactId}</name>
   <description>Full-text indexing for Cloudant</description>
   <inceptionYear>2012</inceptionYear>


### PR DESCRIPTION
As a follow-up to #89, create a commit for tagging the final release of 2.23.0 and open the next snapshot version for 2.23.1.  The RC suffix is now removed as it has received some more testing in a more production-like environment in the last weeks.  We are now ready to deploy it to production clusters. 

To be added with _"rebase and merge"_.
