### PR TITLE
chore: import dependencies into the source tree

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -200,3 +200,40 @@
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
+
+
+Clouseau Subcomponents
+
+Clouseau project includes a number of subcomponents with separate copyright
+notices and license terms. Your use of the code for the these subcomponents
+is subject to the terms and conditions of the following licenses.
+
+For the src/main/scala/com/boundary/logula component:
+
+   Copyright (c) 2010-2011 Coda Hale
+
+   Permission is hereby granted, free of charge, to any person obtaining
+   a copy of this software and associated documentation files (the
+   "Software"), to deal in the Software without restriction, including
+   without limitation the rights to use, copy, modify, merge, publish,
+   distribute, sublicense, and/or sell copies of the Software, and to
+   permit persons to whom the Software is furnished to do so, subject to
+   the following conditions:
+
+   The above copyright notice and this permission notice shall be
+   included in all copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+   EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+   MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+   NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+   LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+   OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+   WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+For the src/main/scala/org/jctools, src/main/scala/overlock, and
+src/main/scala/scalang components:
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/

--- a/pom.xml
+++ b/pom.xml
@@ -13,22 +13,13 @@
 
   <properties>
     <encoding>UTF-8</encoding>
-    <lucene-version>4.6.1-cloudant1</lucene-version>
+    <lucene-version>4.6.1</lucene-version>
     <maven.compiler.source>1.6</maven.compiler.source>
     <maven.compiler.target>1.6</maven.compiler.target>
     <scala.version>2.9.1</scala.version>
-    <scala.plugin.version>3.1.0</scala.plugin.version>
-    <tika-version>1.0</tika-version>
+    <scala.plugin.version>3.2.0</scala.plugin.version>
     <slf4j.version>1.7.32</slf4j.version>
   </properties>
-
-  <repositories>
-    <repository>
-      <id>CloudantPublicRepo</id>
-      <name>Cloudant Public Repo</name>
-      <url>https://maven.cloudant.com/repo/</url>
-    </repository>
-  </repositories>
 
   <dependencies>
     <!-- Lucene -->
@@ -83,37 +74,37 @@
       <version>${lucene-version}</version>
     </dependency>
 
-    <!-- Tika -->
-    <!--
-    <dependency>
-      <groupId>org.apache.tika</groupId>
-      <artifactId>tika-core</artifactId>
-      <version>${tika-version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.tika</groupId>
-      <artifactId>tika-parsers</artifactId>
-      <version>${tika-version}</version>
-    </dependency>
-    -->
-
-    <!-- Scalang -->
-    <dependency>
-      <groupId>com.boundary</groupId>
-      <artifactId>scalang-scala_2.9.1</artifactId>
-      <version>1.0.4</version>
-    </dependency>
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-api</artifactId>
-      <version>${slf4j.version}</version>
-    </dependency>
-
     <!-- Scala -->
     <dependency>
       <groupId>org.scala-lang</groupId>
       <artifactId>scala-library</artifactId>
       <version>${scala.version}</version>
+    </dependency>
+
+    <!-- Scalang dependencies -->
+    <dependency>
+      <groupId>org.jetlang</groupId>
+      <artifactId>jetlang</artifactId>
+      <version>0.2.12</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jboss.netty</groupId>
+      <artifactId>netty</artifactId>
+      <version>3.2.10.Final</version>
+    </dependency>
+
+    <!-- Overlock dependencies -->
+    <dependency>
+      <groupId>com.yammer.metrics</groupId>
+      <artifactId>metrics-core</artifactId>
+      <version>2.2.0</version>
+    </dependency>
+
+    <dependency>
+      <groupId>com.yammer.metrics</groupId>
+      <artifactId>metrics-scala_${scala.version}</artifactId>
+      <version>2.2.0</version>
     </dependency>
 
     <!-- Misc -->
@@ -154,6 +145,7 @@
         <artifactId>scala-maven-plugin</artifactId>
         <version>${scala.plugin.version}</version>
         <configuration>
+	  <recompileMode>incremental</recompileMode>
           <launchers>
             <launcher>
               <id>standard</id>
@@ -386,25 +378,7 @@
     </plugins>
   </reporting>
 
-  <distributionManagement>
-    <repository>
-      <id>maven.cloudant.com</id>
-      <name>maven.cloudant.com-releases</name>
-      <url>scpexe://maven.cloudant.com/var/www/domains/cloudant.com/maven/htdocs/repo/</url>
-    </repository>
-    <snapshotRepository>
-      <id>maven.cloudant.com</id>
-      <name>maven.cloudant.com-snapshots</name>
-      <url>scpexe://maven.cloudant.com/var/www/domains/cloudant.com/maven/htdocs/repo/</url>
-    </snapshotRepository>
-    <site>
-      <id>website</id>
-      <url>scpexe://maven.cloudant.com/var/www/domains/cloudant.com/maven/htdocs/site/</url>
-    </site>
-  </distributionManagement>
-
   <scm>
     <connection>scm:git:https://github.com/cloudant/clouseau.git</connection>
   </scm>
-
 </project>

--- a/src/main/scala/com/boundary/logula/Log.scala
+++ b/src/main/scala/com/boundary/logula/Log.scala
@@ -1,0 +1,165 @@
+package com.boundary.logula
+
+import reflect.NameTransformer
+import org.slf4j.{ LoggerFactory, Logger }
+
+/**
+ * Log's companion object.
+ */
+object Log {
+  /**
+   * Returns a log for a given class.
+   */
+  def forClass[A](implicit mf: Manifest[A]) = forName(mf.erasure.getCanonicalName)
+
+  /**
+   * Returns a log for a given class.
+   */
+  def forClass(klass: Class[_]) = forName(klass.getCanonicalName)
+
+  /**
+   * Returns a log with the given name.
+   */
+  def forName(name: String) = new Log(LoggerFactory.getLogger(clean(name)))
+
+  private def clean(s: String) = NameTransformer.decode(if (s.endsWith("$")) {
+    s.substring(0, s.length - 1)
+  } else {
+    s
+  }.replaceAll("\\$", "."))
+
+  protected val CallerFQCN = classOf[Log].getCanonicalName
+}
+
+/**
+ * <b>In general, use the Logging trait rather than using Log directly.</b>
+ *
+ * A wrapper for org.apache.log4j which allows for a smoother interaction with
+ * Scala classes. All messages are treated as format strings:
+ * <pre>
+ *    log.info("We have this many threads: %d", thread.size)
+ * </pre>
+ * Each log level has two methods: one for logging regular messages, the other
+ * for logging messages with thrown exceptions.
+ *
+ * The log levels here are those of org.apache.log4j.
+ *
+ * @author coda
+ */
+class Log(private val logger: Logger) {
+
+  /**
+   * Logs a message with optional parameters at level TRACE.
+   */
+  def trace(message: String, params: Any*) {
+    if (logger.isTraceEnabled) {
+      val statement = if (params.isEmpty) message else message.format(params: _*)
+      logger.trace(statement)
+    }
+  }
+
+  /**
+   * Logs a thrown exception and a message with optional parameters at level
+   * TRACE.
+   */
+  def trace(thrown: Throwable, message: String, params: Any*) {
+    if (logger.isTraceEnabled) {
+      val statement = if (params.isEmpty) message else message.format(params: _*)
+      logger.trace(statement, thrown)
+    }
+  }
+
+  /**
+   * Logs a message with optional parameters at level DEBUG.
+   */
+  def debug(message: String, params: Any*) {
+    if (logger.isDebugEnabled) {
+      val statement = if (params.isEmpty) message else message.format(params: _*)
+      logger.debug(statement)
+    }
+  }
+
+  /**
+   * Logs a thrown exception and a message with optional parameters at level
+   * DEBUG.
+   */
+  def debug(thrown: Throwable, message: String, params: Any*) {
+    if (logger.isDebugEnabled) {
+      val statement = if (params.isEmpty) message else message.format(params: _*)
+      logger.debug(statement, thrown)
+    }
+  }
+
+  /**
+   * Logs a message with optional parameters at level INFO.
+   */
+  def info(message: String, params: Any*) {
+    if (logger.isInfoEnabled) {
+      val statement = if (params.isEmpty) message else message.format(params: _*)
+      logger.info(statement)
+    }
+  }
+
+  /**
+   * Logs a thrown exception and a message with optional parameters at level
+   * INFO.
+   */
+  def info(thrown: Throwable, message: String, params: Any*) {
+    if (logger.isInfoEnabled) {
+      val statement = if (params.isEmpty) message else message.format(params: _*)
+      logger.info(statement, thrown)
+    }
+  }
+
+  /**
+   * Logs a message with optional parameters at level WARN.
+   */
+  def warn(message: String, params: Any*) {
+    if (logger.isWarnEnabled) {
+      val statement = if (params.isEmpty) message else message.format(params: _*)
+      logger.warn(statement)
+    }
+  }
+
+  /**
+   * Logs a thrown exception and a message with optional parameters at level
+   * WARN.
+   */
+  def warn(thrown: Throwable, message: String, params: Any*) {
+    if (logger.isWarnEnabled) {
+      val statement = if (params.isEmpty) message else message.format(params: _*)
+      logger.warn(statement, thrown)
+    }
+  }
+
+  /**
+   * Logs a message with optional parameters at level ERROR.
+   */
+  def error(message: String, params: Any*) {
+    if (logger.isErrorEnabled) {
+      val statement = if (params.isEmpty) message else message.format(params: _*)
+      logger.error(statement)
+    }
+  }
+
+  /**
+   * Logs a thrown exception and a message with optional parameters at level
+   * ERROR.
+   */
+  def error(thrown: Throwable, message: String, params: Any*) {
+    if (logger.isErrorEnabled) {
+      val statement = if (params.isEmpty) message else message.format(params: _*)
+      logger.error(statement, thrown)
+    }
+  }
+
+  def isTraceEnabled = logger.isTraceEnabled
+
+  def isDebugEnabled = logger.isDebugEnabled
+
+  def isInfoEnabled = logger.isInfoEnabled
+
+  def isWarnEnabled = logger.isWarnEnabled
+
+  def isErrorEnabled = logger.isErrorEnabled
+}

--- a/src/main/scala/com/boundary/logula/Logging.scala
+++ b/src/main/scala/com/boundary/logula/Logging.scala
@@ -1,0 +1,9 @@
+package com.boundary.logula
+
+/**
+ * A mixin trait which provides subclasses with a Log instance keyed to the
+ * subclass's name.
+ */
+trait Logging {
+  protected lazy val log: Log = Log.forClass(getClass)
+}

--- a/src/main/scala/org/jctools/maps/AbstractEntry.java
+++ b/src/main/scala/org/jctools/maps/AbstractEntry.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jctools.maps;
+import java.util.Map;
+
+/**
+ * A simple implementation of {@link java.util.Map.Entry}.
+ * Does not implement {@link java.util.Map.Entry#setValue}, that is done by users of the class.
+ *
+ * @since 1.5
+ * @author Cliff Click
+ * @param <TypeK> the type of keys maintained by this map
+ * @param <TypeV> the type of mapped values
+ */
+
+abstract class AbstractEntry<TypeK,TypeV> implements Map.Entry<TypeK,TypeV> {
+  /** Strongly typed key */
+  protected final TypeK _key; 
+  /** Strongly typed value */
+  protected       TypeV _val;
+  
+  public AbstractEntry(final TypeK key, final TypeV val) { _key = key;        _val = val; }
+  public AbstractEntry(final Map.Entry<TypeK,TypeV> e  ) { _key = e.getKey(); _val = e.getValue(); }
+  /** Return "key=val" string */
+  public String toString() { return _key + "=" + _val; }
+  /** Return key */
+  public TypeK getKey  () { return _key;  }
+  /** Return val */
+  public TypeV getValue() { return _val;  }
+
+  /** Equal if the underlying key & value are equal */
+  public boolean equals(final Object o) {
+    if (!(o instanceof Map.Entry)) return false;
+    final Map.Entry e = (Map.Entry)o;
+    return eq(_key, e.getKey()) && eq(_val, e.getValue());
+  }
+  
+  /** Compute <code>"key.hashCode() ^ val.hashCode()"</code> */
+  public int hashCode() {
+    return 
+      ((_key == null) ? 0 : _key.hashCode()) ^
+      ((_val == null) ? 0 : _val.hashCode());
+  }
+  
+  private static boolean eq(final Object o1, final Object o2) {
+    return (o1 == null ? o2 == null : o1.equals(o2));
+  }
+}

--- a/src/main/scala/org/jctools/maps/ConcurrentAutoTable.java
+++ b/src/main/scala/org/jctools/maps/ConcurrentAutoTable.java
@@ -1,0 +1,219 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jctools.maps;
+import static org.jctools.util.UnsafeAccess.UNSAFE;
+
+import java.io.Serializable;
+import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
+
+
+/**
+ * An auto-resizing table of {@code longs}, supporting low-contention CAS
+ * operations.  Updates are done with CAS's to no particular table element.
+ * The intent is to support highly scalable counters, r/w locks, and other
+ * structures where the updates are associative, loss-free (no-brainer), and
+ * otherwise happen at such a high volume that the cache contention for
+ * CAS'ing a single word is unacceptable.
+ *
+ * @since 1.5
+ * @author Cliff Click
+ */
+public class ConcurrentAutoTable implements Serializable {
+
+  // --- public interface ---
+
+  /**
+   * Add the given value to current counter value.  Concurrent updates will
+   * not be lost, but addAndGet or getAndAdd are not implemented because the
+   * total counter value (i.e., {@link #get}) is not atomically updated.
+   * Updates are striped across an array of counters to avoid cache contention
+   * and has been tested with performance scaling linearly up to 768 CPUs.
+   */
+  public void add( long x ) { add_if(  x); }
+  /** {@link #add} with -1 */
+  public void decrement()   { add_if(-1L); }
+  /** {@link #add} with +1 */
+  public void increment()   { add_if( 1L); }
+
+  /** Atomically set the sum of the striped counters to specified value.
+   *  Rather more expensive than a simple store, in order to remain atomic.
+   */
+  public void set( long x ) {
+    CAT newcat = new CAT(null,4,x);
+    // Spin until CAS works
+    while( !CAS_cat(_cat,newcat) ) {/*empty*/}
+  }
+
+  /**
+   * Current value of the counter.  Since other threads are updating furiously
+   * the value is only approximate, but it includes all counts made by the
+   * current thread.  Requires a pass over the internally striped counters.
+   */
+  public long get()       { return      _cat.sum(); }
+  /** Same as {@link #get}, included for completeness. */
+  public int  intValue()  { return (int)_cat.sum(); }
+  /** Same as {@link #get}, included for completeness. */
+  public long longValue() { return      _cat.sum(); }
+
+  /**
+   * A cheaper {@link #get}.  Updated only once/millisecond, but as fast as a
+   * simple load instruction when not updating.
+   */
+  public long estimate_get( ) { return _cat.estimate_sum(); }
+
+  /**
+   * Return the counter's {@code long} value converted to a string.
+   */
+  public String toString() { return _cat.toString(); }
+
+  /**
+   * A more verbose print than {@link #toString}, showing internal structure.
+   * Useful for debugging.
+   */
+  public void print() { _cat.print(); }
+
+  /**
+   * Return the internal counter striping factor.  Useful for diagnosing
+   * performance problems.
+   */
+  public int internal_size() { return _cat._t.length; }
+
+  // Only add 'x' to some slot in table, hinted at by 'hash'.  The sum can
+  // overflow.  Value is CAS'd so no counts are lost.  The CAS is retried until
+  // it succeeds.  Returned value is the old value.
+  private long add_if( long x ) { return _cat.add_if(x,hash(),this); }
+
+  // The underlying array of concurrently updated long counters
+  private volatile CAT _cat = new CAT(null,16/*Start Small, Think Big!*/,0L);
+  private static AtomicReferenceFieldUpdater<ConcurrentAutoTable,CAT> _catUpdater =
+    AtomicReferenceFieldUpdater.newUpdater(ConcurrentAutoTable.class,CAT.class, "_cat");
+  private boolean CAS_cat( CAT oldcat, CAT newcat ) { return _catUpdater.compareAndSet(this,oldcat,newcat); }
+
+  // Hash spreader
+  private static int hash() {
+    //int h = (int)Thread.currentThread().getId();
+    int h = System.identityHashCode(Thread.currentThread());
+    return h<<3;                // Pad out cache lines.  The goal is to avoid cache-line contention
+  }
+
+  // --- CAT -----------------------------------------------------------------
+  private static class CAT implements Serializable {
+
+    // Unsafe crud: get a function which will CAS arrays
+    private static final int _Lbase  = UNSAFE.arrayBaseOffset(long[].class);
+    private static final int _Lscale = UNSAFE.arrayIndexScale(long[].class);
+    private static long rawIndex(long[] ary, int i) {
+      assert i >= 0 && i < ary.length;
+      return _Lbase + (i * (long)_Lscale);
+    }
+    private static boolean CAS( long[] A, int idx, long old, long nnn ) {
+      return UNSAFE.compareAndSwapLong( A, rawIndex(A,idx), old, nnn );
+    }
+
+    //volatile long _resizers;    // count of threads attempting a resize
+    //static private final AtomicLongFieldUpdater<CAT> _resizerUpdater =
+    //  AtomicLongFieldUpdater.newUpdater(CAT.class, "_resizers");
+
+    private final CAT _next;
+    private volatile long _fuzzy_sum_cache;
+    private volatile long _fuzzy_time;
+    private static final int MAX_SPIN=1;
+    private final long[] _t;     // Power-of-2 array of longs
+
+    CAT( CAT next, int sz, long init ) {
+      _next = next;
+      _t = new long[sz];
+      _t[0] = init;
+    }
+
+    // Only add 'x' to some slot in table, hinted at by 'hash'.  The sum can
+    // overflow.  Value is CAS'd so no counts are lost.  The CAS is attempted
+    // ONCE.
+    public long add_if( long x, int hash, ConcurrentAutoTable master ) {
+      final long[] t = _t;
+      final int idx = hash & (t.length-1);
+      // Peel loop; try once fast
+      long old = t[idx];
+      final boolean ok = CAS( t, idx, old, old+x );
+      if( ok ) return old;      // Got it
+      // Try harder
+      int cnt=0;
+      while( true ) {
+        old = t[idx];
+        if( CAS( t, idx, old, old+x ) ) break; // Got it!
+        cnt++;
+      }
+      if( cnt < MAX_SPIN ) return old; // Allowable spin loop count
+      if( t.length >= 1024*1024 ) return old; // too big already
+
+      // Too much contention; double array size in an effort to reduce contention
+      //long r = _resizers;
+      //final int newbytes = (t.length<<1)<<3/*word to bytes*/;
+      //while( !_resizerUpdater.compareAndSet(this,r,r+newbytes) )
+      //  r = _resizers;
+      //r += newbytes;
+      if( master._cat != this ) return old; // Already doubled, don't bother
+      //if( (r>>17) != 0 ) {      // Already too much allocation attempts?
+      //  // We could use a wait with timeout, so we'll wakeup as soon as the new
+      //  // table is ready, or after the timeout in any case.  Annoyingly, this
+      //  // breaks the non-blocking property - so for now we just briefly sleep.
+      //  //synchronized( this ) { wait(8*megs); }         // Timeout - we always wakeup
+      //  try { Thread.sleep(r>>17); } catch( InterruptedException e ) { }
+      //  if( master._cat != this ) return old;
+      //}
+
+      CAT newcat = new CAT(this,t.length*2,0);
+      // Take 1 stab at updating the CAT with the new larger size.  If this
+      // fails, we assume some other thread already expanded the CAT - so we
+      // do not need to retry until it succeeds.
+      while( master._cat == this && !master.CAS_cat(this,newcat) ) {/*empty*/}
+      return old;
+    }
+
+
+    // Return the current sum of all things in the table.  Writers can be
+    // updating the table furiously, so the sum is only locally accurate.
+    public long sum( ) {
+      long sum = _next == null ? 0 : _next.sum(); // Recursively get cached sum
+      final long[] t = _t;
+      for( long cnt : t ) sum += cnt;
+      return sum;
+    }
+
+    // Fast fuzzy version.  Used a cached value until it gets old, then re-up
+    // the cache.
+    public long estimate_sum( ) {
+      // For short tables, just do the work
+      if( _t.length <= 64 ) return sum();
+      // For bigger tables, periodically freshen a cached value
+      long millis = System.currentTimeMillis();
+      if( _fuzzy_time != millis ) { // Time marches on?
+        _fuzzy_sum_cache = sum(); // Get sum the hard way
+        _fuzzy_time = millis;   // Indicate freshness of cached value
+      }
+      return _fuzzy_sum_cache;  // Return cached sum
+    }
+
+    public String toString( ) { return Long.toString(sum()); }
+
+    public void print() {
+      long[] t = _t;
+      System.out.print("["+t[0]);
+      for( int i=1; i<t.length; i++ )
+        System.out.print(","+t[i]);
+      System.out.print("]");
+      if( _next != null ) _next.print();
+    }
+  }
+}

--- a/src/main/scala/org/jctools/maps/NonBlockingHashMap.java
+++ b/src/main/scala/org/jctools/maps/NonBlockingHashMap.java
@@ -1,0 +1,1464 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jctools.maps;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.*;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
+
+import org.jctools.util.RangeUtil;
+
+import static org.jctools.util.UnsafeAccess.UNSAFE;
+import static org.jctools.util.UnsafeAccess.fieldOffset;
+
+/**
+ * A lock-free alternate implementation of {@link java.util.concurrent.ConcurrentHashMap}
+ * with better scaling properties and generally lower costs to mutate the Map.
+ * It provides identical correctness properties as ConcurrentHashMap.  All
+ * operations are non-blocking and multi-thread safe, including all update
+ * operations.  {@link NonBlockingHashMap} scales substantially better than
+ * {@link java.util.concurrent.ConcurrentHashMap} for high update rates, even with a
+ * large concurrency factor.  Scaling is linear up to 768 CPUs on a 768-CPU
+ * Azul box, even with 100% updates or 100% reads or any fraction in-between.
+ * Linear scaling up to all cpus has been observed on a 32-way Sun US2 box,
+ * 32-way Sun Niagara box, 8-way Intel box and a 4-way Power box.
+ *
+ * This class obeys the same functional specification as {@link
+ * java.util.Hashtable}, and includes versions of methods corresponding to
+ * each method of <tt>Hashtable</tt>. However, even though all operations are
+ * thread-safe, operations do <em>not</em> entail locking and there is
+ * <em>not</em> any support for locking the entire table in a way that
+ * prevents all access.  This class is fully interoperable with
+ * <tt>Hashtable</tt> in programs that rely on its thread safety but not on
+ * its synchronization details.
+ *
+ * <p> Operations (including <tt>put</tt>) generally do not block, so may
+ * overlap with other update operations (including other <tt>puts</tt> and
+ * <tt>removes</tt>).  Retrievals reflect the results of the most recently
+ * <em>completed</em> update operations holding upon their onset.  For
+ * aggregate operations such as <tt>putAll</tt>, concurrent retrievals may
+ * reflect insertion or removal of only some entries.  Similarly, Iterators
+ * and Enumerations return elements reflecting the state of the hash table at
+ * some point at or since the creation of the iterator/enumeration.  They do
+ * <em>not</em> throw {@link ConcurrentModificationException}.  However,
+ * iterators are designed to be used by only one thread at a time.
+ *
+ * <p> Very full tables, or tables with high re-probe rates may trigger an
+ * internal resize operation to move into a larger table.  Resizing is not
+ * terribly expensive, but it is not free either; during resize operations
+ * table throughput may drop somewhat.  All threads that visit the table
+ * during a resize will 'help' the resizing but will still be allowed to
+ * complete their operation before the resize is finished (i.e., a simple
+ * 'get' operation on a million-entry table undergoing resizing will not need
+ * to block until the entire million entries are copied).
+ *
+ * <p>This class and its views and iterators implement all of the
+ * <em>optional</em> methods of the {@link Map} and {@link Iterator}
+ * interfaces.
+ *
+ * <p> Like {@link Hashtable} but unlike {@link HashMap}, this class
+ * does <em>not</em> allow <tt>null</tt> to be used as a key or value.
+ *
+ *
+ * @since 1.5
+ * @author Cliff Click
+ * @param <TypeK> the type of keys maintained by this map
+ * @param <TypeV> the type of mapped values
+ */
+
+public class NonBlockingHashMap<TypeK, TypeV>
+  extends AbstractMap<TypeK, TypeV>
+  implements ConcurrentMap<TypeK, TypeV>, Cloneable, Serializable {
+
+  private static final long serialVersionUID = 1234123412341234123L;
+
+  private static final int REPROBE_LIMIT=10; // Too many reprobes then force a table-resize
+
+  // --- Bits to allow Unsafe access to arrays
+  private static final int _Obase  = UNSAFE.arrayBaseOffset(Object[].class);
+  private static final int _Oscale = UNSAFE.arrayIndexScale(Object[].class);
+  private static final int _Olog   = _Oscale==4?2:(_Oscale==8?3:9999);
+  private static long rawIndex(final Object[] ary, final int idx) {
+    assert idx >= 0 && idx < ary.length;
+    // Note the long-math requirement, to handle arrays of more than 2^31 bytes
+    // - or 2^28 - or about 268M - 8-byte pointer elements.
+    return _Obase + ((long)idx << _Olog);
+  }
+
+  // --- Setup to use Unsafe
+  private static final long _kvs_offset = fieldOffset(NonBlockingHashMap.class, "_kvs");
+
+  private final boolean CAS_kvs( final Object[] oldkvs, final Object[] newkvs ) {
+    return UNSAFE.compareAndSwapObject(this, _kvs_offset, oldkvs, newkvs );
+  }
+
+  // --- Adding a 'prime' bit onto Values via wrapping with a junk wrapper class
+  private static final class Prime {
+    final Object _V;
+    Prime( Object V ) { _V = V; }
+    static Object unbox( Object V ) { return V instanceof Prime ? ((Prime)V)._V : V; }
+  }
+
+  // --- hash ----------------------------------------------------------------
+  // Helper function to spread lousy hashCodes.  Throws NPE for null Key, on
+  // purpose - as the first place to conveniently toss the required NPE for a
+  // null Key.
+  private static final int hash(final Object key) {
+    int h = key.hashCode();     // The real hashCode call
+    h ^= (h>>>20) ^ (h>>>12);
+    h ^= (h>>> 7) ^ (h>>> 4);
+	h += h<<7; // smear low bits up high, for hashcodes that only differ by 1
+    return h;
+  }
+
+  // --- The Hash Table --------------------
+  // Slot 0 is always used for a 'CHM' entry below to hold the interesting
+  // bits of the hash table.  Slot 1 holds full hashes as an array of ints.
+  // Slots {2,3}, {4,5}, etc hold {Key,Value} pairs.  The entire hash table
+  // can be atomically replaced by CASing the _kvs field.
+  //
+  // Why is CHM buried inside the _kvs Object array, instead of the other way
+  // around?  The CHM info is used during resize events and updates, but not
+  // during standard 'get' operations.  I assume 'get' is much more frequent
+  // than 'put'.  'get' can skip the extra indirection of skipping through the
+  // CHM to reach the _kvs array.
+  private transient Object[] _kvs;
+  private static final CHM   chm   (Object[] kvs) { return (CHM  )kvs[0]; }
+  private static final int[] hashes(Object[] kvs) { return (int[])kvs[1]; }
+  // Number of K,V pairs in the table
+  private static final int len(Object[] kvs) { return (kvs.length-2)>>1; }
+
+  // Time since last resize
+  private transient long _last_resize_milli;
+
+  // --- Minimum table size ----------------
+  // Pick size 8 K/V pairs, which turns into (8*2+2)*4+12 = 84 bytes on a
+  // standard 32-bit HotSpot, and (8*2+2)*8+12 = 156 bytes on 64-bit Azul.
+  private static final int MIN_SIZE_LOG=3;             //
+  private static final int MIN_SIZE=(1<<MIN_SIZE_LOG); // Must be power of 2
+
+  // --- Sentinels -------------------------
+  // No-Match-Old - putIfMatch does updates only if it matches the old value,
+  // and NO_MATCH_OLD basically counts as a wildcard match.
+  private static final Object NO_MATCH_OLD = new Object(); // Sentinel
+  // Match-Any-not-null - putIfMatch does updates only if it find a real old
+  // value.
+  private static final Object MATCH_ANY = new Object(); // Sentinel
+  // This K/V pair has been deleted (but the Key slot is forever claimed).
+  // The same Key can be reinserted with a new value later.
+  public static final Object TOMBSTONE = new Object();
+  // Prime'd or box'd version of TOMBSTONE.  This K/V pair was deleted, then a
+  // table resize started.  The K/V pair has been marked so that no new
+  // updates can happen to the old table (and since the K/V pair was deleted
+  // nothing was copied to the new table).
+  private static final Prime TOMBPRIME = new Prime(TOMBSTONE);
+
+  // --- key,val -------------------------------------------------------------
+  // Access K,V for a given idx
+  //
+  // Note that these are static, so that the caller is forced to read the _kvs
+  // field only once, and share that read across all key/val calls - lest the
+  // _kvs field move out from under us and back-to-back key & val calls refer
+  // to different _kvs arrays.
+  private static final Object key(Object[] kvs,int idx) { return kvs[(idx<<1)+2]; }
+  private static final Object val(Object[] kvs,int idx) { return kvs[(idx<<1)+3]; }
+  private static final boolean CAS_key( Object[] kvs, int idx, Object old, Object key ) {
+    return UNSAFE.compareAndSwapObject( kvs, rawIndex(kvs,(idx<<1)+2), old, key );
+  }
+  private static final boolean CAS_val( Object[] kvs, int idx, Object old, Object val ) {
+    return UNSAFE.compareAndSwapObject( kvs, rawIndex(kvs,(idx<<1)+3), old, val );
+  }
+
+
+  // --- dump ----------------------------------------------------------------
+  /** Verbose printout of table internals, useful for debugging.  */
+  public final void print() {
+    System.out.println("=========");
+    print2(_kvs);
+    System.out.println("=========");
+  }
+  // print the entire state of the table
+  private final void print( Object[] kvs ) {
+    for( int i=0; i<len(kvs); i++ ) {
+      Object K = key(kvs,i);
+      if( K != null ) {
+        String KS = (K == TOMBSTONE) ? "XXX" : K.toString();
+        Object V = val(kvs,i);
+        Object U = Prime.unbox(V);
+        String p = (V==U) ? "" : "prime_";
+        String US = (U == TOMBSTONE) ? "tombstone" : U.toString();
+        System.out.println(""+i+" ("+KS+","+p+US+")");
+      }
+    }
+    Object[] newkvs = chm(kvs)._newkvs; // New table, if any
+    if( newkvs != null ) {
+      System.out.println("----");
+      print(newkvs);
+    }
+  }
+  // print only the live values, broken down by the table they are in
+  private final void print2( Object[] kvs) {
+    for( int i=0; i<len(kvs); i++ ) {
+      Object key = key(kvs,i);
+      Object val = val(kvs,i);
+      Object U = Prime.unbox(val);
+      if( key != null && key != TOMBSTONE &&  // key is sane
+          val != null && U   != TOMBSTONE ) { // val is sane
+        String p = (val==U) ? "" : "prime_";
+        System.out.println(""+i+" ("+key+","+p+val+")");
+      }
+    }
+    Object[] newkvs = chm(kvs)._newkvs; // New table, if any
+    if( newkvs != null ) {
+      System.out.println("----");
+      print2(newkvs);
+    }
+  }
+
+  // Count of reprobes
+  private transient ConcurrentAutoTable _reprobes = new ConcurrentAutoTable();
+  /** Get and clear the current count of reprobes.  Reprobes happen on key
+   *  collisions, and a high reprobe rate may indicate a poor hash function or
+   *  weaknesses in the table resizing function.
+   *  @return the count of reprobes since the last call to {@link #reprobes}
+   *  or since the table was created.   */
+  public long reprobes() { long r = _reprobes.get(); _reprobes = new ConcurrentAutoTable(); return r; }
+
+
+  // --- reprobe_limit -----------------------------------------------------
+  // Heuristic to decide if we have reprobed toooo many times.  Running over
+  // the reprobe limit on a 'get' call acts as a 'miss'; on a 'put' call it
+  // can trigger a table resize.  Several places must have exact agreement on
+  // what the reprobe_limit is, so we share it here.
+  private static int reprobe_limit( int len ) {
+    return REPROBE_LIMIT + (len>>4);
+  }
+
+  // --- NonBlockingHashMap --------------------------------------------------
+  // Constructors
+
+  /** Create a new NonBlockingHashMap with default minimum size (currently set
+   *  to 8 K/V pairs or roughly 84 bytes on a standard 32-bit JVM). */
+  public NonBlockingHashMap( ) { this(MIN_SIZE); }
+
+  /** Create a new NonBlockingHashMap with initial room for the given number of
+   *  elements, thus avoiding internal resizing operations to reach an
+   *  appropriate size.  Large numbers here when used with a small count of
+   *  elements will sacrifice space for a small amount of time gained.  The
+   *  initial size will be rounded up internally to the next larger power of 2. */
+  public NonBlockingHashMap( final int initial_sz ) { initialize(initial_sz); }
+  private final void initialize( int initial_sz ) {
+    RangeUtil.checkPositiveOrZero(initial_sz, "initial_sz");
+    int i;                      // Convert to next largest power-of-2
+    if( initial_sz > 1024*1024 ) initial_sz = 1024*1024;
+    for( i=MIN_SIZE_LOG; (1<<i) < (initial_sz<<2); i++ ) ;
+    // Double size for K,V pairs, add 1 for CHM and 1 for hashes
+    _kvs = new Object[((1<<i)<<1)+2];
+    _kvs[0] = new CHM(new ConcurrentAutoTable()); // CHM in slot 0
+    _kvs[1] = new int[1<<i];          // Matching hash entries
+    _last_resize_milli = System.currentTimeMillis();
+  }
+  // Version for subclassed readObject calls, to be called after the defaultReadObject
+  protected final void initialize() { initialize(MIN_SIZE); }
+
+  // --- wrappers ------------------------------------------------------------
+
+  /** Returns the number of key-value mappings in this map.
+   *  @return the number of key-value mappings in this map */
+  @Override
+  public int     size       ( )                       { return chm(_kvs).size(); }
+  /** Returns <tt>size() == 0</tt>.
+   *  @return <tt>size() == 0</tt> */
+  @Override
+  public boolean isEmpty    ( )                       { return size() == 0;      }
+
+  /** Tests if the key in the table using the <tt>equals</tt> method.
+   * @return <tt>true</tt> if the key is in the table using the <tt>equals</tt> method
+   * @throws NullPointerException if the specified key is null  */
+  @Override
+  public boolean containsKey( Object key )            { return get(key) != null; }
+
+  /** Legacy method testing if some key maps into the specified value in this
+   *  table.  This method is identical in functionality to {@link
+   *  #containsValue}, and exists solely to ensure full compatibility with
+   *  class {@link java.util.Hashtable}, which supported this method prior to
+   *  introduction of the Java Collections framework.
+   *  @param  val a value to search for
+   *  @return <tt>true</tt> if this map maps one or more keys to the specified value
+   *  @throws NullPointerException if the specified value is null */
+  public boolean contains   ( Object val )            { return containsValue(val); }
+
+  /** Maps the specified key to the specified value in the table.  Neither key
+   *  nor value can be null.
+   *  <p> The value can be retrieved by calling {@link #get} with a key that is
+   *  equal to the original key.
+   *  @param key key with which the specified value is to be associated
+   *  @param val value to be associated with the specified key
+   *  @return the previous value associated with <tt>key</tt>, or
+   *          <tt>null</tt> if there was no mapping for <tt>key</tt>
+   *  @throws NullPointerException if the specified key or value is null  */
+  @Override
+  public TypeV   put        ( TypeK  key, TypeV val ) { return putIfMatch( key,      val, NO_MATCH_OLD); }
+
+  /** Atomically, do a {@link #put} if-and-only-if the key is not mapped.
+   *  Useful to ensure that only a single mapping for the key exists, even if
+   *  many threads are trying to create the mapping in parallel.
+   *  @return the previous value associated with the specified key,
+   *         or <tt>null</tt> if there was no mapping for the key
+   *  @throws NullPointerException if the specified key or value is null  */
+  @Override
+  public TypeV   putIfAbsent( TypeK  key, TypeV val ) { return putIfMatch( key,      val, TOMBSTONE   ); }
+
+  /** Removes the key (and its corresponding value) from this map.
+   *  This method does nothing if the key is not in the map.
+   *  @return the previous value associated with <tt>key</tt>, or
+   *         <tt>null</tt> if there was no mapping for <tt>key</tt>
+   *  @throws NullPointerException if the specified key is null */
+  @Override
+  public TypeV   remove     ( Object key )            { return putIfMatch( key,TOMBSTONE, NO_MATCH_OLD); }
+
+  /** Atomically do a {@link #remove(Object)} if-and-only-if the key is mapped
+   *  to a value which is <code>equals</code> to the given value.
+   *  @throws NullPointerException if the specified key or value is null */
+  public boolean remove     ( Object key,Object val ) {
+    return objectsEquals(putIfMatch( key,TOMBSTONE, val ), val);
+  }
+
+  /** Atomically do a <code>put(key,val)</code> if-and-only-if the key is
+   *  mapped to some value already.
+   *  @throws NullPointerException if the specified key or value is null */
+  @Override
+  public TypeV   replace    ( TypeK  key, TypeV val ) { return putIfMatch( key,      val,MATCH_ANY   ); }
+
+  /** Atomically do a <code>put(key,newValue)</code> if-and-only-if the key is
+   *  mapped a value which is <code>equals</code> to <code>oldValue</code>.
+   *  @throws NullPointerException if the specified key or value is null */
+  @Override
+  public boolean replace    ( TypeK  key, TypeV  oldValue, TypeV newValue ) {
+    return objectsEquals(putIfMatch( key, newValue, oldValue ), oldValue);
+  }
+  private static boolean objectsEquals(Object a, Object b) {
+    return (a == b) || (b != null && b.equals(a));
+  }
+
+  // Atomically replace newVal for oldVal, returning the value that existed
+  // there before.  If the oldVal matches the returned value, then newVal was
+  // inserted, otherwise not.  A null oldVal means the key does not exist (only
+  // insert if missing); a null newVal means to remove the key.
+  public final TypeV putIfMatchAllowNull( Object key, Object newVal, Object oldVal ) {
+    if( oldVal == null ) oldVal = TOMBSTONE;
+    if( newVal == null ) newVal = TOMBSTONE;
+    final TypeV res = (TypeV) putIfMatch0(this, _kvs, key, newVal, oldVal );
+    assert !(res instanceof Prime);
+    //assert res != null;
+    return res == TOMBSTONE ? null : res;
+  }
+
+  /** Atomically replace newVal for oldVal, returning the value that existed
+   *  there before.  If the oldVal matches the returned value, then newVal was
+   *  inserted, otherwise not.
+   *  @return the previous value associated with the specified key,
+   *         or <tt>null</tt> if there was no mapping for the key
+   *  @throws NullPointerException if the key or either value is null
+   */
+  public final TypeV putIfMatch( Object key, Object newVal, Object oldVal ) {
+    if (oldVal == null || newVal == null) throw new NullPointerException();
+    final Object res = putIfMatch0(this, _kvs, key, newVal, oldVal );
+    assert !(res instanceof Prime);
+    assert res != null;
+    return res == TOMBSTONE ? null : (TypeV)res;
+  }
+
+
+  /** Copies all of the mappings from the specified map to this one, replacing
+   *  any existing mappings.
+   *  @param m mappings to be stored in this map */
+  @Override
+  public void putAll(Map<? extends TypeK, ? extends TypeV> m) {
+    for (Map.Entry<? extends TypeK, ? extends TypeV> e : m.entrySet())
+      put(e.getKey(), e.getValue());
+  }
+
+  /** Removes all of the mappings from this map. */
+  @Override
+  public void clear() {         // Smack a new empty table down
+    Object[] newkvs = new NonBlockingHashMap(MIN_SIZE)._kvs;
+    while( !CAS_kvs(_kvs,newkvs) ) // Spin until the clear works
+      ;
+  }
+
+  /** Returns <tt>true</tt> if this Map maps one or more keys to the specified
+   *  value.  <em>Note</em>: This method requires a full internal traversal of the
+   *  hash table and is much slower than {@link #containsKey}.
+   *  @param val value whose presence in this map is to be tested
+   *  @return <tt>true</tt> if this map maps one or more keys to the specified value
+   *  @throws NullPointerException if the specified value is null */
+  @Override
+  public boolean containsValue( final Object val ) {
+    if( val == null ) throw new NullPointerException();
+    for( TypeV V : values() )
+      if( V == val || V.equals(val) )
+        return true;
+    return false;
+  }
+
+  // This function is supposed to do something for Hashtable, and the JCK
+  // tests hang until it gets called... by somebody ... for some reason,
+  // any reason....
+  protected void rehash() {
+  }
+
+  /**
+   * Creates a shallow copy of this hashtable. All the structure of the
+   * hashtable itself is copied, but the keys and values are not cloned.
+   * This is a relatively expensive operation.
+   *
+   * @return  a clone of the hashtable.
+   */
+  @Override
+  public Object clone() {
+    try {
+      // Must clone, to get the class right; NBHM might have been
+      // extended so it would be wrong to just make a new NBHM.
+      NonBlockingHashMap<TypeK,TypeV> t = (NonBlockingHashMap<TypeK,TypeV>) super.clone();
+      // But I don't have an atomic clone operation - the underlying _kvs
+      // structure is undergoing rapid change.  If I just clone the _kvs
+      // field, the CHM in _kvs[0] won't be in sync.
+      //
+      // Wipe out the cloned array (it was shallow anyways).
+      t.clear();
+      // Now copy sanely
+      for( TypeK K : keySet() ) {
+        final TypeV V = get(K);  // Do an official 'get'
+        t.put(K,V);
+      }
+      return t;
+    } catch (CloneNotSupportedException e) {
+      // this shouldn't happen, since we are Cloneable
+      throw new InternalError();
+    }
+  }
+
+  /**
+   * Returns a string representation of this map.  The string representation
+   * consists of a list of key-value mappings in the order returned by the
+   * map's <tt>entrySet</tt> view's iterator, enclosed in braces
+   * (<tt>"{}"</tt>).  Adjacent mappings are separated by the characters
+   * <tt>", "</tt> (comma and space).  Each key-value mapping is rendered as
+   * the key followed by an equals sign (<tt>"="</tt>) followed by the
+   * associated value.  Keys and values are converted to strings as by
+   * {@link String#valueOf(Object)}.
+   *
+   * @return a string representation of this map
+   */
+  @Override
+  public String toString() {
+    Iterator<Entry<TypeK,TypeV>> i = entrySet().iterator();
+    if( !i.hasNext())
+      return "{}";
+
+    StringBuilder sb = new StringBuilder();
+    sb.append('{');
+    for (;;) {
+      Entry<TypeK,TypeV> e = i.next();
+      TypeK key = e.getKey();
+      TypeV value = e.getValue();
+      sb.append(key   == this ? "(this Map)" : key);
+      sb.append('=');
+      sb.append(value == this ? "(this Map)" : value);
+      if( !i.hasNext())
+        return sb.append('}').toString();
+      sb.append(", ");
+    }
+  }
+
+  // --- keyeq ---------------------------------------------------------------
+  // Check for key equality.  Try direct pointer compare first, then see if
+  // the hashes are unequal (fast negative test) and finally do the full-on
+  // 'equals' v-call.
+  private static boolean keyeq( Object K, Object key, int[] hashes, int hash, int fullhash ) {
+    return
+      K==key ||                 // Either keys match exactly OR
+      // hash exists and matches?  hash can be zero during the install of a
+      // new key/value pair.
+      ((hashes[hash] == 0 || hashes[hash] == fullhash) &&
+       // Do not call the users' "equals()" call with a Tombstone, as this can
+       // surprise poorly written "equals()" calls that throw exceptions
+       // instead of simply returning false.
+       K != TOMBSTONE &&        // Do not call users' equals call with a Tombstone
+       // Do the match the hard way - with the users' key being the loop-
+       // invariant "this" pointer.  I could have flipped the order of
+       // operands (since equals is commutative), but I'm making mega-morphic
+       // v-calls in a re-probing loop and nailing down the 'this' argument
+       // gives both the JIT and the hardware a chance to prefetch the call target.
+       key.equals(K));          // Finally do the hard match
+  }
+
+  // --- get -----------------------------------------------------------------
+  /** Returns the value to which the specified key is mapped, or {@code null}
+   *  if this map contains no mapping for the key.
+   *  <p>More formally, if this map contains a mapping from a key {@code k} to
+   *  a value {@code v} such that {@code key.equals(k)}, then this method
+   *  returns {@code v}; otherwise it returns {@code null}.  (There can be at
+   *  most one such mapping.)
+   * @throws NullPointerException if the specified key is null */
+  // Never returns a Prime nor a Tombstone.
+  @Override
+  public TypeV get( Object key ) {
+    final Object V = get_impl(this,_kvs,key);
+    assert !(V instanceof Prime); // Never return a Prime
+    assert V != TOMBSTONE;
+    return (TypeV)V;
+  }
+
+  private static final Object get_impl( final NonBlockingHashMap topmap, final Object[] kvs, final Object key ) {
+    final int fullhash= hash (key); // throws NullPointerException if key is null
+    final int len     = len  (kvs); // Count of key/value pairs, reads kvs.length
+    final CHM chm     = chm  (kvs); // The CHM, for a volatile read below; reads slot 0 of kvs
+    final int[] hashes=hashes(kvs); // The memoized hashes; reads slot 1 of kvs
+
+    int idx = fullhash & (len-1); // First key hash
+
+    // Main spin/reprobe loop, looking for a Key hit
+    int reprobe_cnt=0;
+    while( true ) {
+      // Probe table.  Each read of 'val' probably misses in cache in a big
+      // table; hopefully the read of 'key' then hits in cache.
+      final Object K = key(kvs,idx); // Get key   before volatile read, could be null
+      final Object V = val(kvs,idx); // Get value before volatile read, could be null or Tombstone or Prime
+      if( K == null ) return null;   // A clear miss
+
+      // We need a volatile-read here to preserve happens-before semantics on
+      // newly inserted Keys.  If the Key body was written just before inserting
+      // into the table a Key-compare here might read the uninitialized Key body.
+      // Annoyingly this means we have to volatile-read before EACH key compare.
+      // .
+      // We also need a volatile-read between reading a newly inserted Value
+      // and returning the Value (so the user might end up reading the stale
+      // Value contents).  Same problem as with keys - and the one volatile
+      // read covers both.
+      final Object[] newkvs = chm._newkvs; // VOLATILE READ before key compare
+
+      // Key-compare
+      if( keyeq(K,key,hashes,idx,fullhash) ) {
+        // Key hit!  Check for no table-copy-in-progress
+        if( !(V instanceof Prime) ) // No copy?
+          return (V == TOMBSTONE) ? null : V; // Return the value
+        // Key hit - but slot is (possibly partially) copied to the new table.
+        // Finish the copy & retry in the new table.
+        return get_impl(topmap,chm.copy_slot_and_check(topmap,kvs,idx,key),key); // Retry in the new table
+      }
+      // get and put must have the same key lookup logic!  But only 'put'
+      // needs to force a table-resize for a too-long key-reprobe sequence.
+      // Check for too-many-reprobes on get - and flip to the new table.
+      if( ++reprobe_cnt >= reprobe_limit(len) || // too many probes
+          K == TOMBSTONE ) // found a TOMBSTONE key, means no more keys in this table
+        return newkvs == null ? null : get_impl(topmap,topmap.help_copy(newkvs),key); // Retry in the new table
+
+      idx = (idx+1)&(len-1);    // Reprobe by 1!  (could now prefetch)
+    }
+  }
+
+  // --- getk -----------------------------------------------------------------
+  /** Returns the Key to which the specified key is mapped, or {@code null}
+   *  if this map contains no mapping for the key.
+   * @throws NullPointerException if the specified key is null */
+  // Never returns a Prime nor a Tombstone.
+  public TypeK getk( TypeK key ) {
+    return (TypeK)getk_impl(this,_kvs,key);
+  }
+
+  private static final Object getk_impl( final NonBlockingHashMap topmap, final Object[] kvs, final Object key ) {
+    final int fullhash= hash (key); // throws NullPointerException if key is null
+    final int len     = len  (kvs); // Count of key/value pairs, reads kvs.length
+    final CHM chm     = chm  (kvs); // The CHM, for a volatile read below; reads slot 0 of kvs
+    final int[] hashes=hashes(kvs); // The memoized hashes; reads slot 1 of kvs
+
+    int idx = fullhash & (len-1); // First key hash
+
+    // Main spin/reprobe loop, looking for a Key hit
+    int reprobe_cnt=0;
+    while( true ) {
+      // Probe table.
+      final Object K = key(kvs,idx); // Get key before volatile read, could be null
+      if( K == null ) return null;   // A clear miss
+
+      // We need a volatile-read here to preserve happens-before semantics on
+      // newly inserted Keys.  If the Key body was written just before inserting
+      // into the table a Key-compare here might read the uninitialized Key body.
+      // Annoyingly this means we have to volatile-read before EACH key compare.
+      // .
+      // We also need a volatile-read between reading a newly inserted Value
+      // and returning the Value (so the user might end up reading the stale
+      // Value contents).  Same problem as with keys - and the one volatile
+      // read covers both.
+      final Object[] newkvs = chm._newkvs; // VOLATILE READ before key compare
+
+      // Key-compare
+      if( keyeq(K,key,hashes,idx,fullhash) )
+        return K;              // Return existing Key!
+
+      // get and put must have the same key lookup logic!  But only 'put'
+      // needs to force a table-resize for a too-long key-reprobe sequence.
+      // Check for too-many-reprobes on get - and flip to the new table.
+      if( ++reprobe_cnt >= reprobe_limit(len) || // too many probes
+          K == TOMBSTONE ) { // found a TOMBSTONE key, means no more keys in this table
+        return newkvs == null ? null : getk_impl(topmap,topmap.help_copy(newkvs),key); // Retry in the new table
+      }
+
+      idx = (idx+1)&(len-1);    // Reprobe by 1!  (could now prefetch)
+    }
+  }
+
+  static volatile int DUMMY_VOLATILE;
+  /**
+   * Put, Remove, PutIfAbsent, etc.  Return the old value.  If the returned value is equal to expVal (or expVal is
+   * {@link #NO_MATCH_OLD}) then the put can be assumed to work (although might have been immediately overwritten).
+   * Only the path through copy_slot passes in an expected value of null, and putIfMatch only returns a null if passed
+   * in an expected null.
+   *
+   * @param topmap the map to act on
+   * @param kvs the KV table snapshot we act on
+   * @param key not null (will result in {@link NullPointerException})
+   * @param putval the new value to use. Not null. {@link #TOMBSTONE} will result in deleting the entry.
+   * @param expVal expected old value. Can be null. {@link #NO_MATCH_OLD} for an unconditional put/remove.
+   *              {@link #TOMBSTONE} if we expect old entry to not exist(null/{@link #TOMBSTONE} value).
+   *              {@link #MATCH_ANY} will ignore the current value, but only if an entry exists. A null expVal is used
+   *               internally to perform a strict insert-if-never-been-seen-before operation.
+   * @return {@link #TOMBSTONE} if key does not exist or match has failed. null if expVal is
+   * null AND old value was null. Otherwise the old entry value (not null).
+   */
+  private static final Object putIfMatch0(
+      final NonBlockingHashMap topmap,
+      final Object[] kvs,
+      final Object key,
+      final Object putval,
+      final Object expVal)
+  {
+    assert putval != null;
+    assert !(putval instanceof Prime);
+    assert !(expVal instanceof Prime);
+    final int fullhash = hash  (key); // throws NullPointerException if key null
+    final int len      = len   (kvs); // Count of key/value pairs, reads kvs.length
+    final CHM chm      = chm   (kvs); // Reads kvs[0]
+    final int[] hashes = hashes(kvs); // Reads kvs[1], read before kvs[0]
+    int idx = fullhash & (len-1);
+
+    // ---
+    // Key-Claim stanza: spin till we can claim a Key (or force a resizing).
+    int reprobe_cnt=0;
+    Object K=null, V=null;
+    Object[] newkvs=null;
+    while( true ) {             // Spin till we get a Key slot
+      V = val(kvs,idx);         // Get old value (before volatile read below!)
+      K = key(kvs,idx);         // Get current key
+      if( K == null ) {         // Slot is free?
+        // Found an empty Key slot - which means this Key has never been in
+        // this table.  No need to put a Tombstone - the Key is not here!
+        if( putval == TOMBSTONE ) return TOMBSTONE; // Not-now & never-been in this table
+        if( expVal == MATCH_ANY ) return TOMBSTONE; // Will not match, even after K inserts
+        // Claim the null key-slot
+        if( CAS_key(kvs,idx, null, key ) ) { // Claim slot for Key
+          chm._slots.add(1);      // Raise key-slots-used count
+          hashes[idx] = fullhash; // Memoize fullhash
+          break;                  // Got it!
+        }
+        // CAS to claim the key-slot failed.
+        //
+        // This re-read of the Key points out an annoying short-coming of Java
+        // CAS.  Most hardware CAS's report back the existing value - so that
+        // if you fail you have a *witness* - the value which caused the CAS to
+        // fail.  The Java API turns this into a boolean destroying the
+        // witness.  Re-reading does not recover the witness because another
+        // thread can write over the memory after the CAS.  Hence we can be in
+        // the unfortunate situation of having a CAS fail *for cause* but
+        // having that cause removed by a later store.  This turns a
+        // non-spurious-failure CAS (such as Azul has) into one that can
+        // apparently spuriously fail - and we avoid apparent spurious failure
+        // by not allowing Keys to ever change.
+
+        // Volatile read, to force loads of K to retry despite JIT, otherwise
+        // it is legal to e.g. haul the load of "K = key(kvs,idx);" outside of
+        // this loop (since failed CAS ops have no memory ordering semantics).
+        int dummy = DUMMY_VOLATILE;
+        continue;
+      }
+      // Key slot was not null, there exists a Key here
+
+      // We need a volatile-read here to preserve happens-before semantics on
+      // newly inserted Keys.  If the Key body was written just before inserting
+      // into the table a Key-compare here might read the uninitialized Key body.
+      // Annoyingly this means we have to volatile-read before EACH key compare.
+      newkvs = chm._newkvs;     // VOLATILE READ before key compare
+
+      if( keyeq(K,key,hashes,idx,fullhash) )
+        break;                  // Got it!
+
+      // get and put must have the same key lookup logic!  Lest 'get' give
+      // up looking too soon.
+      //topmap._reprobes.add(1);
+      if( ++reprobe_cnt >= reprobe_limit(len) || // too many probes or
+          K == TOMBSTONE ) { // found a TOMBSTONE key, means no more keys
+        // We simply must have a new table to do a 'put'.  At this point a
+        // 'get' will also go to the new table (if any).  We do not need
+        // to claim a key slot (indeed, we cannot find a free one to claim!).
+        newkvs = chm.resize(topmap,kvs);
+        if( expVal != null ) topmap.help_copy(newkvs); // help along an existing copy
+        return putIfMatch0(topmap, newkvs, key, putval, expVal);
+      }
+
+      idx = (idx+1)&(len-1); // Reprobe!
+    } // End of spinning till we get a Key slot
+
+    while ( true ) {              // Spin till we insert a value
+      // ---
+      // Found the proper Key slot, now update the matching Value slot.  We
+      // never put a null, so Value slots monotonically move from null to
+      // not-null (deleted Values use Tombstone).  Thus if 'V' is null we
+      // fail this fast cutout and fall into the check for table-full.
+      if( putval == V ) return V; // Fast cutout for no-change
+
+      // See if we want to move to a new table (to avoid high average re-probe
+      // counts).  We only check on the initial set of a Value from null to
+      // not-null (i.e., once per key-insert).  Of course we got a 'free' check
+      // of newkvs once per key-compare (not really free, but paid-for by the
+      // time we get here).
+      if( newkvs == null &&       // New table-copy already spotted?
+          // Once per fresh key-insert check the hard way
+          ((V == null && chm.tableFull(reprobe_cnt,len)) ||
+           // Or we found a Prime, but the JMM allowed reordering such that we
+           // did not spot the new table (very rare race here: the writing
+           // thread did a CAS of _newkvs then a store of a Prime.  This thread
+           // reads the Prime, then reads _newkvs - but the read of Prime was so
+           // delayed (or the read of _newkvs was so accelerated) that they
+           // swapped and we still read a null _newkvs.  The resize call below
+           // will do a CAS on _newkvs forcing the read.
+           V instanceof Prime) ) {
+        newkvs = chm.resize(topmap, kvs); // Force the new table copy to start
+      }
+      // See if we are moving to a new table.
+      // If so, copy our slot and retry in the new table.
+      if( newkvs != null ) {
+        return putIfMatch0(topmap, chm.copy_slot_and_check(topmap, kvs, idx, expVal), key, putval, expVal);
+      }
+      // ---
+      // We are finally prepared to update the existing table
+      assert !(V instanceof Prime);
+
+      // Must match old, and we do not?  Then bail out now.  Note that either V
+      // or expVal might be TOMBSTONE.  Also V can be null, if we've never
+      // inserted a value before.  expVal can be null if we are called from
+      // copy_slot.
+      if( expVal != NO_MATCH_OLD && // Do we care about expected-Value at all?
+          V != expVal &&            // No instant match already?
+          (expVal != MATCH_ANY || V == TOMBSTONE || V == null) &&
+          !(V==null && expVal == TOMBSTONE) &&    // Match on null/TOMBSTONE combo
+          (expVal == null || !expVal.equals(V)) ) { // Expensive equals check at the last
+        return (V == null) ? TOMBSTONE : V;         // Do not update!
+      }
+
+      // Actually change the Value in the Key,Value pair
+      if( CAS_val(kvs, idx, V, putval ) ) break;
+
+      // CAS failed
+      // Because we have no witness, we do not know why it failed.
+      // Indeed, by the time we look again the value under test might have flipped
+      // a thousand times and now be the expected value (despite the CAS failing).
+      // Check for the never-succeed condition of a Prime value and jump to any
+      // nested table, or else just re-run.
+
+      // We would not need this load at all if CAS returned the value on which
+      // the CAS failed (AKA witness). The new CAS semantics are supported via
+      // VarHandle in JDK9.
+      V = val(kvs,idx);         // Get new value
+
+      // If a Prime'd value got installed, we need to re-run the put on the
+      // new table.  Otherwise we lost the CAS to another racing put.
+      if( V instanceof Prime )
+        return putIfMatch0(topmap, chm.copy_slot_and_check(topmap, kvs, idx, expVal), key, putval, expVal);
+
+      // Simply retry from the start.
+      // NOTE: need the fence, since otherwise 'val(kvs,idx)' load could be hoisted
+      // out of loop.
+      int dummy = DUMMY_VOLATILE;
+    }
+
+    // CAS succeeded - we did the update!
+    // Both normal put's and table-copy calls putIfMatch, but table-copy
+    // does not (effectively) increase the number of live k/v pairs.
+    if( expVal != null ) {
+      // Adjust sizes - a striped counter
+      if(  (V == null || V == TOMBSTONE) && putval != TOMBSTONE ) chm._size.add( 1);
+      if( !(V == null || V == TOMBSTONE) && putval == TOMBSTONE ) chm._size.add(-1);
+    }
+
+    // We won; we know the update happened as expected.
+    return (V==null && expVal!=null) ? TOMBSTONE : V;
+  }
+
+  // --- help_copy ---------------------------------------------------------
+  // Help along an existing resize operation.  This is just a fast cut-out
+  // wrapper, to encourage inlining for the fast no-copy-in-progress case.  We
+  // always help the top-most table copy, even if there are nested table
+  // copies in progress.
+  private final Object[] help_copy( Object[] helper ) {
+    // Read the top-level KVS only once.  We'll try to help this copy along,
+    // even if it gets promoted out from under us (i.e., the copy completes
+    // and another KVS becomes the top-level copy).
+    Object[] topkvs = _kvs;
+    CHM topchm = chm(topkvs);
+    if( topchm._newkvs == null ) return helper; // No copy in-progress
+    topchm.help_copy_impl(this,topkvs,false);
+    return helper;
+  }
+
+
+  // --- CHM -----------------------------------------------------------------
+  // The control structure for the NonBlockingHashMap
+  private static final class CHM<TypeK,TypeV> {
+    // Size in active K,V pairs
+    private final ConcurrentAutoTable _size;
+    public int size () { return (int)_size.get(); }
+
+    // ---
+    // These next 2 fields are used in the resizing heuristics, to judge when
+    // it is time to resize or copy the table.  Slots is a count of used-up
+    // key slots, and when it nears a large fraction of the table we probably
+    // end up reprobing too much.  Last-resize-milli is the time since the
+    // last resize; if we are running back-to-back resizes without growing
+    // (because there are only a few live keys but many slots full of dead
+    // keys) then we need a larger table to cut down on the churn.
+
+    // Count of used slots, to tell when table is full of dead unusable slots
+    private final ConcurrentAutoTable _slots;
+    public int slots() { return (int)_slots.get(); }
+
+    // ---
+    // New mappings, used during resizing.
+    // The 'new KVs' array - created during a resize operation.  This
+    // represents the new table being copied from the old one.  It's the
+    // volatile variable that is read as we cross from one table to the next,
+    // to get the required memory orderings.  It monotonically transits from
+    // null to set (once).
+    volatile Object[] _newkvs;
+    private static final AtomicReferenceFieldUpdater<CHM,Object[]> _newkvsUpdater =
+      AtomicReferenceFieldUpdater.newUpdater(CHM.class,Object[].class, "_newkvs");
+    // Set the _next field if we can.
+    boolean CAS_newkvs( Object[] newkvs ) {
+      while( _newkvs == null )
+        if( _newkvsUpdater.compareAndSet(this,null,newkvs) )
+          return true;
+      return false;
+    }
+
+    // Sometimes many threads race to create a new very large table.  Only 1
+    // wins the race, but the losers all allocate a junk large table with
+    // hefty allocation costs.  Attempt to control the overkill here by
+    // throttling attempts to create a new table.  I cannot really block here
+    // (lest I lose the non-blocking property) but late-arriving threads can
+    // give the initial resizing thread a little time to allocate the initial
+    // new table.  The Right Long Term Fix here is to use array-lets and
+    // incrementally create the new very large array.  In C I'd make the array
+    // with malloc (which would mmap under the hood) which would only eat
+    // virtual-address and not real memory - and after Somebody wins then we
+    // could in parallel initialize the array.  Java does not allow
+    // un-initialized array creation (especially of ref arrays!).
+    volatile long _resizers; // count of threads attempting an initial resize
+    private static final AtomicLongFieldUpdater<CHM> _resizerUpdater =
+      AtomicLongFieldUpdater.newUpdater(CHM.class, "_resizers");
+
+    // ---
+    // Simple constructor
+    CHM( ConcurrentAutoTable size ) {
+      _size = size;
+      _slots= new ConcurrentAutoTable();
+    }
+
+    // --- tableFull ---------------------------------------------------------
+    // Heuristic to decide if this table is too full, and we should start a
+    // new table.  Note that if a 'get' call has reprobed too many times and
+    // decided the table must be full, then always the estimate_sum must be
+    // high and we must report the table is full.  If we do not, then we might
+    // end up deciding that the table is not full and inserting into the
+    // current table, while a 'get' has decided the same key cannot be in this
+    // table because of too many reprobes.  The invariant is:
+    //   slots.estimate_sum >= max_reprobe_cnt >= reprobe_limit(len)
+    private final boolean tableFull( int reprobe_cnt, int len ) {
+      return
+        // Do the cheap check first: we allow some number of reprobes always
+        reprobe_cnt >= REPROBE_LIMIT &&
+        (reprobe_cnt >= reprobe_limit(len) ||
+         // More expensive check: see if the table is > 1/2 full.
+         _slots.estimate_get() >= (len>>1));
+    }
+
+    // --- resize ------------------------------------------------------------
+    // Resizing after too many probes.  "How Big???" heuristics are here.
+    // Callers will (not this routine) will 'help_copy' any in-progress copy.
+    // Since this routine has a fast cutout for copy-already-started, callers
+    // MUST 'help_copy' lest we have a path which forever runs through
+    // 'resize' only to discover a copy-in-progress which never progresses.
+    private final Object[] resize( NonBlockingHashMap topmap, Object[] kvs) {
+      assert chm(kvs) == this;
+
+      // Check for resize already in progress, probably triggered by another thread
+      Object[] newkvs = _newkvs; // VOLATILE READ
+      if( newkvs != null )       // See if resize is already in progress
+        return newkvs;           // Use the new table already
+
+      // No copy in-progress, so start one.  First up: compute new table size.
+      int oldlen = len(kvs);    // Old count of K,V pairs allowed
+      int sz = size();          // Get current table count of active K,V pairs
+      int newsz = sz;           // First size estimate
+
+      // Heuristic to determine new size.  We expect plenty of dead-slots-with-keys
+      // and we need some decent padding to avoid endless reprobing.
+      if( sz >= (oldlen>>2) ) { // If we are >25% full of keys then...
+        newsz = oldlen<<1;      // Double size, so new table will be between 12.5% and 25% full
+        // For tables less than 1M entries, if >50% full of keys then...
+        // For tables more than 1M entries, if >75% full of keys then...
+        if( 4L*sz >= ((oldlen>>20)!=0?3L:2L)*oldlen )
+          newsz = oldlen<<2;    // Double double size, so new table will be between %12.5 (18.75%) and 25% (25%)
+      }
+      // This heuristic in the next 2 lines leads to a much denser table
+      // with a higher reprobe rate
+      //if( sz >= (oldlen>>1) ) // If we are >50% full of keys then...
+      //  newsz = oldlen<<1;    // Double size
+
+      // Last (re)size operation was very recent?  Then double again
+      // despite having few live keys; slows down resize operations
+      // for tables subject to a high key churn rate - but do not
+      // forever grow the table.  If there is a high key churn rate
+      // the table needs a steady state of rare same-size resize
+      // operations to clean out the dead keys.
+      long tm = System.currentTimeMillis();
+      if( newsz <= oldlen && // New table would shrink or hold steady?
+          tm <= topmap._last_resize_milli+10000)  // Recent resize (less than 10 sec ago)
+        newsz = oldlen<<1;      // Double the existing size
+
+      // Do not shrink, ever.  If we hit this size once, assume we
+      // will again.
+      if( newsz < oldlen ) newsz = oldlen;
+
+      // Convert to power-of-2
+      int log2;
+      for( log2=MIN_SIZE_LOG; (1<<log2) < newsz; log2++ ) ; // Compute log2 of size
+      long len = ((1L << log2) << 1) + 2;
+      // prevent integer overflow - limit of 2^31 elements in a Java array
+      // so here, 2^30 + 2 is the largest number of elements in the hash table
+      if ((int)len!=len) {
+        log2 = 30;
+        len = (1L << log2) + 2;
+        if (sz > ((len >> 2) + (len >> 1))) throw new RuntimeException("Table is full.");
+      }
+
+      // Now limit the number of threads actually allocating memory to a
+      // handful - lest we have 750 threads all trying to allocate a giant
+      // resized array.
+      long r = _resizers;
+      while( !_resizerUpdater.compareAndSet(this,r,r+1) )
+        r = _resizers;
+      // Size calculation: 2 words (K+V) per table entry, plus a handful.  We
+      // guess at 64-bit pointers; 32-bit pointers screws up the size calc by
+      // 2x but does not screw up the heuristic very much.
+      long megs = ((((1L<<log2)<<1)+8)<<3/*word to bytes*/)>>20/*megs*/;
+      if( r >= 2 && megs > 0 ) { // Already 2 guys trying; wait and see
+        newkvs = _newkvs;        // Between dorking around, another thread did it
+        if( newkvs != null )     // See if resize is already in progress
+          return newkvs;         // Use the new table already
+        // TODO - use a wait with timeout, so we'll wakeup as soon as the new table
+        // is ready, or after the timeout in any case.
+        //synchronized( this ) { wait(8*megs); }         // Timeout - we always wakeup
+        // For now, sleep a tad and see if the 2 guys already trying to make
+        // the table actually get around to making it happen.
+        try { Thread.sleep(megs); } catch( Exception e ) { }
+      }
+      // Last check, since the 'new' below is expensive and there is a chance
+      // that another thread slipped in a new thread while we ran the heuristic.
+      newkvs = _newkvs;
+      if( newkvs != null )      // See if resize is already in progress
+        return newkvs;          // Use the new table already
+
+      // Double size for K,V pairs, add 1 for CHM
+      newkvs = new Object[(int)len]; // This can get expensive for big arrays
+      newkvs[0] = new CHM(_size); // CHM in slot 0
+      newkvs[1] = new int[1<<log2]; // hashes in slot 1
+
+      // Another check after the slow allocation
+      if( _newkvs != null )     // See if resize is already in progress
+        return _newkvs;         // Use the new table already
+
+      // The new table must be CAS'd in so only 1 winner amongst duplicate
+      // racing resizing threads.  Extra CHM's will be GC'd.
+      if( CAS_newkvs( newkvs ) ) { // NOW a resize-is-in-progress!
+        //notifyAll();            // Wake up any sleepers
+        //long nano = System.nanoTime();
+        //System.out.println(" "+nano+" Resize from "+oldlen+" to "+(1<<log2)+" and had "+(_resizers-1)+" extras" );
+        //if( System.out != null ) System.out.print("["+log2);
+        topmap.rehash();        // Call for Hashtable's benefit
+      } else                    // CAS failed?
+        newkvs = _newkvs;       // Reread new table
+      return newkvs;
+    }
+
+
+    // The next part of the table to copy.  It monotonically transits from zero
+    // to _kvs.length.  Visitors to the table can claim 'work chunks' by
+    // CAS'ing this field up, then copying the indicated indices from the old
+    // table to the new table.  Workers are not required to finish any chunk;
+    // the counter simply wraps and work is copied duplicately until somebody
+    // somewhere completes the count.
+    volatile long _copyIdx = 0;
+    static private final AtomicLongFieldUpdater<CHM> _copyIdxUpdater =
+      AtomicLongFieldUpdater.newUpdater(CHM.class, "_copyIdx");
+
+    // Work-done reporting.  Used to efficiently signal when we can move to
+    // the new table.  From 0 to len(oldkvs) refers to copying from the old
+    // table to the new.
+    volatile long _copyDone= 0;
+    static private final AtomicLongFieldUpdater<CHM> _copyDoneUpdater =
+      AtomicLongFieldUpdater.newUpdater(CHM.class, "_copyDone");
+
+    // --- help_copy_impl ----------------------------------------------------
+    // Help along an existing resize operation.  We hope its the top-level
+    // copy (it was when we started) but this CHM might have been promoted out
+    // of the top position.
+    private final void help_copy_impl( NonBlockingHashMap topmap, Object[] oldkvs, boolean copy_all ) {
+      assert chm(oldkvs) == this;
+      Object[] newkvs = _newkvs;
+      assert newkvs != null;    // Already checked by caller
+      int oldlen = len(oldkvs); // Total amount to copy
+      final int MIN_COPY_WORK = Math.min(oldlen,1024); // Limit per-thread work
+
+      // ---
+      int panic_start = -1;
+      int copyidx=-9999;            // Fool javac to think it's initialized
+      while( _copyDone < oldlen ) { // Still needing to copy?
+        // Carve out a chunk of work.  The counter wraps around so every
+        // thread eventually tries to copy every slot repeatedly.
+
+        // We "panic" if we have tried TWICE to copy every slot - and it still
+        // has not happened.  i.e., twice some thread somewhere claimed they
+        // would copy 'slot X' (by bumping _copyIdx) but they never claimed to
+        // have finished (by bumping _copyDone).  Our choices become limited:
+        // we can wait for the work-claimers to finish (and become a blocking
+        // algorithm) or do the copy work ourselves.  Tiny tables with huge
+        // thread counts trying to copy the table often 'panic'.
+        if( panic_start == -1 ) { // No panic?
+          copyidx = (int)_copyIdx;
+          while( !_copyIdxUpdater.compareAndSet(this,copyidx,copyidx+MIN_COPY_WORK) )
+            copyidx = (int)_copyIdx;      // Re-read
+          if( !(copyidx < (oldlen<<1)) )  // Panic!
+            panic_start = copyidx;        // Record where we started to panic-copy
+        }
+
+        // We now know what to copy.  Try to copy.
+        int workdone = 0;
+        for( int i=0; i<MIN_COPY_WORK; i++ )
+          if( copy_slot(topmap,(copyidx+i)&(oldlen-1),oldkvs,newkvs) ) // Made an oldtable slot go dead?
+            workdone++;         // Yes!
+        if( workdone > 0 )      // Report work-done occasionally
+          copy_check_and_promote( topmap, oldkvs, workdone );// See if we can promote
+        //for( int i=0; i<MIN_COPY_WORK; i++ )
+        //  if( copy_slot(topmap,(copyidx+i)&(oldlen-1),oldkvs,newkvs) ) // Made an oldtable slot go dead?
+        //    copy_check_and_promote( topmap, oldkvs, 1 );// See if we can promote
+
+        copyidx += MIN_COPY_WORK;
+        // Uncomment these next 2 lines to turn on incremental table-copy.
+        // Otherwise this thread continues to copy until it is all done.
+        if( !copy_all && panic_start == -1 ) // No panic?
+          return;       // Then done copying after doing MIN_COPY_WORK
+      }
+      // Extra promotion check, in case another thread finished all copying
+      // then got stalled before promoting.
+      copy_check_and_promote( topmap, oldkvs, 0 );// See if we can promote
+    }
+
+
+    // --- copy_slot_and_check -----------------------------------------------
+    // Copy slot 'idx' from the old table to the new table.  If this thread
+    // confirmed the copy, update the counters and check for promotion.
+    //
+    // Returns the result of reading the volatile _newkvs, mostly as a
+    // convenience to callers.  We come here with 1-shot copy requests
+    // typically because the caller has found a Prime, and has not yet read
+    // the _newkvs volatile - which must have changed from null-to-not-null
+    // before any Prime appears.  So the caller needs to read the _newkvs
+    // field to retry his operation in the new table, but probably has not
+    // read it yet.
+    private final Object[] copy_slot_and_check( NonBlockingHashMap topmap, Object[] oldkvs, int idx, Object should_help ) {
+      assert chm(oldkvs) == this;
+      Object[] newkvs = _newkvs; // VOLATILE READ
+      // We're only here because the caller saw a Prime, which implies a
+      // table-copy is in progress.
+      assert newkvs != null;
+      if( copy_slot(topmap,idx,oldkvs,_newkvs) )   // Copy the desired slot
+        copy_check_and_promote(topmap, oldkvs, 1); // Record the slot copied
+      // Generically help along any copy (except if called recursively from a helper)
+      return (should_help == null) ? newkvs : topmap.help_copy(newkvs);
+    }
+
+    // --- copy_check_and_promote --------------------------------------------
+    private final void copy_check_and_promote( NonBlockingHashMap topmap, Object[] oldkvs, int workdone ) {
+      assert chm(oldkvs) == this;
+      int oldlen = len(oldkvs);
+      // We made a slot unusable and so did some of the needed copy work
+      long copyDone = _copyDone;
+      assert (copyDone+workdone) <= oldlen;
+      if( workdone > 0 ) {
+        while( !_copyDoneUpdater.compareAndSet(this,copyDone,copyDone+workdone) ) {
+          copyDone = _copyDone; // Reload, retry
+          assert (copyDone+workdone) <= oldlen;
+        }
+      }
+
+      // Check for copy being ALL done, and promote.  Note that we might have
+      // nested in-progress copies and manage to finish a nested copy before
+      // finishing the top-level copy.  We only promote top-level copies.
+      if( copyDone+workdone == oldlen && // Ready to promote this table?
+          topmap._kvs == oldkvs &&       // Looking at the top-level table?
+          // Attempt to promote
+          topmap.CAS_kvs(oldkvs,_newkvs) ) {
+        topmap._last_resize_milli = System.currentTimeMillis(); // Record resize time for next check
+      }
+    }
+
+    // --- copy_slot ---------------------------------------------------------
+    // Copy one K/V pair from oldkvs[i] to newkvs.  Returns true if we can
+    // confirm that we set an old-table slot to TOMBPRIME, and only returns after
+    // updating the new table.  We need an accurate confirmed-copy count so
+    // that we know when we can promote (if we promote the new table too soon,
+    // other threads may 'miss' on values not-yet-copied from the old table).
+    // We don't allow any direct updates on the new table, unless they first
+    // happened to the old table - so that any transition in the new table from
+    // null to not-null must have been from a copy_slot (or other old-table
+    // overwrite) and not from a thread directly writing in the new table.
+    private boolean copy_slot( NonBlockingHashMap topmap, int idx, Object[] oldkvs, Object[] newkvs ) {
+      // Blindly set the key slot from null to TOMBSTONE, to eagerly stop
+      // fresh put's from inserting new values in the old table when the old
+      // table is mid-resize.  We don't need to act on the results here,
+      // because our correctness stems from box'ing the Value field.  Slamming
+      // the Key field is a minor speed optimization.
+      Object key;
+      while( (key=key(oldkvs,idx)) == null )
+        CAS_key(oldkvs,idx, null, TOMBSTONE);
+
+      // ---
+      // Prevent new values from appearing in the old table.
+      // Box what we see in the old table, to prevent further updates.
+      Object oldval = val(oldkvs,idx); // Read OLD table
+      while( !(oldval instanceof Prime) ) {
+        final Prime box = (oldval == null || oldval == TOMBSTONE) ? TOMBPRIME : new Prime(oldval);
+        if( CAS_val(oldkvs,idx,oldval,box) ) { // CAS down a box'd version of oldval
+          // If we made the Value slot hold a TOMBPRIME, then we both
+          // prevented further updates here but also the (absent)
+          // oldval is vacuously available in the new table.  We
+          // return with true here: any thread looking for a value for
+          // this key can correctly go straight to the new table and
+          // skip looking in the old table.
+          if( box == TOMBPRIME )
+            return true;
+          // Otherwise we boxed something, but it still needs to be
+          // copied into the new table.
+          oldval = box;         // Record updated oldval
+          break;                // Break loop; oldval is now boxed by us
+        }
+        oldval = val(oldkvs,idx); // Else try, try again
+      }
+      if( oldval == TOMBPRIME ) return false; // Copy already complete here!
+
+      // ---
+      // Copy the value into the new table, but only if we overwrite a null.
+      // If another value is already in the new table, then somebody else
+      // wrote something there and that write is happens-after any value that
+      // appears in the old table.
+      Object old_unboxed = ((Prime)oldval)._V;
+      assert old_unboxed != TOMBSTONE;
+      putIfMatch0(topmap, newkvs, key, old_unboxed, null);
+
+      // ---
+      // Finally, now that any old value is exposed in the new table, we can
+      // forever hide the old-table value by slapping a TOMBPRIME down.  This
+      // will stop other threads from uselessly attempting to copy this slot
+      // (i.e., it's a speed optimization not a correctness issue).
+      while( oldval != TOMBPRIME && !CAS_val(oldkvs,idx,oldval,TOMBPRIME) )
+        oldval = val(oldkvs,idx);
+
+      return oldval != TOMBPRIME; // True if we slammed the TOMBPRIME down
+    } // end copy_slot
+  } // End of CHM
+
+
+  // --- Snapshot ------------------------------------------------------------
+  // The main class for iterating over the NBHM.  It "snapshots" a clean
+  // view of the K/V array.
+  private class SnapshotV implements Iterator<TypeV>, Enumeration<TypeV> {
+    final Object[] _sskvs;
+    public SnapshotV() {
+      while( true ) {           // Verify no table-copy-in-progress
+        Object[] topkvs = _kvs;
+        CHM topchm = chm(topkvs);
+        if( topchm._newkvs == null ) { // No table-copy-in-progress
+          // The "linearization point" for the iteration.  Every key in this
+          // table will be visited, but keys added later might be skipped or
+          // even be added to a following table (also not iterated over).
+          _sskvs = topkvs;
+          break;
+        }
+        // Table copy in-progress - so we cannot get a clean iteration.  We
+        // must help finish the table copy before we can start iterating.
+        topchm.help_copy_impl(NonBlockingHashMap.this,topkvs,true);
+      }
+      // Warm-up the iterator
+      next();
+    }
+    int length() { return len(_sskvs); }
+    Object key(int idx) { return NonBlockingHashMap.key(_sskvs,idx); }
+    private int _idx;              // Varies from 0-keys.length
+    private Object _nextK, _prevK; // Last 2 keys found
+    private TypeV  _nextV, _prevV; // Last 2 values found
+    public boolean hasNext() { return _nextV != null; }
+    public TypeV next() {
+      // 'next' actually knows what the next value will be - it had to
+      // figure that out last go-around lest 'hasNext' report true and
+      // some other thread deleted the last value.  Instead, 'next'
+      // spends all its effort finding the key that comes after the
+      // 'next' key.
+      if( _idx != 0 && _nextV == null ) throw new NoSuchElementException();
+      _prevK = _nextK;          // This will become the previous key
+      _prevV = _nextV;          // This will become the previous value
+      _nextV = null;            // We have no more next-key
+      // Attempt to set <_nextK,_nextV> to the next K,V pair.
+      // _nextV is the trigger: stop searching when it is != null
+      while( _idx<length() ) {  // Scan array
+        _nextK = key(_idx++); // Get a key that definitely is in the set (for the moment!)
+        if( _nextK != null && // Found something?
+            _nextK != TOMBSTONE &&
+            (_nextV=get(_nextK)) != null )
+          break;                // Got it!  _nextK is a valid Key
+      }                         // Else keep scanning
+      return _prevV;            // Return current value.
+    }
+
+    public void removeKey() {
+      if( _prevV == null ) throw new IllegalStateException();
+      NonBlockingHashMap.this.putIfMatch(_prevK, TOMBSTONE, NO_MATCH_OLD);
+      _prevV = null;
+    }
+
+    @Override
+    public void remove() {
+      // NOTE: it would seem logical that value removal will semantically mean removing the matching value for the
+      // mapping <k,v>, but the JDK always removes by key, even when the value has changed.
+      removeKey();
+    }
+
+    public TypeV nextElement() { return next(); }
+    public boolean hasMoreElements() { return hasNext(); }
+  }
+  public Object[] raw_array() { return new SnapshotV()._sskvs; }
+
+  /** Returns an enumeration of the values in this table.
+   *  @return an enumeration of the values in this table
+   *  @see #values()  */
+  public Enumeration<TypeV> elements() { return new SnapshotV(); }
+
+  // --- values --------------------------------------------------------------
+  /** Returns a {@link Collection} view of the values contained in this map.
+   *  The collection is backed by the map, so changes to the map are reflected
+   *  in the collection, and vice-versa.  The collection supports element
+   *  removal, which removes the corresponding mapping from this map, via the
+   *  <tt>Iterator.remove</tt>, <tt>Collection.remove</tt>,
+   *  <tt>removeAll</tt>, <tt>retainAll</tt>, and <tt>clear</tt> operations.
+   *  It does not support the <tt>add</tt> or <tt>addAll</tt> operations.
+   *
+   *  <p>The view's <tt>iterator</tt> is a "weakly consistent" iterator that
+   *  will never throw {@link ConcurrentModificationException}, and guarantees
+   *  to traverse elements as they existed upon construction of the iterator,
+   *  and may (but is not guaranteed to) reflect any modifications subsequent
+   *  to construction. */
+  @Override
+  public Collection<TypeV> values() {
+    return new AbstractCollection<TypeV>() {
+      @Override public void    clear   (          ) {        NonBlockingHashMap.this.clear        ( ); }
+      @Override public int     size    (          ) { return NonBlockingHashMap.this.size         ( ); }
+      @Override public boolean contains( Object v ) { return NonBlockingHashMap.this.containsValue(v); }
+      @Override public Iterator<TypeV> iterator()   { return new SnapshotV(); }
+    };
+  }
+
+  // --- keySet --------------------------------------------------------------
+  private class SnapshotK implements Iterator<TypeK>, Enumeration<TypeK> {
+    final SnapshotV _ss;
+    public SnapshotK() { _ss = new SnapshotV(); }
+    public void remove() { _ss.removeKey(); }
+    public TypeK next() { _ss.next(); return (TypeK)_ss._prevK; }
+    public boolean hasNext() { return _ss.hasNext(); }
+    public TypeK nextElement() { return next(); }
+    public boolean hasMoreElements() { return hasNext(); }
+  }
+
+  /** Returns an enumeration of the keys in this table.
+   *  @return an enumeration of the keys in this table
+   *  @see #keySet()  */
+  public Enumeration<TypeK> keys() { return new SnapshotK(); }
+
+  /** Returns a {@link Set} view of the keys contained in this map.  The set
+   *  is backed by the map, so changes to the map are reflected in the set,
+   *  and vice-versa.  The set supports element removal, which removes the
+   *  corresponding mapping from this map, via the <tt>Iterator.remove</tt>,
+   *  <tt>Set.remove</tt>, <tt>removeAll</tt>, <tt>retainAll</tt>, and
+   *  <tt>clear</tt> operations.  It does not support the <tt>add</tt> or
+   *  <tt>addAll</tt> operations.
+   *
+   *  <p>The view's <tt>iterator</tt> is a "weakly consistent" iterator that
+   *  will never throw {@link ConcurrentModificationException}, and guarantees
+   *  to traverse elements as they existed upon construction of the iterator,
+   *  and may (but is not guaranteed to) reflect any modifications subsequent
+   *  to construction.  */
+  @Override
+  public Set<TypeK> keySet() {
+    return new AbstractSet<TypeK> () {
+      @Override public void    clear   (          ) {        NonBlockingHashMap.this.clear   ( ); }
+      @Override public int     size    (          ) { return NonBlockingHashMap.this.size    ( ); }
+      @Override public boolean contains( Object k ) { return NonBlockingHashMap.this.containsKey(k); }
+      @Override public boolean remove  ( Object k ) { return NonBlockingHashMap.this.remove  (k) != null; }
+      @Override public Iterator<TypeK> iterator()   { return new SnapshotK(); }
+      // This is an efficient implementation of toArray instead of the standard
+      // one.  In particular it uses a smart iteration over the NBHM.
+      @Override public <T> T[] toArray(T[] a) {
+        Object[] kvs = raw_array();
+        // Estimate size of array; be prepared to see more or fewer elements
+        int sz = size();
+        T[] r = a.length >= sz ? a :
+          (T[])java.lang.reflect.Array.newInstance(a.getClass().getComponentType(), sz);
+        // Fast efficient element walk.
+        int j=0;
+        for( int i=0; i<len(kvs); i++ ) {
+          Object K = key(kvs,i);
+          Object V = Prime.unbox(val(kvs,i));
+          if( K != null && K != TOMBSTONE && V != null && V != TOMBSTONE ) {
+            if( j >= r.length ) {
+              int sz2 = (int)Math.min(Integer.MAX_VALUE-8,((long)j)<<1);
+              if( sz2<=r.length ) throw new OutOfMemoryError("Required array size too large");
+              r = Arrays.copyOf(r,sz2);
+            }
+            r[j++] = (T)K;
+          }
+        }
+        if( j <= a.length ) {   // Fit in the original array?
+          if( a!=r ) System.arraycopy(r,0,a,0,j);
+          if( j<a.length ) r[j++]=null; // One final null not in the spec but in the default impl
+          return a;             // Return the original
+        }
+        return Arrays.copyOf(r,j);
+      }
+    };
+  }
+
+
+  // --- entrySet ------------------------------------------------------------
+  // Warning: Each call to 'next' in this iterator constructs a new NBHMEntry.
+  private class NBHMEntry extends AbstractEntry<TypeK,TypeV> {
+    NBHMEntry( final TypeK k, final TypeV v ) { super(k,v); }
+    public TypeV setValue(final TypeV val) {
+      if( val == null ) throw new NullPointerException();
+      _val = val;
+      return put(_key, val);
+    }
+  }
+
+  private class SnapshotE implements Iterator<Map.Entry<TypeK,TypeV>> {
+    final SnapshotV _ss;
+    public SnapshotE() { _ss = new SnapshotV(); }
+    public void remove() {
+      // NOTE: it would seem logical that entry removal will semantically mean removing the matching pair <k,v>, but
+      // the JDK always removes by key, even when the value has changed.
+      _ss.removeKey();
+    }
+    public Map.Entry<TypeK,TypeV> next() { _ss.next(); return new NBHMEntry((TypeK)_ss._prevK,_ss._prevV); }
+    public boolean hasNext() { return _ss.hasNext(); }
+  }
+
+  /** Returns a {@link Set} view of the mappings contained in this map.  The
+   *  set is backed by the map, so changes to the map are reflected in the
+   *  set, and vice-versa.  The set supports element removal, which removes
+   *  the corresponding mapping from the map, via the
+   *  <tt>Iterator.remove</tt>, <tt>Set.remove</tt>, <tt>removeAll</tt>,
+   *  <tt>retainAll</tt>, and <tt>clear</tt> operations.  It does not support
+   *  the <tt>add</tt> or <tt>addAll</tt> operations.
+   *
+   *  <p>The view's <tt>iterator</tt> is a "weakly consistent" iterator
+   *  that will never throw {@link ConcurrentModificationException},
+   *  and guarantees to traverse elements as they existed upon
+   *  construction of the iterator, and may (but is not guaranteed to)
+   *  reflect any modifications subsequent to construction.
+   *
+   *  <p><strong>Warning:</strong> the iterator associated with this Set
+   *  requires the creation of {@link java.util.Map.Entry} objects with each
+   *  iteration.  The {@link NonBlockingHashMap} does not normally create or
+   *  using {@link java.util.Map.Entry} objects so they will be created soley
+   *  to support this iteration.  Iterating using {@link Map#keySet} or {@link
+   *  Map#values} will be more efficient.
+   */
+  @Override
+  public Set<Map.Entry<TypeK,TypeV>> entrySet() {
+    return new AbstractSet<Map.Entry<TypeK,TypeV>>() {
+      @Override public void    clear   (          ) {        NonBlockingHashMap.this.clear( ); }
+      @Override public int     size    (          ) { return NonBlockingHashMap.this.size ( ); }
+      @Override public boolean remove( final Object o ) {
+        if( !(o instanceof Map.Entry)) return false;
+        final Map.Entry<?,?> e = (Map.Entry<?,?>)o;
+        return NonBlockingHashMap.this.remove(e.getKey(), e.getValue());
+      }
+      @Override public boolean contains(final Object o) {
+        if( !(o instanceof Map.Entry)) return false;
+        final Map.Entry<?,?> e = (Map.Entry<?,?>)o;
+        TypeV v = get(e.getKey());
+        return v != null && v.equals(e.getValue());
+      }
+      @Override public Iterator<Map.Entry<TypeK,TypeV>> iterator() { return new SnapshotE(); }
+    };
+  }
+
+  // --- writeObject -------------------------------------------------------
+  // Write a NBHM to a stream
+  private void writeObject(java.io.ObjectOutputStream s) throws IOException  {
+    s.defaultWriteObject();     // Nothing to write
+    for( Object K : keySet() ) {
+      final Object V = get(K);  // Do an official 'get'
+      s.writeObject(K);         // Write the <TypeK,TypeV> pair
+      s.writeObject(V);
+    }
+    s.writeObject(null);        // Sentinel to indicate end-of-data
+    s.writeObject(null);
+  }
+
+  // --- readObject --------------------------------------------------------
+  // Read a NBHM from a stream
+  private void readObject(java.io.ObjectInputStream s) throws IOException, ClassNotFoundException {
+    s.defaultReadObject();      // Read nothing
+    initialize(MIN_SIZE);
+    for(;;) {
+      final TypeK K = (TypeK) s.readObject();
+      final TypeV V = (TypeV) s.readObject();
+      if( K == null ) break;
+      put(K,V);                 // Insert with an offical put
+    }
+  }
+
+} // End NonBlockingHashMap class

--- a/src/main/scala/org/jctools/maps/NonBlockingHashSet.java
+++ b/src/main/scala/org/jctools/maps/NonBlockingHashSet.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jctools.maps;
+import java.io.Serializable;
+import java.util.AbstractSet;
+import java.util.Iterator;
+import java.util.Set;
+
+/**
+ * A simple wrapper around {@link NonBlockingHashMap} making it implement the
+ * {@link Set} interface.  All operations are Non-Blocking and multi-thread safe.
+ *
+ * @since 1.5
+ * @author Cliff Click
+ */
+public class NonBlockingHashSet<E> extends AbstractSet<E> implements Serializable {
+  private static final Object V = "";
+
+  private final NonBlockingHashMap<E,Object> _map;
+
+  /** Make a new empty {@link NonBlockingHashSet}.  */
+  public NonBlockingHashSet() { super(); _map = new NonBlockingHashMap<E,Object>(); }
+
+  /** Add {@code o} to the set.  
+   *  @return <tt>true</tt> if {@code o} was added to the set, <tt>false</tt>
+   *  if {@code o} was already in the set.  */
+  public boolean add( final E o ) { return _map.putIfAbsent(o,V) == null; }
+
+  /**  @return <tt>true</tt> if {@code o} is in the set.  */
+  public boolean contains   ( final Object     o ) { return _map.containsKey(o); }
+
+  /**  @return Returns the match for {@code o} if {@code o} is in the set.  */
+  public E get( final E o ) { return _map.getk(o); }
+
+  /** Remove {@code o} from the set.  
+   * @return <tt>true</tt> if {@code o} was removed to the set, <tt>false</tt>
+   * if {@code o} was not in the set.
+   */
+  public boolean remove( final Object o ) { return _map.remove(o) == V; }
+  /** Current count of elements in the set.  Due to concurrent racing updates,
+   *  the size is only ever approximate.  Updates due to the calling thread are
+   *  immediately visible to calling thread.
+   *  @return count of elements.   */
+  public int size( ) { return _map.size(); }
+  /** Empty the set. */
+  public void clear( ) { _map.clear(); }
+
+  public Iterator<E>iterator( ) { return _map.keySet().iterator(); }
+}

--- a/src/main/scala/org/jctools/util/InternalAPI.java
+++ b/src/main/scala/org/jctools/util/InternalAPI.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jctools.util;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * This annotation marks classes and methods which may be public for any reason (to support better testing or reduce
+ * code duplication) but are not intended as public API and may change between releases without the change being
+ * considered a breaking API change (a major release).
+ */
+@Target({ElementType.TYPE, ElementType.METHOD, ElementType.FIELD, ElementType.CONSTRUCTOR})
+@Retention(RetentionPolicy.SOURCE)
+public @interface InternalAPI
+{
+}

--- a/src/main/scala/org/jctools/util/RangeUtil.java
+++ b/src/main/scala/org/jctools/util/RangeUtil.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jctools.util;
+
+@InternalAPI
+public final class RangeUtil
+{
+    public static long checkPositive(long n, String name)
+    {
+        if (n <= 0)
+        {
+            throw new IllegalArgumentException(name + ": " + n + " (expected: > 0)");
+        }
+
+        return n;
+    }
+
+    public static int checkPositiveOrZero(int n, String name)
+    {
+        if (n < 0)
+        {
+            throw new IllegalArgumentException(name + ": " + n + " (expected: >= 0)");
+        }
+
+        return n;
+    }
+
+    public static int checkLessThan(int n, int expected, String name)
+    {
+        if (n >= expected)
+        {
+            throw new IllegalArgumentException(name + ": " + n + " (expected: < " + expected + ')');
+        }
+
+        return n;
+    }
+
+    public static int checkLessThanOrEqual(int n, long expected, String name)
+    {
+        if (n > expected)
+        {
+            throw new IllegalArgumentException(name + ": " + n + " (expected: <= " + expected + ')');
+        }
+
+        return n;
+    }
+
+    public static int checkGreaterThanOrEqual(int n, int expected, String name)
+    {
+        if (n < expected)
+        {
+            throw new IllegalArgumentException(name + ": " + n + " (expected: >= " + expected + ')');
+        }
+
+        return n;
+    }
+}

--- a/src/main/scala/org/jctools/util/UnsafeAccess.java
+++ b/src/main/scala/org/jctools/util/UnsafeAccess.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jctools.util;
+
+import sun.misc.Unsafe;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.util.concurrent.atomic.AtomicReferenceArray;
+import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
+
+/**
+ * Why should we resort to using Unsafe?<br>
+ * <ol>
+ * <li>To construct class fields which allow volatile/ordered/plain access: This requirement is covered by
+ * {@link AtomicReferenceFieldUpdater} and similar but their performance is arguably worse than the DIY approach
+ * (depending on JVM version) while Unsafe intrinsification is a far lesser challenge for JIT compilers.
+ * <li>To construct flavors of {@link AtomicReferenceArray}.
+ * <li>Other use cases exist but are not present in this library yet.
+ * </ol>
+ *
+ * @author nitsanw
+ */
+@InternalAPI
+public class UnsafeAccess
+{
+    public static final boolean SUPPORTS_GET_AND_SET_REF;
+    public static final boolean SUPPORTS_GET_AND_ADD_LONG;
+    public static final Unsafe UNSAFE;
+
+    static
+    {
+        UNSAFE = getUnsafe();
+        SUPPORTS_GET_AND_SET_REF = hasGetAndSetSupport();
+        SUPPORTS_GET_AND_ADD_LONG = hasGetAndAddLongSupport();
+    }
+
+    private static Unsafe getUnsafe()
+    {
+        Unsafe instance;
+        try
+        {
+            final Field field = Unsafe.class.getDeclaredField("theUnsafe");
+            field.setAccessible(true);
+            instance = (Unsafe) field.get(null);
+        }
+        catch (Exception ignored)
+        {
+            // Some platforms, notably Android, might not have a sun.misc.Unsafe implementation with a private
+            // `theUnsafe` static instance. In this case we can try to call the default constructor, which is sufficient
+            // for Android usage.
+            try
+            {
+                Constructor<Unsafe> c = Unsafe.class.getDeclaredConstructor();
+                c.setAccessible(true);
+                instance = c.newInstance();
+            }
+            catch (Exception e)
+            {
+                throw new RuntimeException(e);
+            }
+        }
+        return instance;
+    }
+
+    private static boolean hasGetAndSetSupport()
+    {
+        try
+        {
+            Unsafe.class.getMethod("getAndSetObject", Object.class, Long.TYPE, Object.class);
+            return true;
+        }
+        catch (Exception ignored)
+        {
+        }
+        return false;
+    }
+
+    private static boolean hasGetAndAddLongSupport()
+    {
+        try
+        {
+            Unsafe.class.getMethod("getAndAddLong", Object.class, Long.TYPE, Long.TYPE);
+            return true;
+        }
+        catch (Exception ignored)
+        {
+        }
+        return false;
+    }
+
+    public static long fieldOffset(Class clz, String fieldName) throws RuntimeException
+    {
+        try
+        {
+            return UNSAFE.objectFieldOffset(clz.getDeclaredField(fieldName));
+        }
+        catch (NoSuchFieldException e)
+        {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/main/scala/overlock/atomicmap/AtomicMap.scala
+++ b/src/main/scala/overlock/atomicmap/AtomicMap.scala
@@ -1,0 +1,153 @@
+//
+// Copyright 2011, Boundary
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package overlock.atomicmap
+
+import scala.collection.mutable.ConcurrentMap
+import java.util.concurrent.{ ConcurrentMap => JConcurrentMap, ConcurrentSkipListMap, ConcurrentHashMap }
+import java.util.Comparator
+import org.jctools.maps._
+
+object AtomicMap {
+  def atomicCSLM[A, B]: AtomicNavigableMap[A, B] = {
+    new AtomicNavigableMap(new ConcurrentSkipListMap[A, Any])
+  }
+
+  def atomicCSLM[A, B](comp: Comparator[A]): AtomicNavigableMap[A, B] = {
+    new AtomicNavigableMap(new ConcurrentSkipListMap[A, Any](comp))
+  }
+
+  def atomicNBHM[A, B]: AtomicMap[A, B] = {
+    new AtomicMap(new NonBlockingHashMap[A, Any])
+  }
+
+  def atomicNBHM[A, B](size: Int): AtomicMap[A, B] = {
+    new AtomicMap(new NonBlockingHashMap[A, Any](size))
+  }
+
+  def atomicCHM[A, B]: AtomicMap[A, B] = {
+    new AtomicMap(new ConcurrentHashMap[A, Any])
+  }
+
+  def atomicCHM[A, B](cap: Int): AtomicMap[A, B] = {
+    new AtomicMap(new ConcurrentHashMap[A, Any](cap))
+  }
+
+  def atomicCHM[A, B](cap: Int, loadFactor: Float): AtomicMap[A, B] = {
+    new AtomicMap(new ConcurrentHashMap[A, Any](cap, loadFactor))
+  }
+
+  def atomicCHM[A, B](cap: Int, loadFactor: Float, concurrencyLevel: Int): AtomicMap[A, B] = {
+    new AtomicMap(new ConcurrentHashMap[A, Any](cap, loadFactor, concurrencyLevel))
+  }
+}
+
+class AtomicMap[A, B](u: => JConcurrentMap[A, Any]) extends ConcurrentMap[A, B] {
+  val under = u
+
+  override def empty = new AtomicMap[A, B](u)
+
+  override def getOrElseUpdate(key: A, op: => B): B = {
+    val t = new OneShotThunk(op)
+    under.putIfAbsent(key, t) match {
+      case null =>
+        try {
+          val ve = t.value
+          under.replace(key, t, ve)
+          //regardless of whether or not the replace worked, we must
+          //return ve to remain within the bounds of the getOrElseUpdate
+          // contract. If a concurrent update happened, this thread
+          // ought not to see it until after returning from this call.
+          ve
+        } catch {
+          case ex: Exception =>
+            under.remove(key, t)
+            throw ex
+        }
+      case OneShotThunk(v: B) => v
+      case v: B => v
+    }
+  }
+
+  def replace(key: A, value: B): Option[B] = {
+    Option(under.replace(key, value)).map {
+      case b: B => b
+      case OneShotThunk(v: B) => v
+    }
+  }
+
+  /**
+   * This works because ConcurrentMap defines it as .equals
+   */
+  def replace(key: A, oldVal: B, newVal: B): Boolean = {
+    val oldThunk = new OneShotThunk(oldVal)
+    under.replace(key, oldThunk, newVal)
+  }
+
+  def remove(key: A, value: B): Boolean = {
+    val thunk = new OneShotThunk(value)
+    under.remove(key, thunk)
+  }
+
+  def putIfAbsent(key: A, value: B): Option[B] = {
+    Option(under.putIfAbsent(key, value)).map {
+      case b: B => b
+      case OneShotThunk(v: B) => v
+    }
+  }
+
+  def -=(key: A): this.type = {
+    under.remove(key)
+    this
+  }
+
+  def +=(kv: (A, B)): this.type = {
+    val (key, value) = kv
+    under.put(key, value)
+    this
+  }
+
+  def get(key: A): Option[B] = {
+    Option(under.get(key)) match {
+      case None => None
+      case Some(OneShotThunk(v: B)) => Some(v)
+      case Some(v: B) => Some(v)
+    }
+  }
+
+  def iterator: Iterator[(A, B)] = {
+    new Iterator[(A, B)] {
+      val iter = under.entrySet.iterator
+
+      def next: (A, B) = {
+        val entry = iter.next
+        val key = entry.getKey
+        entry.getValue match {
+          case t: OneShotThunk[_] => (key, t.value.asInstanceOf[B])
+          case v => (key, v.asInstanceOf[B])
+        }
+      }
+
+      def hasNext: Boolean = {
+        iter.hasNext
+      }
+
+      def remove {
+        iter.remove
+      }
+    }
+  }
+}

--- a/src/main/scala/overlock/atomicmap/AtomicNavigableMap.scala
+++ b/src/main/scala/overlock/atomicmap/AtomicNavigableMap.scala
@@ -1,0 +1,32 @@
+//
+// Copyright 2011, Boundary
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package overlock.atomicmap
+
+import java.util.concurrent.{ ConcurrentNavigableMap, ConcurrentSkipListMap }
+import java.util.{ NavigableMap, NavigableSet }
+
+class AtomicNavigableMap[A, B](u: => ConcurrentNavigableMap[A, Any]) extends AtomicMap[A, B](u) {
+
+  override val under = u
+  def comparator = under.comparator
+
+  override def empty = new AtomicNavigableMap[A, B](u)
+
+  def subMap(fromKey: A, fromInclusive: Boolean, toKey: A, toInclusive: Boolean): AtomicNavigableMap[A, B] = {
+    new AtomicNavigableMap(under.subMap(fromKey, fromInclusive, toKey, toInclusive))
+  }
+}

--- a/src/main/scala/overlock/atomicmap/OneShotThunk.scala
+++ b/src/main/scala/overlock/atomicmap/OneShotThunk.scala
@@ -1,0 +1,39 @@
+//
+// Copyright 2011, Boundary
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package overlock.atomicmap
+
+import java.util.concurrent._
+import locks._
+
+object OneShotThunk {
+  def unapply[A](ost: OneShotThunk[A]): Option[A] = {
+    ost.value match {
+      case v: A => Some(v)
+      case _ => None
+    }
+  }
+}
+
+class OneShotThunk[A](op: => A) {
+  lazy val value = op
+
+  override def equals(other: Any) = other match {
+    case o: OneShotThunk[_] => value == o.value
+    case v: A => value == v
+    case _ => false
+  }
+}

--- a/src/main/scala/overlock/cache/CachedSymbol.scala
+++ b/src/main/scala/overlock/cache/CachedSymbol.scala
@@ -1,0 +1,26 @@
+//
+// Copyright 2011, Boundary
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+package overlock.cache
+
+import overlock.atomicmap.AtomicMap
+
+object CachedSymbol {
+  val symbolCache = AtomicMap.atomicNBHM[String, Symbol]
+
+  def apply(string: String): Symbol = {
+    symbolCache.getOrElseUpdate(string, Symbol(string))
+  }
+}

--- a/src/main/scala/overlock/threadpool/ElasticBlockingQueue.scala
+++ b/src/main/scala/overlock/threadpool/ElasticBlockingQueue.scala
@@ -1,0 +1,35 @@
+//
+// Copyright 2011, Boundary
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+package overlock.threadpool
+
+import java.util.concurrent.{ LinkedTransferQueue, ThreadPoolExecutor }
+
+class ElasticBlockingQueue[A] extends LinkedTransferQueue[A] {
+  var executor: ThreadPoolExecutor = null
+
+  override def offer(item: A): Boolean = {
+    val left = executor.getMaximumPoolSize - executor.getPoolSize
+    if (!tryTransfer(item)) {
+      if (left > 0) {
+        false
+      } else {
+        super.offer(item)
+      }
+    } else {
+      true
+    }
+  }
+}

--- a/src/main/scala/overlock/threadpool/InstrumentedThreadPoolExecutor.scala
+++ b/src/main/scala/overlock/threadpool/InstrumentedThreadPoolExecutor.scala
@@ -1,0 +1,62 @@
+//
+// Copyright 2011, Boundary
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+package overlock.threadpool
+
+import java.util.concurrent._
+import com.yammer.metrics._
+import scala._
+import org.slf4j.LoggerFactory
+
+class InstrumentedThreadPoolExecutor(path: String,
+                                     name: String,
+                                     corePoolSize: Int,
+                                     maximumPoolSize: Int,
+                                     keepAliveTime: Long,
+                                     unit: TimeUnit,
+                                     workQueue: BlockingQueue[Runnable],
+                                     factory: ThreadFactory) extends ThreadPoolExecutor(corePoolSize, maximumPoolSize, keepAliveTime, unit, workQueue, factory) with Instrumented {
+  protected lazy val log = LoggerFactory.getLogger(getClass)
+  val requestRate = metrics.meter("request", "requests", path + "." + name, TimeUnit.SECONDS)
+  val rejectedRate = metrics.meter("rejected", "requests", path + "." + name, TimeUnit.SECONDS)
+  val executionTimer = metrics.timer("execution", path + "." + name)
+  val queueGauge = metrics.gauge("queue size", path + "." + name)(getQueue.size)
+  val threadGauge = metrics.gauge("threads", path + "." + name)(getPoolSize)
+  val activeThreadGauge = metrics.gauge("active threads", path + "." + name)(getActiveCount)
+  val startTime = new ThreadLocal[Long]
+
+  setRejectedExecutionHandler(new RejectedExecutionHandler {
+    def rejectedExecution(r: Runnable, executor: ThreadPoolExecutor) {
+      rejectedRate.mark
+      if (!workQueue.offer(r)) {
+        log.warn("Work queue is not accepting work.")
+      }
+    }
+  })
+
+  override def execute(r: Runnable) {
+    requestRate.mark
+    super.execute(r)
+  }
+
+  override protected def beforeExecute(t: Thread, r: Runnable) {
+    startTime.set(System.nanoTime)
+  }
+
+  override protected def afterExecute(r: Runnable, t: Throwable) {
+    val duration = System.nanoTime - startTime.get
+    executionTimer.update(duration, TimeUnit.NANOSECONDS)
+  }
+}

--- a/src/main/scala/overlock/threadpool/NamedThreadFactory.scala
+++ b/src/main/scala/overlock/threadpool/NamedThreadFactory.scala
@@ -1,0 +1,47 @@
+//
+// Copyright 2011, Boundary
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+package overlock.threadpool
+
+import java.util.concurrent._
+import atomic._
+import org.slf4j.LoggerFactory
+
+/**
+ * Based off of the NamedThreadFactory in cassandra
+ */
+class NamedThreadFactory(val name: String, val priority: Int = Thread.NORM_PRIORITY) extends ThreadFactory {
+  val counter = new AtomicInteger(0)
+
+  override def newThread(r: Runnable): Thread = {
+    val threadName = name + ":" + counter.getAndIncrement
+    val t = new ErrorLoggedThread(r, threadName)
+    t.setPriority(priority)
+    t
+  }
+}
+
+class ErrorLoggedThread(r: Runnable, threadName: String) extends Thread(r, threadName) {
+  protected lazy val log = LoggerFactory.getLogger(getClass)
+  override def run {
+    try {
+      super.run
+    } catch {
+      case e: Throwable =>
+        log.error("Exception was thrown in thread " + threadName, e)
+        throw e
+    }
+  }
+}

--- a/src/main/scala/overlock/threadpool/ThreadPool.scala
+++ b/src/main/scala/overlock/threadpool/ThreadPool.scala
@@ -1,0 +1,59 @@
+//
+// Copyright 2011, Boundary
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+package overlock.threadpool
+
+import java.util.concurrent._
+
+object ThreadPool {
+  /**
+   * Makes the equivalent of a cached thread pool from {@link Executors}
+   */
+  def instrumentedCached(path: String, name: String): Executor = {
+    new InstrumentedThreadPoolExecutor(path,
+      name,
+      0,
+      Int.MaxValue,
+      60l,
+      TimeUnit.SECONDS,
+      new SynchronousQueue[Runnable],
+      new NamedThreadFactory(name))
+  }
+
+  def instrumentedFixed(path: String, name: String, n: Int): Executor = {
+    new InstrumentedThreadPoolExecutor(path,
+      name,
+      n,
+      n,
+      60l,
+      TimeUnit.SECONDS,
+      new LinkedBlockingQueue[Runnable],
+      new NamedThreadFactory(name))
+  }
+
+  def instrumentedElastic(path: String, name: String, coreSize: Int, maxSize: Int): Executor = {
+    val queue = new ElasticBlockingQueue[Runnable]
+    val pool = new InstrumentedThreadPoolExecutor(path,
+      name,
+      coreSize,
+      maxSize,
+      60l,
+      TimeUnit.SECONDS,
+      queue,
+      new NamedThreadFactory(name))
+    queue.executor = pool
+    pool
+  }
+}

--- a/src/main/scala/scalang/BigTuple.scala
+++ b/src/main/scala/scalang/BigTuple.scala
@@ -1,0 +1,32 @@
+//
+// Copyright 2011, Boundary
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+package scalang
+
+class BigTuple(val elements: Seq[Any]) extends Product {
+
+  override def productElement(n: Int) = elements(n)
+
+  override def productArity = elements.size
+
+  override def canEqual(other: Any): Boolean = {
+    other match {
+      case o: BigTuple => o.elements == elements
+      case _ => false
+    }
+  }
+
+  override def equals(other: Any) = canEqual(other)
+}

--- a/src/main/scala/scalang/BitString.scala
+++ b/src/main/scala/scalang/BitString.scala
@@ -1,0 +1,20 @@
+//
+// Copyright 2011, Boundary
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+package scalang
+
+import java.nio._
+
+case class BitString(buffer: ByteBuffer, bits: Int)

--- a/src/main/scala/scalang/Cluster.scala
+++ b/src/main/scala/scalang/Cluster.scala
@@ -1,0 +1,30 @@
+//
+// Copyright 2011, Boundary
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+package scalang
+
+class Cluster(ctx: ProcessContext) extends Process(ctx) {
+  @volatile var nodes = Set[Symbol]()
+
+  def onMessage(msg: Any) = msg match {
+    case ('cluster, pid: Pid, ref: Reference) =>
+      pid ! ('cluster, ref, nodes.toList)
+    case ('nodeup, node: Symbol) =>
+      nodes += node
+    case ('nodedown, node: Symbol) =>
+      nodes -= node
+  }
+
+}

--- a/src/main/scala/scalang/ETerm.scala
+++ b/src/main/scala/scalang/ETerm.scala
@@ -1,0 +1,20 @@
+//
+// Copyright 2011, Boundary
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+package scalang
+
+trait ETerm {
+
+}

--- a/src/main/scala/scalang/ErlangPeer.scala
+++ b/src/main/scala/scalang/ErlangPeer.scala
@@ -1,0 +1,18 @@
+//
+// Copyright 2011, Boundary
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+package scalang
+
+case class ErlangPeer(node: String)

--- a/src/main/scala/scalang/Fun.scala
+++ b/src/main/scala/scalang/Fun.scala
@@ -1,0 +1,22 @@
+//
+// Copyright 2011, Boundary
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+package scalang
+
+case class Fun(pid: Pid, module: Symbol, index: Int, uniq: Int, vars: Seq[Any])
+
+case class NewFun(pid: Pid, module: Symbol, oldIndex: Int, oldUniq: Int, arity: Int, index: Int, uniq: Seq[Byte], vars: Seq[Any])
+
+case class ExportFun(module: Symbol, function: Symbol, arity: Int)

--- a/src/main/scala/scalang/FunProcess.scala
+++ b/src/main/scala/scalang/FunProcess.scala
@@ -1,0 +1,78 @@
+//
+// Copyright 2011, Boundary
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+package scalang
+
+import scalang.node._
+import java.util.concurrent.{ LinkedBlockingQueue, TimeUnit }
+
+class FunProcess(fun: Mailbox => Unit, ctx: ProcessContext) extends ProcessAdapter {
+  val queue = new LinkedBlockingQueue[Any]
+  val referenceCounter = ctx.referenceCounter
+  val self = ctx.pid
+  val fiber = ctx.fiber
+  val parentPid = self
+  val parentRef = referenceCounter
+  val parent = this
+  val mbox = new Mailbox {
+    def self = parentPid
+    def referenceCounter = parentRef
+
+    def handleMessage(msg: Any) {
+      queue.offer(msg)
+    }
+
+    def receive: Any = {
+      queue.take
+    }
+
+    def receive(timeout: Long): Option[Any] = {
+      Option(queue.poll(timeout, TimeUnit.MILLISECONDS))
+    }
+
+    def send(pid: Pid, msg: Any) = parent.notifySend(pid, msg)
+
+    def send(name: Symbol, msg: Any) = parent.notifySend(name, msg)
+
+    def send(dest: (Symbol, Symbol), from: Pid, msg: Any) = parent.notifySend(dest, from, msg)
+
+    def exit(reason: Any) = parent.exit(reason)
+
+    def link(to: Pid) = parent.link(to)
+  }
+
+  def start {
+    fiber.execute(new Runnable {
+      override def run {
+        fun(mbox)
+        exit('normal)
+      }
+    })
+  }
+
+  override def handleMessage(msg: Any) {
+    queue.offer(msg)
+  }
+
+  override def handleExit(from: Pid, reason: Any) {
+    queue.offer(('EXIT, from, reason))
+  }
+
+  override def handleMonitorExit(monitored: Any, ref: Reference, reason: Any) {
+    queue.offer(('DOWN, ref, 'process, monitored, reason))
+  }
+
+  def cleanup = fiber.dispose
+}

--- a/src/main/scala/scalang/ImproperList.scala
+++ b/src/main/scala/scalang/ImproperList.scala
@@ -1,0 +1,39 @@
+//
+// Copyright 2011, Boundary
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+package scalang
+
+import scala.collection.immutable.LinearSeq
+import scala.collection.mutable.StringBuilder
+
+case class ImproperList(under: List[Any], lastTail: Any) extends LinearSeq[Any] {
+  override def isEmpty = under.isEmpty
+  override def head = under.head
+  override def tail = under.tail
+
+  override def apply(idx: Int) = under(idx)
+
+  override def length = under.length
+
+  override def toString: String = {
+    val buffer = new StringBuilder
+    buffer ++= "ImproperList("
+    buffer ++= under.toString
+    buffer ++= ", "
+    buffer ++= lastTail.toString
+    buffer ++= ")"
+    buffer.toString
+  }
+}

--- a/src/main/scala/scalang/Node.scala
+++ b/src/main/scala/scalang/Node.scala
@@ -1,0 +1,934 @@
+//
+// Copyright 2011, Boundary
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+package scalang
+
+import java.util.concurrent.atomic._
+import org.jboss.{ netty => netty }
+import netty.channel._
+import java.util.concurrent._
+import scalang.node._
+import org.jctools.maps._
+import overlock.atomicmap._
+import org.jetlang._
+import core._
+import java.io._
+import netty.handler.execution.ExecutionHandler
+import scala.collection.JavaConversions._
+import scalang.epmd._
+import scalang.util._
+import java.security.SecureRandom
+import org.jboss.netty.logging._
+import netty.util.HashedWheelTimer
+import com.yammer.metrics.scala._
+import org.jetlang.fibers.PoolFiberFactory
+import com.boundary.logula.Logging
+
+object Node {
+  val random = SecureRandom.getInstance("SHA1PRNG")
+
+  def apply(name: String): Node = apply(Symbol(name))
+  def apply(name: String, tpf: ThreadPoolFactory): Node = apply(Symbol(name), tpf)
+  def apply(name: String, listener: ClusterListener): Node = apply(Symbol(name), listener)
+  def apply(name: String, nodeConfig: NodeConfig): Node = apply(Symbol(name), nodeConfig)
+  def apply(name: String, cookie: String): Node = apply(Symbol(name), cookie)
+  def apply(name: String, cookie: String, tpf: ThreadPoolFactory): Node = apply(Symbol(name), cookie, tpf)
+  def apply(name: String, cookie: String, listener: ClusterListener): Node = apply(Symbol(name), cookie, listener)
+  def apply(name: String, cookie: String, nodeConfig: NodeConfig): Node = apply(Symbol(name), cookie, nodeConfig)
+
+  def apply(name: Symbol) =
+    new ErlangNode(name, findOrGenerateCookie, NodeConfig(new DefaultThreadPoolFactory, None))
+
+  def apply(name: Symbol, tpf: ThreadPoolFactory) =
+    new ErlangNode(name, findOrGenerateCookie, NodeConfig(tpf, None))
+
+  def apply(name: Symbol, listener: ClusterListener) =
+    new ErlangNode(name, findOrGenerateCookie, NodeConfig(new DefaultThreadPoolFactory, Some(listener)))
+
+  def apply(name: Symbol, nodeConfig: NodeConfig) =
+    new ErlangNode(name, findOrGenerateCookie, nodeConfig)
+
+  def apply(name: Symbol, cookie: String) =
+    new ErlangNode(name, cookie, NodeConfig(new DefaultThreadPoolFactory, None))
+
+  def apply(name: Symbol, cookie: String, tpf: ThreadPoolFactory) =
+    new ErlangNode(name, cookie, NodeConfig(tpf, None))
+
+  def apply(name: Symbol, cookie: String, listener: ClusterListener) =
+    new ErlangNode(name, cookie, NodeConfig(new DefaultThreadPoolFactory, Some(listener)))
+
+  def apply(name: Symbol, cookie: String, nodeConfig: NodeConfig) =
+    new ErlangNode(name, cookie, nodeConfig)
+
+  protected def findOrGenerateCookie: String = {
+    val homeDir = System.getenv("HOME")
+    if (homeDir == null) {
+      throw new Exception("No erlang cookie set and cannot read ~/.erlang.cookie.")
+    }
+    val file = new File(homeDir, ".erlang.cookie")
+    if (file.isFile) {
+      readFile(file)
+    } else {
+      val cookie = randomCookie
+      writeCookie(file, cookie)
+      cookie
+    }
+  }
+
+  protected def randomCookie: String = {
+    val ary = new Array[Byte](20)
+    random.nextBytes(ary)
+    ary.map("%02X" format _).mkString
+  }
+
+  protected def readFile(file: File): String = {
+    val in = new BufferedReader(new FileReader(file))
+    try
+      in.readLine
+    finally
+      in.close
+  }
+
+  protected def writeCookie(file: File, cookie: String) {
+    val out = new FileWriter(file)
+    try
+      out.write(cookie)
+    finally
+      out.close
+  }
+}
+
+trait ClusterListener {
+  def nodeUp(node: Symbol)
+  def nodeDown(node: Symbol)
+}
+
+trait ClusterPublisher {
+  @volatile var listeners: List[ClusterListener] = Nil
+
+  def addListener(listener: ClusterListener) {
+    listeners = listener :: listeners
+  }
+
+  def clearListeners {
+    listeners = Nil
+  }
+
+  def notifyNodeUp(node: Symbol) {
+    for (listener <- listeners) {
+      listener.nodeUp(node)
+    }
+  }
+
+  def notifyNodeDown(node: Symbol) {
+    for (listener <- listeners) {
+      listener.nodeDown(node)
+    }
+  }
+}
+
+trait Node extends ClusterListener with ClusterPublisher {
+  def name: Symbol
+  def cookie: String
+  def spawn[T <: Process](implicit mf: Manifest[T]): Pid
+  def spawn[T <: Process](regName: String)(implicit mf: Manifest[T]): Pid
+  def spawn[T <: Process](regName: Symbol)(implicit mf: Manifest[T]): Pid
+  def spawnService[T <: Service[A], A <: Product](args: A)(implicit mf: Manifest[T]): Pid
+  def spawnService[T <: Service[A], A <: Product](regName: String, args: A)(implicit mf: Manifest[T]): Pid
+  def spawnService[T <: Service[A], A <: Product](regName: Symbol, args: A)(implicit mf: Manifest[T]): Pid
+  def spawn(fun: Mailbox => Unit): Pid
+  def spawn(regName: String, fun: Mailbox => Unit): Pid
+  def spawn(regName: Symbol, fun: Mailbox => Unit): Pid
+  def spawnMbox: Mailbox
+  def spawnMbox(regName: String): Mailbox
+  def spawnMbox(regName: Symbol): Mailbox
+  def send(to: Pid, msg: Any)
+  def send(to: Symbol, msg: Any)
+  def send(to: (Symbol, Symbol), from: Pid, msg: Any)
+  def call(to: Pid, msg: Any): Any
+  def call(to: Pid, msg: Any, timeout: Long): Any
+  def call(from: Pid, to: Pid, msg: Any): Any
+  def call(from: Pid, to: Pid, msg: Any, timeout: Long): Any
+  def call(to: Symbol, msg: Any): Any
+  def call(to: Symbol, msg: Any, timeout: Long): Any
+  def call(from: Pid, to: Symbol, msg: Any): Any
+  def call(from: Pid, to: Symbol, msg: Any, timeout: Long): Any
+  def call(to: (Symbol, Symbol), msg: Any): Any
+  def call(to: (Symbol, Symbol), msg: Any, timeout: Long): Any
+  def call(from: Pid, to: (Symbol, Symbol), msg: Any): Any
+  def call(from: Pid, to: (Symbol, Symbol), msg: Any, timeout: Long): Any
+  def cast(to: Pid, msg: Any)
+  def cast(to: Symbol, msg: Any)
+  def cast(to: (Symbol, Symbol), msg: Any)
+  def register(regName: String, pid: Pid)
+  def register(regName: Symbol, pid: Pid)
+  def getNames: Set[Symbol]
+  def whereis(name: Symbol): Option[Pid]
+  def ping(node: Symbol, timeout: Long): Boolean
+  def nodes: Set[Symbol]
+  def makeRef: Reference
+  def isAlive(pidOrProc: Any): Boolean
+  def shutdown
+  def timer: HashedWheelTimer
+}
+
+class ErlangNode(val name: Symbol, val cookie: String, config: NodeConfig) extends Node
+    with ExitListener
+    with SendListener
+    with LinkListener
+    with MonitorListener
+    with ReplyRegistry
+    with Instrumented
+    with Logging {
+  InternalLoggerFactory.setDefaultFactory(new Slf4JLoggerFactory)
+
+  val timer = new HashedWheelTimer
+  val tickTime = config.tickTime
+  val poolFactory = config.poolFactory
+  var creation: Int = 0
+  val processes = new NonBlockingHashMap[Pid, ProcessAdapter]
+  val registeredNames = new NonBlockingHashMap[Symbol, Pid]
+  val channels = AtomicMap.atomicNBHM[Symbol, Channel]
+  val links = AtomicMap.atomicNBHM[Channel, NonBlockingHashSet[Link]]
+  val monitors = AtomicMap.atomicNBHM[Channel, NonBlockingHashSet[Monitor]]
+  val pidCount = new AtomicInteger(0)
+  val pidSerial = new AtomicInteger(0)
+  val executor = poolFactory.createActorPool
+  val factory = new PoolFiberFactory(executor)
+  val executionHandler = new ExecutionHandler(poolFactory.createExecutorPool)
+  val server = new ErlangNodeServer(this, config.typeFactory, config.typeEncoder, config.typeDecoder)
+  val localEpmd = Epmd("localhost")
+  localEpmd.alive(server.port, splitNodename(name)) match {
+    case Some(c) => creation = c
+    case None => throw new ErlangNodeException("EPMD alive announcement failed.")
+  }
+  val referenceCounter = new ReferenceCounter(name, creation)
+  val netKernel = spawn[NetKernel]('net_kernel)
+  val cluster = spawn[Cluster]('cluster)
+
+  def shutdown {
+    localEpmd.close
+    for ((node, channel) <- channels) {
+      channel.close
+    }
+    for ((pid, process) <- processes) {
+      process.exit('node_shutdown)
+    }
+  }
+
+  def spawnMbox: MailboxProcess = {
+    val p = createPid
+    val n = this
+    val ctx = new ProcessContext {
+      val pid = p
+      val referenceCounter = n.referenceCounter
+      val node = n
+      val fiber = null
+      val replyRegistry = n
+      var adapter: ProcessAdapter = null
+    }
+    val mailbox = new MailboxProcess(ctx)
+    ctx.adapter = mailbox
+    mailbox.addExitListener(this)
+    mailbox.addSendListener(this)
+    mailbox.addLinkListener(this)
+    mailbox.addMonitorListener(this)
+    processes.put(p, mailbox)
+    mailbox
+  }
+
+  def spawnMbox(regName: String): Mailbox = spawnMbox(Symbol(regName))
+  def spawnMbox(regName: Symbol): Mailbox = {
+    val mbox = spawnMbox
+    register(regName, mbox.self)
+    mbox
+  }
+
+  def createPid: Pid = {
+    val id = pidCount.getAndIncrement & 0x7fff
+
+    val serial = if (id == 0)
+      pidSerial.getAndIncrement & 0x1fff
+    else
+      pidSerial.get & 0x1fff
+    Pid(name, id, serial, creation)
+  }
+
+  //node external interface
+  def spawn(fun: Mailbox => Unit): Pid = {
+    val n = this
+    val p = createPid
+    val ctx = new ProcessContext {
+      val pid = p
+      val referenceCounter = n.referenceCounter
+      val node = n
+      val fiber = factory.create(poolFactory.createBatchExecutor(false))
+      val replyRegistry = n
+      var adapter: ProcessAdapter = null
+    }
+    val process = new FunProcess(fun, ctx)
+    ctx.adapter = process
+    process.addExitListener(this)
+    process.addSendListener(this)
+    process.addLinkListener(this)
+    process.addMonitorListener(this)
+    process.fiber.start
+    process.start
+    p
+  }
+
+  def spawn(name: String, fun: Mailbox => Unit): Pid = {
+    spawn(Symbol(name), fun)
+  }
+
+  def spawn(name: Symbol, fun: Mailbox => Unit): Pid = {
+    val n = this
+    val p = createPid
+    val ctx = new ProcessContext {
+      val pid = p
+      val referenceCounter = n.referenceCounter
+      val node = n
+      val fiber = factory.create(poolFactory.createBatchExecutor(name.name, false))
+      val replyRegistry = n
+      var adapter: ProcessAdapter = null
+    }
+    val process = new FunProcess(fun, ctx)
+    ctx.adapter = process
+    process.addExitListener(this)
+    process.addSendListener(this)
+    process.addLinkListener(this)
+    process.addMonitorListener(this)
+    process.fiber.start
+    process.start
+    registeredNames.put(name, p)
+    p
+  }
+
+  def spawn[T <: Process](implicit mf: Manifest[T]): Pid = {
+    val pid = createPid
+    createProcess(mf.erasure.asInstanceOf[Class[T]], pid, poolFactory.createBatchExecutor(false))
+    pid
+  }
+
+  def spawn[T <: Process](regName: Symbol)(implicit mf: Manifest[T]): Pid = {
+    val pid = createPid
+    createProcess(mf.erasure.asInstanceOf[Class[T]], pid, poolFactory.createBatchExecutor(regName.name, false))
+    registeredNames.put(regName, pid)
+    pid
+  }
+
+  def spawn[T <: Process](regName: String)(implicit mf: Manifest[T]): Pid = {
+    spawn(Symbol(regName))(mf)
+  }
+
+  def spawn[T <: Process](reentrant: Boolean)(implicit mf: Manifest[T]): Pid = {
+    val pid = createPid
+    createProcess(mf.erasure.asInstanceOf[Class[T]], pid, poolFactory.createBatchExecutor(reentrant))
+    pid
+  }
+
+  def spawn[T <: Process](regName: Symbol, reentrant: Boolean)(implicit mf: Manifest[T]): Pid = {
+    val pid = createPid
+    createProcess(mf.erasure.asInstanceOf[Class[T]], pid, poolFactory.createBatchExecutor(regName.name, reentrant))
+    registeredNames.put(regName, pid)
+    pid
+  }
+
+  def spawn[T <: Process](regName: String, reentrant: Boolean)(implicit mf: Manifest[T]): Pid = {
+    spawn[T](Symbol(regName), reentrant)(mf)
+  }
+
+  def spawnService[T <: Service[A], A <: Product](args: A)(implicit mf: Manifest[T]): Pid = {
+    spawnService[T, A](args, false)(mf)
+  }
+
+  def spawnService[T <: Service[A], A <: Product](args: A, reentrant: Boolean)(implicit mf: Manifest[T]): Pid = {
+    val pid = createPid
+    createService(mf.erasure.asInstanceOf[Class[T]], pid, args, poolFactory.createBatchExecutor(reentrant))
+    pid
+  }
+
+  def spawnService[T <: Service[A], A <: Product](regName: String, args: A)(implicit mf: Manifest[T]): Pid = {
+    spawnService[T, A](regName, args, false)(mf)
+  }
+
+  def spawnService[T <: Service[A], A <: Product](regName: String, args: A, reentrant: Boolean)(implicit mf: Manifest[T]): Pid = {
+    spawnService[T, A](Symbol(regName), args, reentrant)(mf)
+  }
+
+  def spawnService[T <: Service[A], A <: Product](regName: Symbol, args: A)(implicit mf: Manifest[T]): Pid = {
+    spawnService[T, A](regName, args, false)(mf)
+  }
+
+  def spawnService[T <: Service[A], A <: Product](regName: Symbol, args: A, reentrant: Boolean)(implicit mf: Manifest[T]): Pid = {
+    val pid = createPid
+    createService(mf.erasure.asInstanceOf[Class[T]], pid, args, poolFactory.createBatchExecutor(regName.name, reentrant))
+    registeredNames.put(regName, pid)
+    pid
+  }
+
+  override def nodeDown(node: Symbol) {
+    send('cluster, ('nodedown, node))
+  }
+
+  override def nodeUp(node: Symbol) {
+    send('cluster, ('nodeup, node))
+  }
+
+  protected def createService[A <: Product, T <: Service[A]](clazz: Class[T], p: Pid, a: A, batch: BatchExecutor) {
+    val n = this
+    val ctx = new ServiceContext[A] {
+      val pid = p
+      val referenceCounter = n.referenceCounter
+      val node = n
+      val fiber = factory.create(batch)
+      val replyRegistry = n
+      val args = a
+      var adapter: ProcessAdapter = null
+    }
+    val adapter = new ServiceLauncher[A, T](clazz, ctx)
+    ctx.adapter = adapter
+    adapter.addExitListener(this)
+    adapter.addSendListener(this)
+    adapter.addLinkListener(this)
+    adapter.addMonitorListener(this)
+    ctx.fiber.start
+    ctx.fiber.execute(new Runnable {
+      def run {
+        adapter.init
+      }
+    })
+    processes.put(p, adapter)
+  }
+
+  protected def createProcess[T <: Process](clazz: Class[T], p: Pid, batch: BatchExecutor) {
+    val n = this
+    val ctx = new ProcessContext {
+      val pid = p
+      val referenceCounter = n.referenceCounter
+      val node = n
+      val fiber = factory.create(batch)
+      val replyRegistry = n
+      var adapter: ProcessAdapter = null
+    }
+    val adapter = new ProcessLauncher[T](clazz, ctx)
+    ctx.adapter = adapter
+    adapter.addExitListener(this)
+    adapter.addSendListener(this)
+    adapter.addLinkListener(this)
+    adapter.addMonitorListener(this)
+    ctx.fiber.start
+    ctx.fiber.execute(new Runnable {
+      def run {
+        adapter.init
+      }
+    })
+    processes.put(p, adapter)
+  }
+
+  def register(regName: String, pid: Pid) {
+    register(Symbol(regName), pid)
+  }
+
+  def register(regName: Symbol, pid: Pid) {
+    registeredNames.put(regName, pid)
+  }
+
+  def getNames: Set[Symbol] = {
+    registeredNames.keySet.toSet.asInstanceOf[Set[Symbol]]
+  }
+
+  def registerConnection(name: Symbol, channel: Channel) {
+    channels.put(name, channel)
+  }
+
+  def whereis(regName: Symbol): Option[Pid] = {
+    Option(registeredNames.get(regName))
+  }
+
+  def ping(node: Symbol, timeout: Long): Boolean = {
+    val mbox = spawnMbox
+    val ref = makeRef
+    mbox.send(('net_kernel, Symbol(node.name)), mbox.self, ((Symbol("$gen_call"), (mbox.self, ref), ('is_auth, node))))
+    val result = mbox.receive(timeout) match {
+      case Some((ref, 'yes)) => true
+      case m =>
+        false
+    }
+    mbox.exit('normal)
+    result
+  }
+
+  def nodes: Set[Symbol] = {
+    channels.keySet.toSet.asInstanceOf[Set[Symbol]]
+  }
+
+  def deliverLink(link: Link) {
+    val from = link.from
+    val to = link.to
+    log.debug("deliverLink %s -> %s", from, to)
+    if (from == to) {
+      log.warn("Trying to link a pid to itself: %s", from)
+      return
+    }
+
+    if (isLocal(to)) {
+      process(to) match {
+        case Some(p: ProcessAdapter) =>
+          p.registerLink(from)
+        case None =>
+          break(link, 'noproc)
+      }
+    } else {
+      getOrConnectAndSend(to.node, LinkMessage(from, to), { channel =>
+        val set = links.getOrElseUpdate(channel, new NonBlockingHashSet[Link])
+        set.add(link)
+      })
+    }
+  }
+
+  //node internal interface
+  def link(from: Pid, to: Pid) {
+    log.debug("link %s -> %s", from, to)
+    if (from == to) {
+      log.warn("Trying to link a pid to itself: %s", from)
+      return
+    }
+    if (!isLocal(from) && !isLocal(to)) {
+      log.warn("Trying to link non-local pids: %s -> %s", from, to)
+      return
+    }
+
+    for (p <- process(from)) {
+      p.link(to)
+    }
+
+    for (p <- process(to)) {
+      p.link(from)
+    }
+  }
+
+  // Link two pids without triggering a send of a Link message to the remote.
+  def linkWithoutNotify(from: Pid, to: Pid, channel: Channel) {
+    log.debug("link w/o notify %s -> %s", from, to)
+    if (from == to) {
+      log.warn("Trying to link a pid to itself: %s", from)
+      return
+    }
+
+    if (!isLocal(from) && !isLocal(to)) {
+      log.warn("Trying to link non-local pids: %s -> %s", from, to)
+      return
+    }
+
+    process(from) match {
+      case Some(p: ProcessAdapter) =>
+        val link = p.registerLink(to)
+        if (!isLocal(from))
+          links.getOrElseUpdate(channel, new NonBlockingHashSet[Link]).add(link)
+      case None =>
+        if (isLocal(from)) {
+          log.warn("Try to link non-live process %s to %s", from, to)
+          val link = Link(from, to)
+          break(link, 'noproc)
+        } else {
+          links.getOrElseUpdate(channel, new NonBlockingHashSet[Link]).add(Link(from, to))
+        }
+    }
+
+    process(to) match {
+      case Some(p: ProcessAdapter) =>
+        val link = p.registerLink(from)
+        if (!isLocal(to))
+          links.getOrElseUpdate(channel, new NonBlockingHashSet[Link]).add(link)
+
+      case None =>
+        if (isLocal(to)) {
+          log.warn("Try to link non-live process %s to %s", to, from)
+          val link = Link(from, to)
+          break(link, 'noproc)
+        } else {
+          links.getOrElseUpdate(channel, new NonBlockingHashSet[Link]).add(Link(from, to))
+        }
+    }
+  }
+
+  def deliverMonitor(monitor: Monitor) {
+    val monitoring = monitor.monitoring
+    val monitored = monitor.monitored
+    var ref = monitor.ref
+    log.debug("deliverMonitor %s -> %s (%s)", monitoring, monitored, ref)
+    if (monitoring == monitored) {
+      log.warn("A process tried to monitor itself: %s", monitoring)
+      return
+    }
+
+    if (isLocal(monitored)) {
+      process(monitored) match {
+        case Some(p: ProcessAdapter) =>
+          p.registerMonitor(monitoring, ref)
+        case None =>
+          monitorExit(monitor, 'noproc)
+      }
+    } else {
+      getOrConnectAndSend(nodeOf(monitored), MonitorMessage(monitoring, monitored, ref), { channel =>
+        val set = monitors.getOrElseUpdate(channel, new NonBlockingHashSet[Monitor])
+        set.add(monitor)
+      })
+    }
+  }
+
+  def monitorWithoutNotify(monitoring: Pid, monitored: Any, ref: Reference, channel: Channel) {
+    log.debug("monitor %s -> %s (%s)", monitoring, monitored, ref)
+    if (monitoring == monitored) {
+      log.warn("Trying to monitor itself: %s", monitoring)
+      return
+    }
+
+    if (!isLocal(monitoring) && !isLocal(monitored)) {
+      log.warn("Try to monitor between non-local pids: %s -> %s (%s)", monitoring, monitored, ref)
+      return
+    }
+
+    if (log.isDebugEnabled) {
+      // skip running toList() if we don't intend to log it
+      log.debug("pids %s", processes.keys.toList)
+    }
+    process(monitored) match {
+      case Some(p) =>
+        log.debug("adding monitor for %s", p)
+        val monitor = p.registerMonitor(monitoring, ref)
+        if (!isLocal(monitored))
+          monitors.getOrElseUpdate(channel, new NonBlockingHashSet[Monitor]).add(monitor)
+      case None =>
+        if (isLocal(monitored)) {
+          log.warn("Try to monitor non-live process: %s -> %s (%s)", monitoring, monitored, ref)
+          val monitor = Monitor(monitoring, monitored, ref)
+          monitorExit(monitor, 'noproc)
+        } else {
+          monitors.getOrElseUpdate(channel, new NonBlockingHashSet[Monitor]).add(Monitor(monitoring, monitored, ref))
+        }
+    }
+  }
+
+  //node internal interface
+  def demonitor(monitoring: Pid, monitored: Any, ref: Reference) {
+    log.debug("demonitor %s -> %s (%s)", monitoring, monitored, ref)
+    for (p <- process(monitored)) {
+      p.demonitor(ref)
+    }
+  }
+
+  def monitorExit(monitor: Monitor, reason: Any) {
+    val monitoring = monitor.monitoring
+    val monitored = monitor.monitored
+    val ref = monitor.ref
+    log.debug("handling monitor exit for %s", monitor)
+    if (isLocal(monitoring)) {
+      log.debug("monitoring is local %s", monitoring)
+      for (proc <- process(monitoring)) {
+        proc.handleMonitorExit(monitored, ref, reason)
+      }
+    } else {
+      getOrConnectAndSend(monitoring.node, MonitorExitMessage(monitored, monitoring, ref, reason))
+    }
+  }
+
+  def remoteMonitorExit(monitor: Monitor, reason: Any) {
+    val monitoring = monitor.monitoring
+    val monitored = monitor.monitored
+    val ref = monitor.ref
+    for (proc <- process(monitoring)) {
+      proc.monitors.remove(monitor)
+      proc.handleMonitorExit(monitored, ref, reason)
+    }
+  }
+
+  def send(to: Pid, msg: Any) = handleSend(to, msg)
+  def send(to: Symbol, msg: Any) = handleSend(to, msg)
+  def send(to: (Symbol, Symbol), from: Pid, msg: Any) = handleSend(to, from, msg)
+
+  def call(to: Pid, msg: Any): Any = call(createPid, to, msg)
+  def call(to: Pid, msg: Any, timeout: Long): Any = call(createPid, to, msg, timeout)
+  def call(from: Pid, to: Pid, msg: Any): Any = call(from, to, msg, Long.MaxValue)
+  def call(from: Pid, to: Pid, msg: Any, timeout: Long): Any = {
+    val (ref, c) = makeCall(from, msg)
+    val channel = makeReplyChannel(from, ref)
+    send(to, c)
+    waitReply(from, ref, channel, timeout)
+  }
+
+  def call(to: Symbol, msg: Any): Any = call(createPid, to, msg)
+  def call(to: Symbol, msg: Any, timeout: Long): Any = call(createPid, to, msg, timeout)
+  def call(from: Pid, to: Symbol, msg: Any): Any = call(from, to, msg, Long.MaxValue)
+  def call(from: Pid, to: Symbol, msg: Any, timeout: Long): Any = {
+    val (ref, c) = makeCall(from, msg)
+    val channel = makeReplyChannel(from, ref)
+    send(to, c)
+    waitReply(from, ref, channel, timeout)
+  }
+
+  def call(to: (Symbol, Symbol), msg: Any) = call(createPid, to, msg)
+  def call(to: (Symbol, Symbol), msg: Any, timeout: Long) = call(createPid, to, msg, timeout)
+  def call(from: Pid, to: (Symbol, Symbol), msg: Any) = call(from, to, msg, Long.MaxValue)
+  def call(from: Pid, to: (Symbol, Symbol), msg: Any, timeout: Long): Any = {
+    val (ref, c) = makeCall(from, msg)
+    val channel = makeReplyChannel(from, ref)
+    send(to, from, c)
+    waitReply(from, ref, channel, timeout)
+  }
+
+  def cast(to: Pid, msg: Any) = send(to, (Symbol("$gen_cast"), msg))
+  def cast(to: Symbol, msg: Any) = send(to, (Symbol("$gen_cast"), msg))
+  def cast(to: (Symbol, Symbol), msg: Any) = send(to, createPid, (Symbol("$gen_cast"), msg))
+
+  def makeReplyChannel(pid: Pid, ref: Reference): BlockingQueue[Any] = {
+    val queue = new LinkedBlockingQueue[Any]
+    registerReplyQueue(pid, ref, queue)
+    queue
+  }
+
+  def waitReply(from: Pid, ref: Reference, channel: BlockingQueue[Any], timeout: Long): Any = {
+    channel.poll(timeout, TimeUnit.MILLISECONDS) match {
+      case null =>
+
+        /*        removeReplyQueue(from,ref)*/
+        /*        ignoreRef(ref)*/
+        ('error, 'timeout)
+      case response =>
+        response
+    }
+  }
+
+  def makeCall(from: Pid, msg: Any): (Reference, Any) = {
+    val ref = makeRef
+    val call = (Symbol("$gen_call"), (from, ref), msg)
+    (ref, call)
+  }
+
+  def handleSend(to: Pid, msg: Any) {
+    log.debug("send %s to %s", msg, to)
+    if (!tryDeliverReply(to, msg)) {
+      if (isLocal(to)) {
+        val process = processes.get(to)
+        log.debug("send local to %s", process)
+        if (process != null) {
+          process.handleMessage(msg)
+        }
+      } else {
+        log.debug("send remote to %s", to.node)
+        try {
+          getOrConnectAndSend(to.node, SendMessage(to, msg))
+        } catch {
+          case e: Exception =>
+            log.warn(e, "trouble sending message to %s", to.node)
+        }
+      }
+    }
+  }
+
+  def handleSend(to: Symbol, msg: Any) {
+    for (pid <- whereis(to)) {
+      handleSend(pid, msg)
+    }
+  }
+
+  def makeRef: Reference = {
+    referenceCounter.makeRef
+  }
+
+  def handleSend(dest: (Symbol, Symbol), from: Pid, msg: Any) {
+    val (regName, peer) = dest
+    try {
+      getOrConnectAndSend(peer, RegSend(from, regName, msg))
+    } catch {
+      case e: Exception =>
+        log.warn(e, "trouble sending message to %s", peer)
+    }
+  }
+
+  def handleExit(from: Pid, reason: Any) {
+    Option(processes.get(from)) match {
+      case Some(pf: Process) =>
+        val fiber = pf.fiber
+        fiber.dispose
+      case _ =>
+        Unit
+    }
+    processes.remove(from)
+  }
+
+  //this only gets called from a remote link breakage()
+  def remoteBreak(link: Link, reason: Any) {
+
+    val from = link.from
+    val to = link.to
+    for (proc <- process(to)) {
+      proc.links.remove(link)
+      proc.handleExit(from, reason)
+    }
+    for (proc <- process(from)) {
+      proc.links.remove(link)
+      proc.handleExit(to, reason)
+    }
+  }
+
+  //this will only get called from a local link breakage (process exit)
+  def break(link: Link, reason: Any) {
+    val from = link.from
+    val to = link.to
+    if (isLocal(to)) {
+      for (proc <- process(to)) {
+        proc.handleExit(from, reason)
+      }
+    } else {
+      getOrConnectAndSend(to.node, ExitMessage(from, to, reason))
+    }
+    if (isLocal(from)) {
+      for (proc <- process(from)) {
+        proc.handleExit(to, reason)
+      }
+    } else {
+      getOrConnectAndSend(from.node, ExitMessage(to, from, reason))
+    }
+  }
+
+  def process(pidOrProc: Any): Option[ProcessAdapter] = pidOrProc match {
+    case pid: Pid =>
+      Option(processes.get(pid))
+    case regName: Symbol =>
+      whereis(regName) match {
+        case Some(pid: Pid) =>
+          process(pid)
+        case None =>
+          None
+      }
+    case (regname: Symbol, node: Symbol) =>
+      None
+  }
+
+  def unlink(from: Pid, to: Pid) {
+    for (p <- process(from)) {
+      p.unlink(to)
+    }
+
+    for (p <- process(to)) {
+      p.unlink(from)
+    }
+  }
+
+  def isLocal(pidOrProc: Any): Boolean = pidOrProc match {
+    case pid: Pid =>
+      pid.node == name
+    case regName: Symbol =>
+      true
+    case (regName: Symbol, node: Symbol) =>
+      node == name
+  }
+
+  def nodeOf(pidOrProc: Any): Symbol = pidOrProc match {
+    case pid: Pid =>
+      pid.node
+    case regName: Symbol =>
+      name
+    case (regName: Symbol, node: Symbol) =>
+      node
+  }
+
+  def disconnected(peer: Symbol, channel: Channel) {
+    if (channels.containsKey(peer)) {
+      channels.remove(peer)
+      //must break all links here
+      if (links.contains(channel)) {
+        val setOption = links.remove(channel)
+        for (set <- setOption; link <- set) {
+          remoteBreak(link, 'noconnection)
+        }
+      }
+      //must send all monitor exits too
+      if (monitors.contains(channel)) {
+        val setOption = monitors.remove(channel)
+        for (set <- setOption; monitor <- set) {
+          remoteMonitorExit(monitor, 'noconnection)
+        }
+      }
+    }
+  }
+
+  def getOrConnectAndSend(peer: Symbol, msg: Any, afterHandshake: Channel => Unit = { channel => Unit }) {
+    log.debug("node %s sending %s", this, msg)
+    val channel = channels.getOrElseUpdate(peer, {
+      connectAndSend(peer, None)
+    })
+    channel.write(msg)
+
+    /*    if (channel.isOpen) {
+      channel.write(msg)
+    } else {
+      channels.remove(peer, channel)
+      channel.close()
+      channels.getOrElseUpdate(peer, { connectAndSend(peer, None) }).write(msg)
+    }
+*/
+    afterHandshake(channel)
+  }
+
+  def connectAndSend(peer: Symbol, msg: Option[Any] = None, afterHandshake: Channel => Unit = { _ => Unit }): Channel = {
+    val hostname = splitHostname(peer).getOrElse(throw new ErlangNodeException("Cannot resolve peer with no hostname: " + peer.name))
+    val peerName = splitNodename(peer)
+    val port = Epmd(hostname).lookupPort(peerName).getOrElse(throw new ErlangNodeException("Cannot lookup peer: " + peer.name))
+    val client = new ErlangNodeClient(this, peer, hostname, port, msg, config.typeFactory,
+      config.typeEncoder, config.typeDecoder, afterHandshake)
+    client.channel
+  }
+
+  def posthandshake: (Symbol, ChannelPipeline) => Unit = {
+    { (peer: Symbol, p: ChannelPipeline) =>
+      p.addFirst("packetCounter", new PacketCounter("stream-" + peer.name))
+      if (p.get("encoderFramer") != null)
+        p.addAfter("encoderFramer", "framedCounter", new PacketCounter("framed-" + peer.name))
+      if (p.get("erlangEncoder") != null)
+        p.addAfter("erlangEncoder", "erlangCounter", new PacketCounter("erlang-" + peer.name))
+      p.addAfter("erlangCounter", "failureDetector", new FailureDetectionHandler(name, new SystemClock, tickTime, timer))
+    }
+  }
+
+  def splitNodename(peer: Symbol): String = {
+    val parts = peer.name.split('@')
+    if (parts.length < 2) {
+      peer.name
+    } else {
+      parts(0)
+    }
+  }
+
+  def splitHostname(peer: Symbol): Option[String] = {
+    val parts = peer.name.split('@')
+    if (parts.length < 2) {
+      None
+    } else {
+      Some(parts(1))
+    }
+  }
+
+  def isAlive(pidOrProc: Any): Boolean = {
+    process(pidOrProc) match {
+      case Some(_) => true
+      case None => false
+    }
+  }
+}
+
+class ErlangNodeException(msg: String) extends Exception(msg)

--- a/src/main/scala/scalang/NodeConfig.scala
+++ b/src/main/scala/scalang/NodeConfig.scala
@@ -1,0 +1,41 @@
+//
+// Copyright 2011, Boundary
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+package scalang
+
+import util._
+import org.jboss.netty.buffer.ChannelBuffer
+
+case class NodeConfig(
+  poolFactory: ThreadPoolFactory = new DefaultThreadPoolFactory,
+  clusterListener: Option[ClusterListener] = None,
+  typeFactory: TypeFactory = NoneTypeFactory,
+  typeEncoder: TypeEncoder = NoneTypeEncoder,
+  typeDecoder: TypeDecoder = NoneTypeDecoder,
+  tickTime: Int = 60)
+
+object NoneTypeFactory extends TypeFactory {
+  def createType(name: Symbol, arity: Int, reader: TermReader) = None
+}
+
+object NoneTypeEncoder extends TypeEncoder {
+  def unapply(obj: Any) = { None }
+  def encode(obj: Any, buffer: ChannelBuffer) {}
+}
+
+object NoneTypeDecoder extends TypeDecoder {
+  def unapply(typeOrdinal: Int): Option[Int] = { None }
+  def decode(typeOrdinal: Int, buffer: ChannelBuffer): Any = {}
+}

--- a/src/main/scala/scalang/Pid.scala
+++ b/src/main/scala/scalang/Pid.scala
@@ -1,0 +1,23 @@
+//
+// Copyright 2011, Boundary
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+package scalang
+
+case class Pid(node: Symbol, id: Int, serial: Int, creation: Int) {
+
+  def toErlangString: String = {
+    "<" + id + "." + serial + "." + creation + ">"
+  }
+}

--- a/src/main/scala/scalang/Port.scala
+++ b/src/main/scala/scalang/Port.scala
@@ -1,0 +1,18 @@
+//
+// Copyright 2011, Boundary
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+package scalang
+
+case class Port(node: Symbol, id: Int, creation: Int)

--- a/src/main/scala/scalang/Process.scala
+++ b/src/main/scala/scalang/Process.scala
@@ -1,0 +1,89 @@
+//
+// Copyright 2011, Boundary
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+package scalang
+
+import scalang.node.ProcessLike
+import scala._
+import com.boundary.logula.Logging
+
+abstract class Process(ctx: ProcessContext) extends ProcessLike with Logging {
+  val self = ctx.pid
+  val adapter = ctx.adapter
+  val referenceCounter = ctx.referenceCounter
+  val replyRegistry = ctx.replyRegistry
+  val node = ctx.node
+
+  implicit def pid2sendable(pid: Pid) = new PidSend(pid, this)
+  implicit def sym2sendable(to: Symbol) = new SymSend(to, this)
+  implicit def dest2sendable(dest: (Symbol, Symbol)) = new DestSend(dest, self, this)
+
+  def sendEvery(pid: Pid, msg: Any, delay: Long) = adapter.sendEvery(pid, msg, delay)
+  def sendEvery(name: Symbol, msg: Any, delay: Long) = adapter.sendEvery(name, msg, delay)
+  def sendEvery(name: (Symbol, Symbol), msg: Any, delay: Long) = adapter.sendEvery(name, msg, delay)
+
+  def sendAfter(pid: Pid, msg: Any, delay: Long) = adapter.sendAfter(pid, msg, delay)
+  def sendAfter(name: Symbol, msg: Any, delay: Long) = adapter.sendAfter(name, msg, delay)
+  def sendAfter(dest: (Symbol, Symbol), msg: Any, delay: Long) = adapter.sendAfter(dest, msg, delay)
+
+  override def handleMessage(msg: Any) {
+    onMessage(msg)
+  }
+
+  override def handleExit(from: Pid, msg: Any) {
+    trapExit(from, msg)
+  }
+
+  /**
+   * Subclasses should override this method with their own message handlers
+   */
+  def onMessage(msg: Any)
+
+  /**
+   * Subclasses wishing to trap exits should override this method.
+   */
+  def trapExit(from: Pid, msg: Any) {
+    exit(msg)
+  }
+
+  def handleMonitorExit(monitored: Any, ref: Reference, reason: Any) {
+    trapMonitorExit(monitored, ref, reason)
+  }
+
+  /**
+   * Subclasses wishing to trap monitor exits should override this method.
+   */
+  def trapMonitorExit(monitored: Any, ref: Reference, reason: Any) {
+  }
+
+}
+
+class PidSend(to: Pid, proc: Process) {
+  def !(msg: Any) {
+    proc.adapter.notifySend(to, msg)
+  }
+}
+
+class SymSend(to: Symbol, proc: Process) {
+  def !(msg: Any) {
+    proc.adapter.notifySend(to, msg)
+  }
+}
+
+class DestSend(to: (Symbol, Symbol), from: Pid, proc: Process) {
+  def !(msg: Any) {
+    proc.adapter.notifySend(to, from, msg)
+  }
+}

--- a/src/main/scala/scalang/ProcessContext.scala
+++ b/src/main/scala/scalang/ProcessContext.scala
@@ -1,0 +1,28 @@
+//
+// Copyright 2011, Boundary
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+package scalang
+
+import scalang.node._
+import org.jetlang.fibers._
+
+trait ProcessContext {
+  def pid: Pid
+  def node: ErlangNode
+  def referenceCounter: ReferenceCounter
+  def fiber: Fiber
+  def replyRegistry: ReplyRegistry
+  var adapter: ProcessAdapter
+}

--- a/src/main/scala/scalang/Reference.scala
+++ b/src/main/scala/scalang/Reference.scala
@@ -1,0 +1,18 @@
+//
+// Copyright 2011, Boundary
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+package scalang
+
+case class Reference(node: Symbol, id: Seq[Int], creation: Int)

--- a/src/main/scala/scalang/ReplyRegistry.scala
+++ b/src/main/scala/scalang/ReplyRegistry.scala
@@ -1,0 +1,46 @@
+//
+// Copyright 2011, Boundary
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+package scalang
+
+import java.util.concurrent.BlockingQueue
+import org.jctools.maps.NonBlockingHashMap
+
+trait ReplyRegistry {
+  val replyWaiters = new NonBlockingHashMap[(Pid, Reference), BlockingQueue[Any]]
+
+  /**
+   * Returns true if the reply delivery succeeded. False otherwise.
+   */
+  def tryDeliverReply(pid: Pid, msg: Any) = msg match {
+    case (tag: Reference, reply: Any) =>
+      val waiter = replyWaiters.remove((pid, tag))
+      if (waiter == null) {
+        false
+      } else {
+        waiter.offer(reply)
+        true
+      }
+    case _ => false
+  }
+
+  def removeReplyQueue(pid: Pid, ref: Reference) {
+    replyWaiters.remove((pid, ref))
+  }
+
+  def registerReplyQueue(pid: Pid, tag: Reference, queue: BlockingQueue[Any]) {
+    replyWaiters.put((pid, tag), queue)
+  }
+}

--- a/src/main/scala/scalang/Service.scala
+++ b/src/main/scala/scalang/Service.scala
@@ -1,0 +1,87 @@
+//
+// Copyright 2011, Boundary
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+package scalang
+
+import node._
+import org.jetlang._
+import channels._
+import core._
+import fibers._
+import java.util.concurrent.{ LinkedBlockingQueue, TimeUnit }
+
+/**
+ * Service is a class that provides a responder in the shape expected
+ * by gen_lb.  A service may define handlers for either cast, call, or both.
+ */
+abstract class Service[A <: Product](ctx: ServiceContext[A]) extends Process(ctx) {
+  /**
+   * Init callback for any context that the service might need.
+   */
+  /*  def init(args : Any) {
+    // noop
+  }
+*/
+  /**
+   * Handle a call style of message which will expect a response.
+   */
+  def handleCall(tag: (Pid, Any), request: Any): Any = {
+    throw new Exception(getClass + " did not define a call handler.")
+  }
+
+  /**
+   * Handle a cast style of message which will receive no response.
+   */
+  def handleCast(request: Any) {
+    throw new Exception(getClass + " did not define a cast handler.")
+  }
+
+  /**
+   * Handle any messages that do not fit the call or cast pattern.
+   */
+  def handleInfo(request: Any) {
+    throw new Exception(getClass + " did not define an info handler.")
+  }
+
+  override def onMessage(msg: Any) = msg match {
+    case ('ping, from: Pid, ref: Reference) =>
+      from ! ('pong, ref)
+    case (Symbol("$gen_call"), (from: Pid, ref: Any), request: Any) =>
+      handleCall((from, ref), request) match {
+        case ('reply, reply) =>
+          from ! (ref, reply)
+        case 'noreply =>
+          Unit
+        case reply =>
+          from ! (ref, reply)
+      }
+    case (Symbol("$gen_cast"), request: Any) =>
+      handleCast(request)
+    case _ =>
+      handleInfo(msg)
+  }
+
+  def call(to: Pid, msg: Any): Any = node.call(self, to, msg)
+  def call(to: Pid, msg: Any, timeout: Long): Any = node.call(self, to, msg, timeout)
+  def call(to: Symbol, msg: Any): Any = node.call(self, to, msg)
+  def call(to: Symbol, msg: Any, timeout: Long): Any = node.call(self, to, msg, timeout)
+  def call(to: (Symbol, Symbol), msg: Any): Any = node.call(self, to, msg)
+  def call(to: (Symbol, Symbol), msg: Any, timeout: Long): Any = node.call(self, to, msg, timeout)
+
+  def cast(to: Pid, msg: Any) = node.cast(to, msg)
+  def cast(to: Symbol, msg: Any) = node.cast(to, msg)
+  def cast(to: (Symbol, Symbol), msg: Any) = node.cast(to, msg)
+
+}

--- a/src/main/scala/scalang/ServiceContext.scala
+++ b/src/main/scala/scalang/ServiceContext.scala
@@ -1,0 +1,9 @@
+package scalang
+
+trait ServiceContext[A <: Product] extends ProcessContext {
+  def args: A
+}
+
+case class NoArgs()
+
+object NoArgs extends NoArgs

--- a/src/main/scala/scalang/TypeFactory.scala
+++ b/src/main/scala/scalang/TypeFactory.scala
@@ -1,0 +1,57 @@
+//
+// Copyright 2011, Boundary
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+package scalang
+
+import node._
+import org.jboss.netty.buffer.ChannelBuffer
+
+trait TypeFactory {
+  def createType(name: Symbol, arity: Int, reader: TermReader): Option[Any]
+}
+
+trait TypeEncoder {
+  def unapply(obj: Any): Option[Any]
+
+  def encode(obj: Any, buffer: ChannelBuffer)
+}
+
+trait TypeDecoder {
+  def unapply(typeOrdinal: Int): Option[Int]
+
+  def decode(typeOrdinal: Int, buffer: ChannelBuffer): Any
+}
+
+class TermReader(val buffer: ChannelBuffer, decoder: ScalaTermDecoder) {
+  var m: Int = 0
+
+  def mark: TermReader = {
+    m = buffer.readerIndex
+    this
+  }
+
+  def reset: TermReader = {
+    buffer.readerIndex(m)
+    this
+  }
+
+  def readTerm: Any = {
+    decoder.readTerm(buffer)
+  }
+
+  def readAs[A]: A = {
+    readTerm.asInstanceOf[A]
+  }
+}

--- a/src/main/scala/scalang/epmd/Epmd.scala
+++ b/src/main/scala/scalang/epmd/Epmd.scala
@@ -1,0 +1,95 @@
+//
+// Copyright 2011, Boundary
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+package scalang.epmd
+
+import java.net._
+import org.jboss.{ netty => netty }
+import netty.bootstrap._
+import netty.channel._
+import socket.nio._
+import overlock.threadpool._
+import java.util.concurrent.Callable
+
+object Epmd {
+  val defaultPort = 4369
+  lazy val bossPool = ThreadPool.instrumentedFixed("scalang.epmd", "boss", 20)
+  lazy val workerPool = ThreadPool.instrumentedFixed("scalang.epmd", "worker", 20)
+
+  def apply(host: String): Epmd = {
+    val port = Option(System.getenv("ERL_EPMD_PORT")).map(_.toInt).getOrElse(defaultPort)
+    new Epmd(host, port)
+  }
+
+  def apply(host: String, port: Int): Epmd = {
+    new Epmd(host, port)
+  }
+}
+
+class Epmd(val host: String, val port: Int) {
+  val bootstrap = new ClientBootstrap(
+    new NioClientSocketChannelFactory(
+      Epmd.bossPool,
+      Epmd.workerPool))
+
+  val handler = new EpmdHandler
+
+  bootstrap.setPipelineFactory(new ChannelPipelineFactory {
+    def getPipeline: ChannelPipeline = {
+      Channels.pipeline(
+        new EpmdEncoder,
+        new EpmdDecoder,
+        handler)
+    }
+  })
+
+  val connectFuture = bootstrap.connect(new InetSocketAddress(host, port))
+  val channel = connectFuture.awaitUninterruptibly.getChannel
+  if (!connectFuture.isSuccess) {
+    throw connectFuture.getCause
+  }
+
+  def close {
+    channel.close
+  }
+
+  def alive(portNo: Int, nodeName: String): Option[Int] = {
+    var response: Callable[Any] = null
+    handler.synchronized {
+      response = handler.response
+      channel.write(AliveReq(portNo, nodeName))
+    }
+    val aliveResponse = response.call.asInstanceOf[AliveResp]
+    if (aliveResponse.result == 0) {
+      Some(aliveResponse.creation)
+    } else {
+      sys.error("Epmd response was: " + aliveResponse.result)
+      None
+    }
+  }
+
+  def lookupPort(nodeName: String): Option[Int] = {
+    var response: Callable[Any] = null
+    handler.synchronized {
+      response = handler.response
+      channel.write(PortPleaseReq(nodeName))
+    }
+    response.call match {
+      case PortPleaseResp(portNo, _) => Some(portNo)
+      case PortPleaseError(_) => None
+    }
+  }
+}
+

--- a/src/main/scala/scalang/epmd/EpmdDecoder.scala
+++ b/src/main/scala/scalang/epmd/EpmdDecoder.scala
@@ -1,0 +1,60 @@
+//
+// Copyright 2011, Boundary
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+package scalang.epmd
+
+import org.jboss.{ netty => netty }
+import netty.buffer._
+import netty.channel._
+import netty.handler.codec.frame._
+
+class EpmdDecoder extends FrameDecoder {
+  override def decode(ctx: ChannelHandlerContext, channel: Channel, buffer: ChannelBuffer): Object = {
+    if (buffer.readableBytes < 1) return null
+    val header = buffer.getByte(0)
+    header match {
+      case 118 => //decode alive2 resp
+        if (buffer.readableBytes < 4) return null
+        val result = buffer.getByte(1)
+        val creation = buffer.getInt(2)
+        buffer.skipBytes(4)
+        AliveResp(result, creation)
+      case 121 => //decode alive2 resp
+        if (buffer.readableBytes < 4) return null
+        val result = buffer.getByte(1)
+        val creation = buffer.getUnsignedShort(2)
+        buffer.skipBytes(4)
+        AliveResp(result, creation)
+      case 119 => //decode port2 resp
+        val result = buffer.getByte(1)
+        if (result > 0) {
+          buffer.skipBytes(2)
+          PortPleaseError(result)
+        } else {
+          if (buffer.readableBytes < 12) return null
+          val nlen = buffer.getUnsignedShort(10)
+          if (buffer.readableBytes < (14 + nlen)) return null
+          val elen = buffer.getUnsignedShort(12 + nlen)
+          if (buffer.readableBytes < (14 + nlen + elen)) return null
+          val portNo = buffer.getUnsignedShort(2)
+          val bytes = new Array[Byte](nlen)
+          buffer.getBytes(12, bytes)
+          val nodeName = new String(bytes)
+          buffer.skipBytes(14 + nlen + elen)
+          PortPleaseResp(portNo, nodeName)
+        }
+    }
+  }
+}

--- a/src/main/scala/scalang/epmd/EpmdEncoder.scala
+++ b/src/main/scala/scalang/epmd/EpmdEncoder.scala
@@ -1,0 +1,54 @@
+//
+// Copyright 2011, Boundary
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+package scalang.epmd
+
+import org.jboss.{ netty => netty }
+import netty.buffer._
+import netty.channel._
+import netty.handler.codec.oneone._
+
+object EpmdConst {
+  val ntypeR6 = 110
+  val ntypeR4Erlang = 109
+  val ntypeR4Hidden = 104
+}
+
+class EpmdEncoder extends OneToOneEncoder {
+  import EpmdConst._
+
+  override def encode(ctx: ChannelHandlerContext, channel: Channel, msg: Object): Object = {
+    val bout = new ChannelBufferOutputStream(ChannelBuffers.dynamicBuffer(24, ctx.getChannel.getConfig.getBufferFactory))
+    bout.writeShort(0) //length placeholder
+    msg match {
+      case AliveReq(portNo, nodeName) =>
+        bout.writeByte(120)
+        bout.writeShort(portNo)
+        bout.writeByte(ntypeR6) //node type
+        bout.writeByte(0) //protocol
+        bout.writeShort(5) // highest version
+        bout.writeShort(5) // lowest version
+        bout.writeShort(nodeName.size) // name length
+        bout.writeBytes(nodeName) // name
+        bout.writeShort(0) //extra len
+      case PortPleaseReq(nodeName) =>
+        bout.writeByte(122)
+        bout.writeBytes(nodeName)
+    }
+    val encoded = bout.buffer
+    encoded.setShort(0, encoded.writerIndex - 2)
+    encoded
+  }
+}

--- a/src/main/scala/scalang/epmd/EpmdHandler.scala
+++ b/src/main/scala/scalang/epmd/EpmdHandler.scala
@@ -1,0 +1,88 @@
+//
+// Copyright 2011, Boundary
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+package scalang.epmd
+
+import java.util.concurrent.{ ConcurrentLinkedQueue, Callable, CountDownLatch, atomic => atomic }
+import atomic._
+import org.jboss.{ netty => netty }
+import netty.channel._
+import java.util.concurrent.TimeUnit
+import com.boundary.logula.Logging
+
+class EpmdHandler extends SimpleChannelUpstreamHandler with Logging {
+  val queue = new ConcurrentLinkedQueue[EpmdResponse]
+
+  def response: Callable[Any] = {
+    val call = new EpmdResponse
+    queue.add(call)
+    call
+  }
+
+  override def channelClosed(ctx: ChannelHandlerContext, e: ChannelStateEvent) {
+    log.debug("Oh snap channel closed.")
+  }
+
+  override def channelDisconnected(ctx: ChannelHandlerContext, e: ChannelStateEvent) {
+    log.debug("Uh oh disconnect.")
+  }
+
+  override def exceptionCaught(ctx: ChannelHandlerContext, e: ExceptionEvent) {
+    var rsp = queue.poll
+    while (rsp != null) {
+      rsp.setError(e.getCause)
+      rsp = queue.poll
+    }
+  }
+
+  override def messageReceived(ctx: ChannelHandlerContext, e: MessageEvent) {
+    val response = e.getMessage
+    val rsp = queue.poll()
+    if (rsp != null) {
+      rsp.set(response)
+    } else {
+      log.warn("Unable to find EpmdResponse for: %s", response)
+    }
+  }
+
+  class EpmdResponse extends Callable[Any] {
+    val response = new AtomicReference[Any]
+    val error = new AtomicReference[Throwable]
+    val lock = new CountDownLatch(1)
+
+    def setError(t: Throwable) {
+      error.set(t)
+      lock.countDown()
+
+    }
+
+    def set(v: Any) {
+      response.set(v)
+      lock.countDown()
+    }
+
+    def call: Any = {
+      if (lock.await(5000, TimeUnit.MILLISECONDS)) {
+        if (error.get != null) {
+          throw new Exception("EPMD Registration failed.", error.get)
+        } else {
+          response.get
+        }
+      } else {
+        throw new Exception("EPMD Registration timed out.")
+      }
+    }
+  }
+}

--- a/src/main/scala/scalang/epmd/EpmdMessages.scala
+++ b/src/main/scala/scalang/epmd/EpmdMessages.scala
@@ -1,0 +1,26 @@
+//
+// Copyright 2011, Boundary
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+package scalang.epmd
+
+case class AliveReq(portNo: Int, nodeName: String)
+
+case class AliveResp(result: Int, creation: Int)
+
+case class PortPleaseReq(nodeName: String)
+
+case class PortPleaseError(result: Int)
+
+case class PortPleaseResp(portNo: Int, nodeName: String)

--- a/src/main/scala/scalang/node/CaseClassFactory.scala
+++ b/src/main/scala/scalang/node/CaseClassFactory.scala
@@ -1,0 +1,100 @@
+//
+// Copyright 2011, Boundary
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+package scalang.node
+
+import scalang._
+import overlock.atomicmap._
+import scalang.util.UnderToCamel._
+
+class CaseClassFactory(searchPrefixes: Seq[String], typeMappings: Map[String, Class[_]]) extends TypeFactory {
+  //it's important to cache the negative side as well
+  val classCache = AtomicMap.atomicNBHM[String, Option[Class[_]]]
+
+  def createType(name: Symbol, arity: Int, reader: TermReader): Option[Any] = {
+    classCache.getOrElseUpdate(name.name, lookupClass(name.name)).flatMap { clazz =>
+      tryCreateInstance(reader, clazz, arity)
+    }
+  }
+
+  /**
+   * Arity is the length of the tuple after the header
+   */
+  protected def tryCreateInstance(reader: TermReader, clazz: Class[_], arity: Int): Option[Any] = {
+    val candidates = for (constructor <- clazz.getConstructors if constructor.getParameterTypes.length == arity - 1) yield { constructor }
+    if (candidates.isEmpty) return None
+    reader.mark
+    val parameters = for (i <- (1 until arity)) yield { reader.readTerm }
+    val classes = parameters.map {
+      case param: AnyRef =>
+        param.getClass
+    }
+    candidates.find { constructor =>
+      val params = constructor.getParameterTypes
+      boxEquals(classes.toList, params.toList)
+    }.flatMap { constructor =>
+      try {
+        Some(constructor.newInstance(parameters.asInstanceOf[Seq[Object]]: _*))
+      } catch {
+        case _ => None
+      }
+    }.orElse {
+      reader.reset
+      None
+    }
+  }
+
+  protected def boxEquals(a: List[Class[_]], b: List[Class[_]]): Boolean = {
+    def scrubPrimitive(a: Class[_]): Class[_] = a match {
+      case java.lang.Byte.TYPE => classOf[java.lang.Byte]
+      case java.lang.Short.TYPE => classOf[java.lang.Short]
+      case java.lang.Integer.TYPE => classOf[java.lang.Integer]
+      case java.lang.Long.TYPE => classOf[java.lang.Long]
+      case java.lang.Boolean.TYPE => classOf[java.lang.Boolean]
+      case java.lang.Character.TYPE => classOf[java.lang.Character]
+      case java.lang.Float.TYPE => classOf[java.lang.Float]
+      case java.lang.Double.TYPE => classOf[java.lang.Double]
+      case x => x
+    }
+
+    (a, b) match {
+      case (classA :: tailA, classB :: tailB) =>
+        if (!(scrubPrimitive(classA) == scrubPrimitive(classB))) {
+          return false
+        }
+        boxEquals(tailA, tailB)
+      case (Nil, Nil) => true
+      case _ => false
+    }
+
+  }
+
+  protected def lookupClass(name: String): Option[Class[_]] = {
+    typeMappings.get(name) match {
+      case Some(c) => Some(c)
+      case None =>
+        for (prefix <- searchPrefixes) {
+          try {
+            return Some(Class.forName(prefix + "." + name.underToCamel))
+          } catch {
+            case e: Exception =>
+              e.printStackTrace
+              Unit
+          }
+        }
+        None
+    }
+  }
+}

--- a/src/main/scala/scalang/node/ClientHandshakeHandler.scala
+++ b/src/main/scala/scalang/node/ClientHandshakeHandler.scala
@@ -1,0 +1,102 @@
+//
+// Copyright 2011, Boundary
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+package scalang.node
+
+import java.net._
+import java.util.concurrent._
+import atomic._
+import org.jboss.{ netty => netty }
+import netty.bootstrap._
+import netty.channel._
+import netty.handler.codec.frame._
+import scalang._
+import util._
+import java.util.ArrayDeque
+import scala.annotation._
+import scala.math._
+import scala.collection.JavaConversions._
+import java.security.{ SecureRandom, MessageDigest }
+
+class ClientHandshakeHandler(name: Symbol, cookie: String, creation: Int, posthandshake: (Symbol, ChannelPipeline) => Unit) extends HandshakeHandler(posthandshake) {
+  states(
+    state('disconnected, {
+      case ConnectedMessage =>
+        sendName
+        'connected
+    }),
+
+    state('connected, {
+      case StatusMessage("ok") =>
+        'status_ok
+      case StatusMessage("ok_simultaneous") =>
+        'status_ok
+      case StatusMessage("alive") => //means the other node sees another conn from us. reconnecting too quick.
+        sendStatus("true")
+        'status_ok
+      case StatusMessage(status) =>
+        throw new ErlangAuthException("Bad status message: " + status)
+    }),
+
+    state('status_ok, {
+      case ChallengeMessage(flags, challenge, creation, name) =>
+        peer = Symbol(name)
+        sendChallengeReply(challenge)
+        'reply_sent
+    }),
+
+    state('reply_sent, {
+      case ChallengeAckMessage(digest) =>
+        verifyChallengeAck(digest)
+        drainQueue
+        handshakeSucceeded
+        'verified
+    }),
+
+    state('verified, {
+      case _ => 'verified
+    }))
+
+  protected def sendStatus(st: String) {
+    val channel = ctx.getChannel
+    val future = Channels.future(channel)
+    val msg = StatusMessage(st)
+    ctx.sendDownstream(new DownstreamMessageEvent(channel, future, msg, null))
+  }
+
+  protected def sendName {
+    val channel = ctx.getChannel
+    val future = Channels.future(channel)
+    val msg = NameMessage(DistributionFlags.default, creation, name.name)
+    ctx.sendDownstream(new DownstreamMessageEvent(channel, future, msg, null))
+  }
+
+  protected def sendChallengeReply(c: Int) {
+    val channel = ctx.getChannel
+    val future = Channels.future(channel)
+    this.peerChallenge = c
+    this.challenge = random.nextInt
+    val d = digest(peerChallenge, cookie)
+    val msg = ChallengeReplyMessage(challenge, d)
+    ctx.sendDownstream(new DownstreamMessageEvent(channel, future, msg, null))
+  }
+
+  protected def verifyChallengeAck(peerDigest: Array[Byte]) {
+    val ourDigest = digest(challenge, cookie)
+    if (!digestEquals(ourDigest, peerDigest)) {
+      throw new ErlangAuthException("Peer authentication error.")
+    }
+  }
+}

--- a/src/main/scala/scalang/node/Clock.scala
+++ b/src/main/scala/scalang/node/Clock.scala
@@ -1,0 +1,9 @@
+package scalang.node
+
+trait Clock {
+  def currentTimeMillis: Long
+}
+
+class SystemClock extends Clock {
+  override def currentTimeMillis = System.currentTimeMillis
+}

--- a/src/main/scala/scalang/node/ErlangHandler.scala
+++ b/src/main/scala/scalang/node/ErlangHandler.scala
@@ -1,0 +1,76 @@
+//
+// Copyright 2011, Boundary
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+package scalang.node
+
+import org.jboss.netty._
+import channel._
+import scalang._
+import com.boundary.logula.Logging
+
+class ErlangHandler(
+    node: ErlangNode,
+    afterHandshake: Channel => Unit = { _ => Unit }) extends SimpleChannelUpstreamHandler with Logging {
+
+  @volatile var peer: Symbol = null
+
+  override def exceptionCaught(ctx: ChannelHandlerContext, e: ExceptionEvent) {
+    log.error(e.getCause, "error caught in erlang handler %s", peer)
+    ctx.getChannel.close
+  }
+
+  override def messageReceived(ctx: ChannelHandlerContext, e: MessageEvent) {
+    val msg = e.getMessage
+    log.debug("handler message %s", msg)
+    msg match {
+      case Tick =>
+        ctx.getChannel.write(Tock) //channel heartbeat for erlang
+      case HandshakeFailed(name) =>
+        //not much we can do here?
+        ctx.getChannel.close
+      case HandshakeSucceeded(name, channel) =>
+        peer = name
+        node.registerConnection(name, channel)
+        afterHandshake(channel)
+      case LinkMessage(from, to) =>
+        log.debug("received link request from %s.", from)
+        node.linkWithoutNotify(from, to, e.getChannel)
+      case SendMessage(to, msg) =>
+        node.handleSend(to, msg)
+      case ExitMessage(from, to, reason) =>
+        node.remoteBreak(Link(from, to), reason)
+      case Exit2Message(from, to, reason) =>
+        node.remoteBreak(Link(from, to), reason)
+      case UnlinkMessage(from, to) =>
+        node.unlink(from, to)
+      case RegSend(from, to, msg) =>
+        node.handleSend(to, msg)
+      case MonitorMessage(monitoring, monitored, ref) =>
+        node.monitorWithoutNotify(monitoring, monitored, ref, e.getChannel)
+      case DemonitorMessage(monitoring, monitored, ref) =>
+        node.demonitor(monitoring, monitored, ref)
+      case MonitorExitMessage(monitored, monitoring, ref, reason) =>
+        node.remoteMonitorExit(Monitor(monitoring, monitored, ref), reason)
+    }
+  }
+
+  override def channelDisconnected(ctx: ChannelHandlerContext, e: ChannelStateEvent) {
+    log.info("channel disconnected %s %s. peer: %s", ctx, e, peer)
+    if (peer != null) {
+      node.disconnected(peer, e.getChannel)
+    }
+  }
+
+}

--- a/src/main/scala/scalang/node/ErlangNodeClient.scala
+++ b/src/main/scala/scalang/node/ErlangNodeClient.scala
@@ -1,0 +1,75 @@
+//
+// Copyright 2011, Boundary
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+package scalang.node
+
+import java.net.InetSocketAddress
+import org.jboss.{ netty => netty }
+import scalang._
+import netty.channel._
+import netty.bootstrap._
+import netty.handler.codec.frame._
+import socket.nio.NioClientSocketChannelFactory
+import com.boundary.logula.Logging
+
+class ErlangNodeClient(
+    node: ErlangNode,
+    peer: Symbol,
+    host: String,
+    port: Int,
+    control: Option[Any],
+    typeFactory: TypeFactory,
+    typeEncoder: TypeEncoder,
+    typeDecoder: TypeDecoder,
+    afterHandshake: Channel => Unit) extends Logging {
+  val bootstrap = new ClientBootstrap(
+    new NioClientSocketChannelFactory(
+      node.poolFactory.createBossPool,
+      node.poolFactory.createWorkerPool))
+  bootstrap.setPipelineFactory(new ChannelPipelineFactory {
+    def getPipeline: ChannelPipeline = {
+      val pipeline = Channels.pipeline
+
+      val handshakeDecoder = new HandshakeDecoder
+      handshakeDecoder.mode = 'challenge //first message on the client side is challenge, not name
+      pipeline.addLast("executionHandler", node.executionHandler)
+      pipeline.addLast("handshakeFramer", new LengthFieldBasedFrameDecoder(Short.MaxValue, 0, 2, 0, 2))
+      pipeline.addLast("handshakeDecoder", handshakeDecoder)
+      pipeline.addLast("handshakeEncoder", new HandshakeEncoder)
+      pipeline.addLast("handshakeHandler", new ClientHandshakeHandler(node.name, node.cookie, node.creation, node.posthandshake))
+      pipeline.addLast("erlangFramer", new LengthFieldBasedFrameDecoder(Int.MaxValue, 0, 4, 0, 4))
+      pipeline.addLast("encoderFramer", new LengthFieldPrepender(4))
+      pipeline.addLast("erlangDecoder", new ScalaTermDecoder(peer, typeFactory, typeDecoder))
+      pipeline.addLast("erlangEncoder", new ScalaTermEncoder(peer, typeEncoder))
+      pipeline.addLast("erlangHandler", new ErlangHandler(node, afterHandshake))
+
+      pipeline
+    }
+  })
+
+  val future = bootstrap.connect(new InetSocketAddress(host, port))
+  val channel = future.getChannel
+  future.addListener(new ChannelFutureListener {
+    def operationComplete(f: ChannelFuture) {
+      if (f.isSuccess) {
+        for (c <- control) {
+          channel.write(c)
+        }
+      } else {
+        node.disconnected(peer, channel)
+      }
+    }
+  })
+}

--- a/src/main/scala/scalang/node/ErlangNodeServer.scala
+++ b/src/main/scala/scalang/node/ErlangNodeServer.scala
@@ -1,0 +1,53 @@
+//
+// Copyright 2011, Boundary
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+package scalang.node
+
+import java.net.InetSocketAddress
+import org.jboss.{ netty => netty }
+import scalang._
+import netty.channel._
+import netty.bootstrap._
+import netty.handler.codec.frame._
+import socket.nio.NioServerSocketChannelFactory
+import com.boundary.logula.Logging
+
+class ErlangNodeServer(node: ErlangNode, typeFactory: TypeFactory, typeEncoder: TypeEncoder,
+                       typeDecoder: TypeDecoder) extends Logging {
+  val bootstrap = new ServerBootstrap(
+    new NioServerSocketChannelFactory(
+      node.poolFactory.createBossPool,
+      node.poolFactory.createWorkerPool))
+  bootstrap.setPipelineFactory(new ChannelPipelineFactory {
+    def getPipeline: ChannelPipeline = {
+      val pipeline = Channels.pipeline
+      pipeline.addLast("executionHandler", node.executionHandler)
+      pipeline.addLast("handshakeFramer", new LengthFieldBasedFrameDecoder(Short.MaxValue, 0, 2, 0, 2))
+      pipeline.addLast("handshakeDecoder", new HandshakeDecoder)
+      pipeline.addLast("handshakeEncoder", new HandshakeEncoder)
+      pipeline.addLast("handshakeHandler", new ServerHandshakeHandler(node.name, node.cookie, node.creation, node.posthandshake))
+      pipeline.addLast("erlangFramer", new LengthFieldBasedFrameDecoder(Int.MaxValue, 0, 4, 0, 4))
+      pipeline.addLast("encoderFramer", new LengthFieldPrepender(4))
+      pipeline.addLast("erlangDecoder", new ScalaTermDecoder('server, typeFactory, typeDecoder))
+      pipeline.addLast("erlangEncoder", new ScalaTermEncoder('server, typeEncoder))
+      pipeline.addLast("erlangHandler", new ErlangHandler(node))
+
+      pipeline
+    }
+  })
+
+  val channel = bootstrap.bind(new InetSocketAddress(0))
+  def port = channel.getLocalAddress.asInstanceOf[InetSocketAddress].getPort
+}

--- a/src/main/scala/scalang/node/ExitListenable.scala
+++ b/src/main/scala/scalang/node/ExitListenable.scala
@@ -1,0 +1,32 @@
+//
+// Copyright 2011, Boundary
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+package scalang.node
+
+import scalang._
+
+trait ExitListenable {
+  @volatile var exitListeners: List[ExitListener] = Nil
+
+  def addExitListener(listener: ExitListener) {
+    exitListeners = listener :: exitListeners
+  }
+
+  def notifyExit(from: Pid, reason: Any) {
+    for (l <- exitListeners) {
+      l.handleExit(from, reason)
+    }
+  }
+}

--- a/src/main/scala/scalang/node/ExitListener.scala
+++ b/src/main/scala/scalang/node/ExitListener.scala
@@ -1,0 +1,27 @@
+//
+// Copyright 2011, Boundary
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+package scalang.node
+
+import scalang._
+
+/**
+ * Exit notifications are intended for internal book-keeping tasks.  They are not meant for link breakages,
+ * which require the pid of both ends.
+ */
+
+trait ExitListener {
+  def handleExit(from: Pid, reason: Any)
+}

--- a/src/main/scala/scalang/node/FailureDetectionHandler.scala
+++ b/src/main/scala/scalang/node/FailureDetectionHandler.scala
@@ -1,0 +1,52 @@
+package scalang.node
+
+import org.jboss.{ netty => netty }
+import netty.channel._
+import netty.util._
+import netty.handler.timeout._
+import java.util.concurrent._
+import com.boundary.logula.Logging
+
+class FailureDetectionHandler(node: Symbol, clock: Clock, tickTime: Int, timer: Timer) extends SimpleChannelHandler with Logging {
+  @volatile var nextTick: Timeout = null
+  @volatile var lastTimeReceived = 0l
+  @volatile var ctx: ChannelHandlerContext = null
+  val exception = new ReadTimeoutException
+
+  override def channelOpen(ctx: ChannelHandlerContext, e: ChannelStateEvent) {
+    this.ctx = ctx
+    lastTimeReceived = clock.currentTimeMillis
+    scheduleTick
+  }
+
+  override def channelClosed(ctx: ChannelHandlerContext, e: ChannelStateEvent) {
+    if (nextTick != null) nextTick.cancel
+  }
+
+  override def messageReceived(ctx: ChannelHandlerContext, e: MessageEvent) {
+    lastTimeReceived = clock.currentTimeMillis
+    e.getMessage match {
+      case Tick =>
+        if (nextTick != null) nextTick.cancel
+        ctx.getChannel.write(Tock)
+      case _ =>
+        ctx.sendUpstream(e);
+    }
+  }
+
+  object TickTask extends TimerTask {
+    override def run(timeout: Timeout) {
+      val last = (clock.currentTimeMillis - lastTimeReceived) / 1000
+      if (last > (tickTime - tickTime / 4)) {
+        log.warn("Connection to %s has failed for %d seconds. Closing the connection.", node, last)
+        Channels.fireExceptionCaught(ctx, exception);
+      }
+      ctx.getChannel.write(Tick)
+      scheduleTick
+    }
+  }
+
+  def scheduleTick {
+    nextTick = timer.newTimeout(TickTask, tickTime / 4, TimeUnit.SECONDS)
+  }
+}

--- a/src/main/scala/scalang/node/HandshakeDecoder.scala
+++ b/src/main/scala/scalang/node/HandshakeDecoder.scala
@@ -1,0 +1,92 @@
+//
+// Copyright 2011, Boundary
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+package scalang.node
+
+import org.jboss.{ netty => netty }
+import netty.handler.codec.oneone._
+import netty.channel._
+import netty.buffer._
+
+class HandshakeDecoder extends OneToOneDecoder {
+
+  //we need to have a dirty fucking mode context
+  //because name messages and challenge replies have
+  //the same identifier
+  @volatile var mode = 'name
+
+  def decode(ctx: ChannelHandlerContext, channel: Channel, obj: Any): Object = {
+    //dispatch on first byte
+    val buffer = obj.asInstanceOf[ChannelBuffer]
+    if (!buffer.readable) {
+      return buffer
+    }
+    buffer.markReaderIndex
+    (mode, buffer.readByte) match {
+      case ('name, 78) => //new name message, 78 = ascii 'N'
+        val flags = buffer.readLong
+        val creation = buffer.readInt
+        val nameLength = buffer.readShort
+        val bytes = new Array[Byte](nameLength)
+        buffer.readBytes(bytes)
+        mode = 'challenge
+        NameMessage(flags, creation, new String(bytes))
+      case ('name, 110) => //old name message, 110 = ascii 'n'
+        val version = buffer.readShort
+        val flags = buffer.readInt
+        val nameLength = buffer.readableBytes
+        val bytes = new Array[Byte](nameLength)
+        buffer.readBytes(bytes)
+        mode = 'challenge
+        NameMessageV5(version, flags, new String(bytes))
+      case ('challenge, 78) => //new challenge message
+        val flags = buffer.readLong
+        val challenge = buffer.readInt
+        val creation = buffer.readInt
+        val nameLength = buffer.readShort
+        val bytes = new Array[Byte](nameLength)
+        buffer.readBytes(bytes)
+        ChallengeMessage(flags, challenge, creation, new String(bytes))
+      case ('challenge, 110) => //old challenge message
+        val version = buffer.readShort
+        val flags = buffer.readInt
+        val challenge = buffer.readInt
+        val nameLength = buffer.readableBytes
+        val bytes = new Array[Byte](nameLength)
+        buffer.readBytes(bytes)
+        ChallengeMessageV5(version, flags, challenge, new String(bytes))
+      case (_, 115) => //status message
+        val statusLength = buffer.readableBytes
+        val bytes = new Array[Byte](statusLength)
+        buffer.readBytes(bytes)
+        StatusMessage(new String(bytes))
+      case (_, 114) => //reply message
+        val challenge = buffer.readInt
+        val digestLength = buffer.readableBytes
+        val bytes = new Array[Byte](digestLength)
+        buffer.readBytes(bytes)
+        ChallengeReplyMessage(challenge, bytes)
+      case (_, 97) => //ack message
+        val digestLength = buffer.readableBytes
+        val bytes = new Array[Byte](digestLength)
+        buffer.readBytes(bytes)
+        ChallengeAckMessage(bytes)
+      case (_, _) => // overwhelmingly likely to be race between first message in and removal from pipeline
+        buffer.resetReaderIndex
+        buffer
+    }
+  }
+
+}

--- a/src/main/scala/scalang/node/HandshakeEncoder.scala
+++ b/src/main/scala/scalang/node/HandshakeEncoder.scala
@@ -1,0 +1,99 @@
+//
+// Copyright 2011, Boundary
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+package scalang.node
+
+import org.jboss.{ netty => netty }
+import netty.handler.codec.oneone._
+import netty.channel._
+import netty.buffer._
+
+class HandshakeEncoder extends OneToOneEncoder {
+
+  def encode(ctx: ChannelHandlerContext, channel: Channel, obj: Any): Object = {
+    obj match {
+      case NameMessage(flags, creation, name) =>
+        val bytes = name.getBytes
+        val length = 1 + 8 + 4 + 2 + bytes.length
+        val buffer = ChannelBuffers.dynamicBuffer(length + 2)
+        buffer.writeShort(length)
+        buffer.writeByte(78)
+        buffer.writeLong(flags)
+        buffer.writeInt(creation)
+        buffer.writeShort(bytes.length)
+        buffer.writeBytes(bytes)
+        buffer
+      case NameMessageV5(version, flags, name) =>
+        val bytes = name.getBytes
+        val length = 7 + bytes.length
+        val buffer = ChannelBuffers.dynamicBuffer(length + 2)
+        buffer.writeShort(length)
+        buffer.writeByte(110)
+        buffer.writeShort(version)
+        buffer.writeInt(flags)
+        buffer.writeBytes(bytes)
+        buffer
+      case StatusMessage(status) =>
+        val bytes = status.getBytes
+        val length = 1 + bytes.length
+        val buffer = ChannelBuffers.dynamicBuffer(length + 2)
+        buffer.writeShort(length)
+        buffer.writeByte(115)
+        buffer.writeBytes(bytes)
+        buffer
+      case ChallengeMessage(flags, challenge, creation, name) =>
+        val bytes = name.getBytes
+        val length = 1 + 8 + 4 + 4 + 2 + bytes.length
+        val buffer = ChannelBuffers.dynamicBuffer(length + 2)
+        buffer.writeShort(length)
+        buffer.writeByte(78)
+        buffer.writeLong(flags)
+        buffer.writeInt(challenge)
+        buffer.writeInt(creation)
+        buffer.writeShort(bytes.length)
+        buffer.writeBytes(bytes)
+        buffer
+      case ChallengeMessageV5(version, flags, challenge, name) =>
+        val bytes = name.getBytes
+        val length = 11 + bytes.length
+        val buffer = ChannelBuffers.dynamicBuffer(length + 2)
+        buffer.writeShort(length)
+        buffer.writeByte(110)
+        buffer.writeShort(version)
+        buffer.writeInt(flags)
+        buffer.writeInt(challenge)
+        buffer.writeBytes(bytes)
+        buffer
+      case ChallengeReplyMessage(challenge, digest) =>
+        val length = 5 + digest.length
+        val buffer = ChannelBuffers.dynamicBuffer(length + 2)
+        buffer.writeShort(length)
+        buffer.writeByte(114)
+        buffer.writeInt(challenge)
+        buffer.writeBytes(digest)
+        buffer
+      case ChallengeAckMessage(digest) =>
+        val length = 1 + digest.length
+        val buffer = ChannelBuffers.dynamicBuffer(length + 2)
+        buffer.writeShort(length)
+        buffer.writeByte(97)
+        buffer.writeBytes(digest)
+        buffer
+      case buffer: ChannelBuffer => //we have yet to be removed from the conn
+        buffer
+    }
+  }
+
+}

--- a/src/main/scala/scalang/node/HandshakeHandler.scala
+++ b/src/main/scala/scalang/node/HandshakeHandler.scala
@@ -1,0 +1,131 @@
+//
+// Copyright 2011, Boundary
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+package scalang.node
+
+import org.jboss.{ netty => netty }
+import netty.channel._
+import scalang._
+import util._
+import java.util.ArrayDeque
+import scala.math._
+import scala.collection.JavaConversions._
+import java.security.{ SecureRandom, MessageDigest }
+import com.boundary.logula.Logging
+
+abstract class HandshakeHandler(posthandshake: (Symbol, ChannelPipeline) => Unit) extends SimpleChannelHandler with StateMachine with Logging {
+  override val start = 'disconnected
+  @volatile var ctx: ChannelHandlerContext = null
+  @volatile var peer: Symbol = null
+  @volatile var challenge: Int = 0
+  @volatile var peerChallenge: Int = 0
+
+  val messages = new ArrayDeque[MessageEvent]
+  val random = SecureRandom.getInstance("SHA1PRNG")
+
+  def isVerified = currentState == 'verified
+
+  //handler callbacks
+  override def messageReceived(ctx: ChannelHandlerContext, e: MessageEvent) {
+    this.ctx = ctx
+    val msg = e.getMessage
+    if (isVerified) {
+      super.messageReceived(ctx, e)
+      return
+    }
+
+    event(msg)
+  }
+
+  override def channelConnected(ctx: ChannelHandlerContext, e: ChannelStateEvent) {
+    this.ctx = ctx
+    val channel = ctx.getChannel
+    val future = Channels.future(channel)
+    event(ConnectedMessage)
+  }
+
+  override def channelClosed(ctx: ChannelHandlerContext, e: ChannelStateEvent) {
+    this.ctx = ctx
+    log.error("Channel closed during handshake")
+    handshakeFailed
+  }
+
+  override def exceptionCaught(ctx: ChannelHandlerContext, e: ExceptionEvent) {
+    this.ctx = ctx
+    log.error(e.getCause, "Exception caught during erlang handshake: ")
+    handshakeFailed
+  }
+
+  override def writeRequested(ctx: ChannelHandlerContext, e: MessageEvent) {
+    this.ctx = ctx
+    if (isVerified) {
+      super.writeRequested(ctx, e)
+    } else {
+      messages.offer(e)
+    }
+  }
+
+  //utility methods
+  protected def digest(challenge: Int, cookie: String): Array[Byte] = {
+    val masked = mask(challenge)
+    val md5 = MessageDigest.getInstance("MD5")
+    md5.update(cookie.getBytes)
+    md5.update(masked.toString.getBytes)
+    md5.digest
+  }
+
+  def mask(challenge: Int): Long = {
+    if (challenge < 0) {
+      (1L << 31) | (challenge & 0x7FFFFFFFL)
+    } else {
+      challenge.toLong
+    }
+  }
+
+  protected def digestEquals(a: Array[Byte], b: Array[Byte]): Boolean = {
+    var equals = true
+    if (a.length != b.length) {
+      equals = false
+    }
+    val length = min(a.length, b.length)
+    for (i <- (0 until length)) {
+      equals &&= (a(i) == b(i))
+    }
+    equals
+  }
+
+  protected def drainQueue {
+    val p = ctx.getPipeline
+    val keys = p.toMap.keySet
+    for (name <- List("handshakeFramer", "handshakeDecoder", "handshakeEncoder", "handshakeHandler"); if keys.contains(name)) {
+      p.remove(name)
+    }
+    posthandshake(peer, p)
+
+    for (msg <- messages) {
+      ctx.sendDownstream(msg)
+    }
+    messages.clear
+  }
+
+  protected def handshakeSucceeded {
+    ctx.sendUpstream(new UpstreamMessageEvent(ctx.getChannel, HandshakeSucceeded(peer, ctx.getChannel), null))
+  }
+
+  protected def handshakeFailed {
+    ctx.getChannel.close
+    ctx.sendUpstream(new UpstreamMessageEvent(ctx.getChannel, HandshakeFailed(peer), null))
+  }
+}

--- a/src/main/scala/scalang/node/HandshakeMessages.scala
+++ b/src/main/scala/scalang/node/HandshakeMessages.scala
@@ -1,0 +1,87 @@
+//
+// Copyright 2011, Boundary
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+package scalang.node
+
+import org.jboss.netty.channel.Channel
+import scala.collection.mutable.StringBuilder
+
+case object ConnectedMessage
+
+case class NameMessage(flags: Long, creation: Int, name: String)
+
+case class NameMessageV5(version: Short, flags: Int, name: String)
+
+case class StatusMessage(status: String)
+
+case class ChallengeMessage(flags: Long, challenge: Int, creation: Int, name: String)
+
+case class ChallengeMessageV5(version: Short, flags: Int, challenge: Int, name: String)
+
+case class ChallengeReplyMessage(challenge: Int, digest: Array[Byte]) {
+  override def toString: String = {
+    val b = new StringBuilder("ChallengeReplyMessage(")
+    b ++= challenge.toString
+    b ++= ", "
+    b ++= digest.deep.toString
+    b ++= ")"
+    b.toString
+  }
+}
+
+case class ChallengeAckMessage(digest: Array[Byte]) {
+  override def toString: String = {
+    val b = new StringBuilder("ChallengeAckMessage(")
+    b ++= digest.deep.toString
+    b ++= ")"
+    b.toString
+  }
+}
+
+case class HandshakeSucceeded(node: Symbol, channel: Channel)
+
+case class HandshakeFailed(node: Symbol)
+
+object DistributionFlags {
+  val published = 1
+  val atomCache = 2
+  val extendedReferences = 4
+  val distMonitor = 8
+  val funTags = 0x10
+  val distMonitorName = 0x20
+  val hiddenAtomCache = 0x40
+  val newFunTags = 0x80
+  val extendedPidsPorts = 0x100
+  val exportPtrTag = 0x200
+  val bitBinaries = 0x400
+  val newFloats = 0x800
+  val smallAtomTags = 0x4000
+  val utf8Atoms = 0x10000
+  val mapTag = 0x20000
+  val bigCreation = 0x40000
+  val handshake23 = 0x1000000
+  val unlinkId = 0x2000000
+  val v4PidsRefs = 0x4L << 32
+
+  val defaultV5 = extendedReferences | extendedPidsPorts |
+    bitBinaries | newFloats | funTags | newFunTags |
+    distMonitor | distMonitorName | smallAtomTags | utf8Atoms |
+    bigCreation
+
+  val default = defaultV5 | exportPtrTag | mapTag | handshake23 |
+    unlinkId | v4PidsRefs
+}
+
+class ErlangAuthException(msg: String) extends Exception(msg)

--- a/src/main/scala/scalang/node/Link.scala
+++ b/src/main/scala/scalang/node/Link.scala
@@ -1,0 +1,24 @@
+//
+// Copyright 2011, Boundary
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+package scalang.node
+
+import scalang._
+
+case class Link(from: Pid, to: Pid) extends LinkListenable {
+  def break(reason: Any) {
+    notifyBreak(this, reason)
+  }
+}

--- a/src/main/scala/scalang/node/LinkListenable.scala
+++ b/src/main/scala/scalang/node/LinkListenable.scala
@@ -1,0 +1,38 @@
+//
+// Copyright 2011, Boundary
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+package scalang.node
+
+import scalang._
+
+trait LinkListenable {
+  @volatile var linkListeners: List[LinkListener] = Nil
+
+  def addLinkListener(listener: LinkListener) {
+    linkListeners = listener :: linkListeners
+  }
+
+  def notifyBreak(link: Link, reason: Any) {
+    for (listener <- linkListeners) {
+      listener.break(link, reason)
+    }
+  }
+
+  def notifyDeliverLink(link: Link) {
+    for (listener <- linkListeners) {
+      listener.deliverLink(link)
+    }
+  }
+}

--- a/src/main/scala/scalang/node/LinkListener.scala
+++ b/src/main/scala/scalang/node/LinkListener.scala
@@ -1,0 +1,24 @@
+//
+// Copyright 2011, Boundary
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+package scalang.node
+
+import scalang._
+
+trait LinkListener {
+  def deliverLink(link: Link)
+
+  def break(link: Link, reason: Any)
+}

--- a/src/main/scala/scalang/node/Mailbox.scala
+++ b/src/main/scala/scalang/node/Mailbox.scala
@@ -1,0 +1,65 @@
+//
+// Copyright 2011, Boundary
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+package scalang.node
+
+import scalang._
+import java.util.concurrent.TimeUnit
+import concurrent.forkjoin.LinkedTransferQueue
+
+trait Mailbox {
+  def self: Pid
+  def receive: Any
+  def receive(timeout: Long): Option[Any]
+  def send(pid: Pid, msg: Any): Any
+  def send(name: Symbol, msg: Any): Any
+  def send(dest: (Symbol, Symbol), from: Pid, msg: Any): Any
+  def exit(reason: Any)
+  def link(to: Pid)
+}
+
+class MailboxProcess(ctx: ProcessContext) extends ProcessAdapter with Mailbox {
+  val self = ctx.pid
+  val fiber = ctx.fiber
+  val referenceCounter = ctx.referenceCounter
+
+  val queue = new LinkedTransferQueue[Any]
+  def cleanup {}
+  val adapter = ctx.adapter
+
+  def receive: Any = {
+    queue.take
+  }
+
+  def receive(timeout: Long): Option[Any] = {
+    Option(queue.poll(timeout, TimeUnit.MILLISECONDS))
+  }
+
+  override def handleMessage(msg: Any) {
+    queue.offer(msg)
+  }
+
+  override def handleExit(from: Pid, reason: Any) {
+    exit(reason)
+  }
+
+  override def handleMonitorExit(monitored: Any, ref: Reference, reason: Any) {
+    queue.offer(('DOWN, ref, 'process, monitored, reason))
+  }
+
+  def send(to: Pid, msg: Any) = notifySend(to, msg)
+  def send(dest: (Symbol, Symbol), from: Pid, msg: Any) = notifySend(dest, from, msg)
+  def send(name: Symbol, msg: Any) = notifySend(name, msg)
+}

--- a/src/main/scala/scalang/node/Monitor.scala
+++ b/src/main/scala/scalang/node/Monitor.scala
@@ -1,0 +1,24 @@
+//
+// Copyright 2012, Boundary
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+package scalang.node
+
+import scalang._
+
+case class Monitor(monitoring: Pid, monitored: Any, ref: Reference) extends MonitorListenable {
+  def monitorExit(reason: Any) {
+    notifyMonitorExit(this, reason)
+  }
+}

--- a/src/main/scala/scalang/node/MonitorListenable.scala
+++ b/src/main/scala/scalang/node/MonitorListenable.scala
@@ -1,0 +1,39 @@
+//
+// Copyright 2012, Boundary
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+package scalang.node
+
+import scalang._
+
+trait MonitorListenable {
+  @volatile var monitorListeners: List[MonitorListener] = Nil
+
+  def addMonitorListener(listener: MonitorListener) {
+    monitorListeners = listener :: monitorListeners
+  }
+
+  def notifyMonitorExit(monitor: Monitor, reason: Any) {
+    for (listener <- monitorListeners) {
+      listener.monitorExit(monitor, reason)
+    }
+  }
+
+  def notifyDeliverMonitor(monitor: Monitor) {
+    for (listener <- monitorListeners) {
+      listener.deliverMonitor(monitor)
+    }
+  }
+
+}

--- a/src/main/scala/scalang/node/MonitorListener.scala
+++ b/src/main/scala/scalang/node/MonitorListener.scala
@@ -1,0 +1,24 @@
+//
+// Copyright 2012, Boundary
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+package scalang.node
+
+import scalang._
+
+trait MonitorListener {
+  def deliverMonitor(monitor: Monitor)
+
+  def monitorExit(monitor: Monitor, reason: Any)
+}

--- a/src/main/scala/scalang/node/NetKernel.scala
+++ b/src/main/scala/scalang/node/NetKernel.scala
@@ -1,0 +1,26 @@
+//
+// Copyright 2011, Boundary
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+package scalang.node
+
+import scalang._
+
+class NetKernel(ctx: ProcessContext) extends Process(ctx: ProcessContext) {
+
+  override def onMessage(msg: Any) = msg match {
+    case (Symbol("$gen_call"), (pid: Pid, ref: Any), ('is_auth, node: Symbol)) =>
+      pid ! (ref, 'yes)
+  }
+}

--- a/src/main/scala/scalang/node/NodeMessages.scala
+++ b/src/main/scala/scalang/node/NodeMessages.scala
@@ -1,0 +1,44 @@
+//
+// Copyright 2011, Boundary
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+package scalang.node
+
+import scalang._
+
+case class LinkMessage(from: Pid, to: Pid)
+
+case class SendMessage(to: Pid, msg: Any)
+
+case class ExitMessage(from: Pid, to: Pid, reason: Any)
+
+case class Exit2Message(from: Pid, to: Pid, reason: Any)
+
+case class UnlinkMessage(from: Pid, to: Pid)
+
+case class RegSend(from: Pid, to: Symbol, msg: Any)
+
+case object Tick
+
+case object Tock
+
+//must implement trace tags later
+
+case class MonitorMessage(monitoring: Pid, monitored: Any, ref: Reference)
+
+case class DemonitorMessage(monitoring: Pid, monitored: Any, ref: Reference)
+
+case class MonitorExitMessage(monitored: Any, monitoring: Pid, ref: Reference, reason: Any)
+
+class DistributedProtocolException(msg: String) extends Exception(msg)

--- a/src/main/scala/scalang/node/PacketCounter.scala
+++ b/src/main/scala/scalang/node/PacketCounter.scala
@@ -1,0 +1,29 @@
+package scalang.node
+
+import org.jboss.netty
+import netty.bootstrap._
+import netty.channel._
+import netty.handler.codec.frame._
+import com.yammer.metrics.scala._
+import java.util.concurrent._
+
+class PacketCounter(name: String) extends SimpleChannelHandler with Instrumented {
+  val ingress = metrics.meter("ingress", "packets", name, TimeUnit.SECONDS)
+  val egress = metrics.meter("egress", "packets", name, TimeUnit.SECONDS)
+  val exceptions = metrics.meter("exceptions", "exceptions", name, TimeUnit.SECONDS)
+
+  override def messageReceived(ctx: ChannelHandlerContext, e: MessageEvent) {
+    ingress.mark
+    super.messageReceived(ctx, e)
+  }
+
+  override def exceptionCaught(ctx: ChannelHandlerContext, e: ExceptionEvent) {
+    exceptions.mark
+    super.exceptionCaught(ctx, e)
+  }
+
+  override def writeRequested(ctx: ChannelHandlerContext, e: MessageEvent) {
+    egress.mark
+    super.writeRequested(ctx, e)
+  }
+}

--- a/src/main/scala/scalang/node/ProcessAdapter.scala
+++ b/src/main/scala/scalang/node/ProcessAdapter.scala
@@ -1,0 +1,233 @@
+//
+// Copyright 2012, Boundary
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+package scalang.node
+
+import scalang._
+import com.yammer.metrics.scala._
+import org.jetlang.fibers._
+import org.jetlang.channels._
+import org.jetlang.core._
+import java.util.concurrent.TimeUnit
+import org.jctools.maps.NonBlockingHashSet
+import org.jctools.maps.NonBlockingHashMap
+import scala.collection.JavaConversions._
+import com.boundary.logula.Logging
+
+abstract class ProcessHolder(ctx: ProcessContext) extends ProcessAdapter {
+  val self = ctx.pid
+  val fiber = ctx.fiber
+  val messageRate = metrics.meter("messages", "messages", instrumentedName)
+  val executionTimer = metrics.timer("execution", instrumentedName)
+  def process: ProcessLike
+
+  val msgChannel = new MemoryChannel[Any]
+  msgChannel.subscribe(fiber, new Callback[Any] {
+    def onMessage(msg: Any) {
+      executionTimer.time {
+        try {
+          process.handleMessage(msg)
+        } catch {
+          case e: Throwable =>
+            log.error(e, "An error occurred in actor %s", process)
+            process.exit(e.getMessage)
+        }
+      }
+    }
+  })
+
+  val exitChannel = new MemoryChannel[(Pid, Any)]
+  exitChannel.subscribe(fiber, new Callback[(Pid, Any)] {
+    def onMessage(msg: (Pid, Any)) {
+      try {
+        process.handleExit(msg._1, msg._2)
+      } catch {
+        case e: Throwable =>
+          log.error(e, "An error occurred during handleExit in actor %s", this)
+          process.exit(e.getMessage)
+      }
+    }
+  })
+
+  val monitorChannel = new MemoryChannel[(Any, Reference, Any)]
+  monitorChannel.subscribe(fiber, new Callback[(Any, Reference, Any)] {
+    def onMessage(msg: (Any, Reference, Any)) {
+      try {
+        process.handleMonitorExit(msg._1, msg._2, msg._3)
+      } catch {
+        case e: Throwable =>
+          log.error(e, "An error occurred during handleMonitorExit in actor %s", this)
+          process.exit(e.getMessage)
+      }
+    }
+  })
+
+  override def handleMessage(msg: Any) {
+    messageRate.mark
+    msgChannel.publish(msg)
+  }
+
+  override def handleExit(from: Pid, msg: Any) {
+    exitChannel.publish((from, msg))
+  }
+
+  override def handleMonitorExit(monitored: Any, ref: Reference, reason: Any) {
+    monitorChannel.publish((monitored, ref, reason))
+  }
+
+  def cleanup {
+    fiber.dispose
+    metricsRegistry.removeMetric(getClass, "messages", instrumentedName)
+    metricsRegistry.removeMetric(getClass, "execution", instrumentedName)
+  }
+}
+
+trait ProcessAdapter extends ExitListenable with SendListenable with LinkListenable with MonitorListenable with Instrumented with Logging {
+  var state = 'alive
+  def self: Pid
+  def fiber: Fiber
+  def referenceCounter: ReferenceCounter
+  val links = new NonBlockingHashSet[Link]
+  val monitors = new NonBlockingHashMap[Reference, Monitor]
+  def instrumentedName = self.toErlangString
+  def cleanup
+
+  def handleMessage(msg: Any)
+  def handleExit(from: Pid, msg: Any)
+  def handleMonitorExit(monitored: Any, ref: Reference, reason: Any)
+
+  def exit(reason: Any) {
+    synchronized {
+      if (state != 'alive) return
+      state = 'dead
+    }
+
+    // Exit listeners first, so that process is removed from table.
+    for (e <- exitListeners) {
+      e.handleExit(self, reason)
+    }
+    for (link <- links) {
+      link.break(reason)
+    }
+    for (m <- monitors.values) {
+      m.monitorExit(reason)
+    }
+    cleanup
+  }
+
+  def unlink(to: Pid) {
+    links.remove(Link(self, to))
+  }
+
+  def link(to: Pid) {
+    val l = registerLink(to)
+    for (listener <- linkListeners) {
+      listener.deliverLink(l)
+    }
+  }
+
+  def registerLink(to: Pid): Link = {
+    val l = Link(self, to)
+    for (listener <- linkListeners) {
+      l.addLinkListener(listener)
+    }
+    synchronized {
+      if (state != 'alive)
+        l.break('noproc)
+      else
+        links.add(l)
+    }
+    l
+  }
+
+  def monitor(monitored: Any): Reference = {
+    val m = Monitor(self, monitored, makeRef)
+    for (listener <- monitorListeners) {
+      listener.deliverMonitor(m)
+    }
+    m.ref
+  }
+
+  def demonitor(ref: Reference) {
+    monitors.remove(ref)
+  }
+
+  def registerMonitor(monitoring: Pid, ref: Reference): Monitor = {
+    registerMonitor(Monitor(monitoring, self, ref))
+  }
+
+  private def registerMonitor(m: Monitor): Monitor = {
+    for (listener <- monitorListeners) {
+      m.addMonitorListener(listener)
+    }
+    synchronized {
+      if (state != 'alive)
+        m.monitorExit('noproc)
+      else
+        monitors.put(m.ref, m)
+    }
+    m
+  }
+
+  def makeRef = referenceCounter.makeRef
+
+  def sendEvery(pid: Pid, msg: Any, delay: Long) {
+    val runnable = new Runnable {
+      def run = notifySend(pid, msg)
+    }
+    fiber.scheduleAtFixedRate(runnable, delay, delay, TimeUnit.MILLISECONDS)
+  }
+
+  def sendEvery(name: Symbol, msg: Any, delay: Long) {
+    val runnable = new Runnable {
+      def run = notifySend(name, msg)
+    }
+    fiber.scheduleAtFixedRate(runnable, delay, delay, TimeUnit.MILLISECONDS)
+  }
+
+  def sendEvery(name: (Symbol, Symbol), msg: Any, delay: Long) {
+    val runnable = new Runnable {
+      def run = notifySend(name, self, msg)
+    }
+    fiber.scheduleAtFixedRate(runnable, delay, delay, TimeUnit.MILLISECONDS)
+  }
+
+  def sendAfter(pid: Pid, msg: Any, delay: Long) {
+    val runnable = new Runnable {
+      def run {
+        notifySend(pid, msg)
+      }
+    }
+    fiber.schedule(runnable, delay, TimeUnit.MILLISECONDS)
+  }
+
+  def sendAfter(name: Symbol, msg: Any, delay: Long) {
+    val runnable = new Runnable {
+      def run {
+        notifySend(name, msg)
+      }
+    }
+    fiber.schedule(runnable, delay, TimeUnit.MILLISECONDS)
+  }
+
+  def sendAfter(dest: (Symbol, Symbol), msg: Any, delay: Long) {
+    val runnable = new Runnable {
+      def run {
+        notifySend(dest, self, msg)
+      }
+    }
+    fiber.schedule(runnable, delay, TimeUnit.MILLISECONDS)
+  }
+}

--- a/src/main/scala/scalang/node/ProcessLauncher.scala
+++ b/src/main/scala/scalang/node/ProcessLauncher.scala
@@ -1,0 +1,29 @@
+//
+// Copyright 2012, Boundary
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+package scalang.node
+
+import scalang._
+
+class ProcessLauncher[T <: Process](clazz: Class[T], ctx: ProcessContext) extends ProcessHolder(ctx) {
+  val referenceCounter = ctx.referenceCounter
+  var process: Process = null
+
+  def init {
+    val constructor = clazz.getConstructor(classOf[ProcessContext])
+    ctx.adapter = this
+    process = constructor.newInstance(ctx)
+  }
+}

--- a/src/main/scala/scalang/node/ProcessLike.scala
+++ b/src/main/scala/scalang/node/ProcessLike.scala
@@ -1,0 +1,59 @@
+//
+// Copyright 2011, Boundary
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+package scalang.node
+
+import scalang._
+import com.yammer.metrics.scala._
+import com.boundary.logula.Logging
+
+trait ProcessLike extends Instrumented with Logging {
+  def adapter: ProcessAdapter
+  def self: Pid
+
+  def send(pid: Pid, msg: Any) = adapter.notifySend(pid, msg)
+  def send(name: Symbol, msg: Any) = adapter.notifySend(name, msg)
+  def send(dest: (Symbol, Symbol), from: Pid, msg: Any) = adapter.notifySend(dest, from, msg)
+
+  def handleMessage(msg: Any)
+
+  def handleExit(from: Pid, reason: Any) {
+    exit(reason)
+  }
+
+  def handleMonitorExit(monitored: Any, ref: Reference, reason: Any)
+
+  def exit(reason: Any) {
+    adapter.exit(reason)
+  }
+
+  def makeRef = adapter.makeRef
+
+  def unlink(to: Pid) {
+    adapter.unlink(to)
+  }
+
+  def link(to: Pid) {
+    adapter.link(to)
+  }
+
+  def monitor(monitored: Any): Reference = {
+    adapter.monitor(monitored)
+  }
+
+  def demonitor(ref: Reference) {
+    adapter.demonitor(ref)
+  }
+}

--- a/src/main/scala/scalang/node/ReferenceCounter.scala
+++ b/src/main/scala/scalang/node/ReferenceCounter.scala
@@ -1,0 +1,52 @@
+//
+// Copyright 2011, Boundary
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+package scalang.node
+
+import scalang._
+import scala.annotation.tailrec
+import java.util.concurrent._
+import atomic._
+import locks._
+import java.util.Arrays
+
+class ReferenceCounter(name: Symbol, creation: Int) {
+  @volatile var refid = Array(0, 0, 0)
+  val lock = new ReentrantLock
+
+  protected def increment {
+    val newRefid = Arrays.copyOf(refid, 3)
+    newRefid(0) += 1
+    if (newRefid(0) > 0x3ffff) {
+      newRefid(0) = 0
+      newRefid(1) += 1
+      if (newRefid(1) == 0) {
+        newRefid(2) += 1
+      }
+    }
+    refid = newRefid
+  }
+
+  def makeRef: Reference = {
+    lock.lock
+    try {
+      val ref = Reference(name, refid, creation)
+      increment
+      ref
+    } finally {
+      lock.unlock
+    }
+  }
+}

--- a/src/main/scala/scalang/node/ScalaTermDecoder.scala
+++ b/src/main/scala/scalang/node/ScalaTermDecoder.scala
@@ -1,0 +1,361 @@
+//
+// Copyright 2011, Boundary
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+package scalang.node
+
+import org.jboss.netty
+import netty.handler.codec.oneone._
+import netty.channel._
+import java.nio._
+import netty.buffer._
+import scala.annotation.tailrec
+import scalang._
+import com.yammer.metrics.scala._
+import scala.collection.mutable.ArrayBuffer
+import overlock.cache.CachedSymbol
+import sun.misc.Unsafe
+
+object ScalaTermDecoder {
+  private val field = classOf[Unsafe].getDeclaredField("theUnsafe")
+  field.setAccessible(true)
+  val unsafe = field.get(classOf[ScalaTermDecoder]).asInstanceOf[Unsafe]
+
+  val stringValueOffset = unsafe.objectFieldOffset(classOf[String].getDeclaredField("value"))
+  private[this] val stringUsesCount = classOf[String].getDeclaredFields.map { f => f.getName }.contains("count")
+  val stringCountOffset = {
+    if (stringUsesCount)
+      unsafe.objectFieldOffset(classOf[String].getDeclaredField("count"))
+    else
+      0
+  }
+
+  // Initializes a string by creating an empty String object, then populating it with our own
+  // backing char[] to prevent allocating / copying between byte[] or char[] twice.
+  def fastString(buffer: ChannelBuffer, length: Int): String = {
+    val destArray = new Array[Char](length)
+
+    var i = 0
+    while (i < length) {
+      destArray(i) = buffer.readByte().asInstanceOf[Char]
+      i += 1
+    }
+
+    val result = unsafe.allocateInstance(classOf[String]).asInstanceOf[String]
+    unsafe.putObject(result, stringValueOffset, destArray)
+    if (stringUsesCount) {
+      unsafe.putInt(result, stringCountOffset, length)
+    }
+    result
+  }
+}
+
+class ScalaTermDecoder(peer: Symbol, factory: TypeFactory, decoder: TypeDecoder = NoneTypeDecoder) extends OneToOneDecoder with Instrumented {
+  val decodeTimer = metrics.timer("decoding", peer.name)
+
+  def decode(ctx: ChannelHandlerContext, channel: Channel, obj: Any): Object = obj match {
+    case buffer: ChannelBuffer =>
+      if (buffer.readableBytes > 0) {
+        decodeTimer.time {
+          readMessage(buffer)
+        }
+      } else {
+        Tick
+      }
+    case _ =>
+      obj.asInstanceOf[AnyRef]
+  }
+
+  def readMessage(buffer: ChannelBuffer): AnyRef = {
+    val t = buffer.readByte
+    if (t != 112) throw new DistributedProtocolException("Got message of type " + t)
+
+    val version = buffer.readUnsignedByte
+    if (version != 131) throw new DistributedProtocolException("Version mismatch " + version)
+    readTerm(buffer) match {
+      case (1, from: Pid, to: Pid) =>
+        LinkMessage(from, to)
+      case (2, _, to: Pid) =>
+        buffer.skipBytes(1)
+        val msg = readTerm(buffer)
+        SendMessage(to, msg)
+      case (3, from: Pid, to: Pid, reason: Any) =>
+        ExitMessage(from, to, reason)
+      case (4, from: Pid, to: Pid) =>
+        UnlinkMessage(from, to)
+      case (6, from: Pid, _, to: Symbol) =>
+        buffer.skipBytes(1)
+        val msg = readTerm(buffer)
+        RegSend(from, to, msg)
+      case (8, from: Pid, to: Pid, reason: Any) =>
+        Exit2Message(from, to, reason)
+      case (19, monitoring: Pid, monitored: Any, ref: Reference) =>
+        MonitorMessage(monitoring, monitored, ref)
+      case (20, monitoring: Pid, monitored: Any, ref: Reference) =>
+        DemonitorMessage(monitoring, monitored, ref)
+      case (21, monitored: Any, monitoring: Pid, ref: Reference, reason: Any) =>
+        MonitorExitMessage(monitored, monitoring, ref, reason)
+    }
+  }
+
+  def readTerm(buffer: ChannelBuffer): Any = {
+    val typeOrdinal: Int = buffer.readUnsignedByte
+    typeOrdinal match {
+      case decoder(_) =>
+        decoder.decode(typeOrdinal, buffer)
+      case 131 => //version derp
+        readTerm(buffer)
+      case 97 => //small integer
+        buffer.readUnsignedByte.toInt
+      case 98 => //integer
+        buffer.readInt
+      case 99 => //float string
+        val floatString = ScalaTermDecoder.fastString(buffer, 31)
+        floatString.toDouble
+      case 100 => //atom OR boolean
+        val len = buffer.readShort
+        val str = ScalaTermDecoder.fastString(buffer, len)
+        atomOrBoolean(str)
+      case 101 => //reference
+        val node = readTerm(buffer).asInstanceOf[Symbol]
+        val id = buffer.readInt
+        val creation = buffer.readUnsignedByte
+        Reference(node, Seq(id), creation)
+      case 89 => //new port(erl 23)
+        val node = readTerm(buffer).asInstanceOf[Symbol]
+        val id = buffer.readInt
+        val creation = buffer.readInt
+        Port(node, id, creation)
+      case 102 => //port
+        val node = readTerm(buffer).asInstanceOf[Symbol]
+        val id = buffer.readInt
+        val creation = buffer.readByte
+        Port(node, id, creation)
+      case 88 => //new pid(erl 23)
+        val node = readTerm(buffer).asInstanceOf[Symbol]
+        val id = buffer.readInt
+        val serial = buffer.readInt
+        val creation = buffer.readInt
+        Pid(node, id, serial, creation)
+      case 103 => //pid
+        val node = readTerm(buffer).asInstanceOf[Symbol]
+        val id = buffer.readInt
+        val serial = buffer.readInt
+        val creation = buffer.readUnsignedByte
+        Pid(node, id, serial, creation)
+      case 104 => //small tuple -- will be a scala tuple up to size 22
+        val arity = buffer.readUnsignedByte
+        readTuple(arity, buffer)
+      case 105 => //large tuple -- will be an untyped erlang tuple
+        val arity = buffer.readInt
+        readTuple(arity, buffer)
+      case 106 => //nil
+        Nil
+      case 107 => //string
+        val length = buffer.readShort
+        ScalaTermDecoder.fastString(buffer, length)
+      case 108 => //list
+        val length = buffer.readInt
+        val (list, improper) = readList(length, buffer)
+        improper match {
+          case None => list
+          case Some(imp) => new ImproperList(list, imp)
+        }
+      case 109 => //binary
+        val length = buffer.readInt
+        val byteBuffer = ByteBuffer.allocate(length)
+        buffer.readBytes(byteBuffer)
+        byteBuffer.flip
+        byteBuffer
+      case 110 => //small bignum
+        val length = buffer.readUnsignedByte
+        val sign = buffer.readUnsignedByte match {
+          case 0 => 1
+          case _ => -1
+        }
+        if (length <= 8) {
+          readLittleEndianLong(length, sign, buffer)
+        } else {
+          val bytes = readReversed(length, buffer)
+          BigInt(sign, bytes)
+        }
+      case 111 => //large bignum
+        val length = buffer.readInt
+        val sign = buffer.readUnsignedByte match {
+          case 0 => 1
+          case _ => -1
+        }
+        if (length <= 8) {
+          readLittleEndianLong(length, sign, buffer)
+        } else {
+          val bytes = readReversed(length, buffer)
+          BigInt(sign, bytes)
+        }
+      case 90 => //newer reference(erl 23)
+        val length = buffer.readShort
+        val node = readTerm(buffer).asInstanceOf[Symbol]
+        val creation = buffer.readInt
+        val id = (for (n <- (0 until length)) yield {
+          buffer.readInt
+        }).toSeq
+        Reference(node, id, creation)
+      case 114 => //new reference
+        val length = buffer.readShort
+        val node = readTerm(buffer).asInstanceOf[Symbol]
+        val creation = buffer.readUnsignedByte
+        val id = (for (n <- (0 until length)) yield {
+          buffer.readInt
+        }).toSeq
+        Reference(node, id, creation)
+      case 115 => //small atom
+        val length = buffer.readUnsignedByte
+        val str = ScalaTermDecoder.fastString(buffer, length)
+        atomOrBoolean(str)
+      case 117 => //fun
+        val numFree = buffer.readInt
+        val pid = readTerm(buffer).asInstanceOf[Pid]
+        val module = readTerm(buffer).asInstanceOf[Symbol]
+        val index = readTerm(buffer).asInstanceOf[Int]
+        val uniq = readTerm(buffer).asInstanceOf[Int]
+        val vars = (for (n <- (0 until numFree)) yield {
+          readTerm(buffer)
+        }).toSeq
+        Fun(pid, module, index, uniq, vars)
+      case 112 => //new fun
+        val size = buffer.readInt
+        val arity = buffer.readUnsignedByte
+        val uniq = new Array[Byte](16)
+        buffer.readBytes(uniq)
+        val index = buffer.readInt
+        val numFree = buffer.readInt
+        val module = readTerm(buffer).asInstanceOf[Symbol]
+        val oldIndex = readTerm(buffer).asInstanceOf[Int]
+        val oldUniq = readTerm(buffer).asInstanceOf[Int]
+        val pid = readTerm(buffer).asInstanceOf[Pid]
+        val vars = (for (n <- (0 until numFree)) yield {
+          readTerm(buffer)
+        }).toSeq
+        NewFun(pid, module, oldIndex, oldUniq, arity, index, uniq, vars)
+      case 113 => //export
+        val module = readTerm(buffer).asInstanceOf[Symbol]
+        val function = readTerm(buffer).asInstanceOf[Symbol]
+        val arity = readTerm(buffer).asInstanceOf[Int]
+        ExportFun(module, function, arity)
+      case 118 => // atom_utf8_ext
+        val len = buffer.readShort
+        val str = ScalaTermDecoder.fastString(buffer, len)
+        atomOrBoolean(str)
+      case 119 => // small_atom_utf8_ext
+        val len = buffer.readUnsignedByte
+        val str = ScalaTermDecoder.fastString(buffer, len)
+        atomOrBoolean(str)
+      case 77 => //bit binary
+        val length = buffer.readInt
+        val bits = buffer.readUnsignedByte
+        val byteBuffer = ByteBuffer.allocate(length)
+        buffer.readBytes(byteBuffer)
+        byteBuffer.flip
+        BitString(byteBuffer, bits)
+      case 70 => //new float
+        buffer.readDouble
+    }
+  }
+
+  def readLittleEndianLong(length: Int, sign: Int, buffer: ChannelBuffer): Long = {
+    val bytes = new Array[Byte](8)
+    buffer.readBytes(bytes, 0, length)
+    val little = ChannelBuffers.wrappedBuffer(ByteOrder.LITTLE_ENDIAN, bytes)
+    sign * little.readLong
+  }
+
+  def readReversed(length: Int, buffer: ChannelBuffer): Array[Byte] = {
+    val bytes = new Array[Byte](length)
+    for (n <- (1 to length)) {
+      bytes(length - n) = buffer.readByte
+    }
+    bytes
+  }
+
+  def readList(length: Int, buffer: ChannelBuffer): (List[Any], Option[Any]) = {
+    var i = 0
+    val b = new ArrayBuffer[Any](length)
+    while (i <= length) {
+      val term = readTerm(buffer)
+      if (i == length) {
+        term match {
+          case Nil => return (b.toList, None)
+          case improper => return (b.toList, Some(improper))
+        }
+      } else {
+        b += term
+        i += 1
+      }
+    }
+    (b.toList, None)
+  }
+
+  def readTuple(arity: Int, buffer: ChannelBuffer) = {
+    readTerm(buffer) match {
+      case name: Symbol =>
+        val reader = new TermReader(buffer, this)
+        factory.createType(name, arity, reader) match {
+          case Some(obj) => obj
+          case None =>
+            readVanillaTuple(name, arity, buffer)
+        }
+      case first =>
+        readVanillaTuple(first, arity, buffer)
+    }
+  }
+
+  def readVanillaTuple(first: Any, arity: Int, buffer: ChannelBuffer): Any = arity match {
+    case 1 => (first)
+    case 2 => (first, readTerm(buffer))
+    case 3 => (first, readTerm(buffer), readTerm(buffer))
+    case 4 => (first, readTerm(buffer), readTerm(buffer), readTerm(buffer))
+    case 5 => (first, readTerm(buffer), readTerm(buffer), readTerm(buffer), readTerm(buffer))
+    case 6 => (first, readTerm(buffer), readTerm(buffer), readTerm(buffer), readTerm(buffer), readTerm(buffer))
+    case 7 => (first, readTerm(buffer), readTerm(buffer), readTerm(buffer), readTerm(buffer), readTerm(buffer), readTerm(buffer))
+    case 8 => (first, readTerm(buffer), readTerm(buffer), readTerm(buffer), readTerm(buffer), readTerm(buffer), readTerm(buffer), readTerm(buffer))
+    case 9 => (first, readTerm(buffer), readTerm(buffer), readTerm(buffer), readTerm(buffer), readTerm(buffer), readTerm(buffer), readTerm(buffer), readTerm(buffer))
+    case 10 => (first, readTerm(buffer), readTerm(buffer), readTerm(buffer), readTerm(buffer), readTerm(buffer), readTerm(buffer), readTerm(buffer), readTerm(buffer), readTerm(buffer))
+    case 11 => (first, readTerm(buffer), readTerm(buffer), readTerm(buffer), readTerm(buffer), readTerm(buffer), readTerm(buffer), readTerm(buffer), readTerm(buffer), readTerm(buffer), readTerm(buffer))
+    case 12 => (first, readTerm(buffer), readTerm(buffer), readTerm(buffer), readTerm(buffer), readTerm(buffer), readTerm(buffer), readTerm(buffer), readTerm(buffer), readTerm(buffer), readTerm(buffer), readTerm(buffer))
+    case 13 => (first, readTerm(buffer), readTerm(buffer), readTerm(buffer), readTerm(buffer), readTerm(buffer), readTerm(buffer), readTerm(buffer), readTerm(buffer), readTerm(buffer), readTerm(buffer), readTerm(buffer), readTerm(buffer))
+    case 14 => (first, readTerm(buffer), readTerm(buffer), readTerm(buffer), readTerm(buffer), readTerm(buffer), readTerm(buffer), readTerm(buffer), readTerm(buffer), readTerm(buffer), readTerm(buffer), readTerm(buffer), readTerm(buffer), readTerm(buffer))
+    case 15 => (first, readTerm(buffer), readTerm(buffer), readTerm(buffer), readTerm(buffer), readTerm(buffer), readTerm(buffer), readTerm(buffer), readTerm(buffer), readTerm(buffer), readTerm(buffer), readTerm(buffer), readTerm(buffer), readTerm(buffer), readTerm(buffer))
+    case 16 => (first, readTerm(buffer), readTerm(buffer), readTerm(buffer), readTerm(buffer), readTerm(buffer), readTerm(buffer), readTerm(buffer), readTerm(buffer), readTerm(buffer), readTerm(buffer), readTerm(buffer), readTerm(buffer), readTerm(buffer), readTerm(buffer), readTerm(buffer))
+    case 17 => (first, readTerm(buffer), readTerm(buffer), readTerm(buffer), readTerm(buffer), readTerm(buffer), readTerm(buffer), readTerm(buffer), readTerm(buffer), readTerm(buffer), readTerm(buffer), readTerm(buffer), readTerm(buffer), readTerm(buffer), readTerm(buffer), readTerm(buffer), readTerm(buffer))
+    case 18 => (first, readTerm(buffer), readTerm(buffer), readTerm(buffer), readTerm(buffer), readTerm(buffer), readTerm(buffer), readTerm(buffer), readTerm(buffer), readTerm(buffer), readTerm(buffer), readTerm(buffer), readTerm(buffer), readTerm(buffer), readTerm(buffer), readTerm(buffer), readTerm(buffer), readTerm(buffer))
+    case 19 => (first, readTerm(buffer), readTerm(buffer), readTerm(buffer), readTerm(buffer), readTerm(buffer), readTerm(buffer), readTerm(buffer), readTerm(buffer), readTerm(buffer), readTerm(buffer), readTerm(buffer), readTerm(buffer), readTerm(buffer), readTerm(buffer), readTerm(buffer), readTerm(buffer), readTerm(buffer), readTerm(buffer))
+    case 20 => (first, readTerm(buffer), readTerm(buffer), readTerm(buffer), readTerm(buffer), readTerm(buffer), readTerm(buffer), readTerm(buffer), readTerm(buffer), readTerm(buffer), readTerm(buffer), readTerm(buffer), readTerm(buffer), readTerm(buffer), readTerm(buffer), readTerm(buffer), readTerm(buffer), readTerm(buffer), readTerm(buffer), readTerm(buffer))
+    case 21 => (first, readTerm(buffer), readTerm(buffer), readTerm(buffer), readTerm(buffer), readTerm(buffer), readTerm(buffer), readTerm(buffer), readTerm(buffer), readTerm(buffer), readTerm(buffer), readTerm(buffer), readTerm(buffer), readTerm(buffer), readTerm(buffer), readTerm(buffer), readTerm(buffer), readTerm(buffer), readTerm(buffer), readTerm(buffer), readTerm(buffer))
+    case 22 => (first, readTerm(buffer), readTerm(buffer), readTerm(buffer), readTerm(buffer), readTerm(buffer), readTerm(buffer), readTerm(buffer), readTerm(buffer), readTerm(buffer), readTerm(buffer), readTerm(buffer), readTerm(buffer), readTerm(buffer), readTerm(buffer), readTerm(buffer), readTerm(buffer), readTerm(buffer), readTerm(buffer), readTerm(buffer), readTerm(buffer), readTerm(buffer))
+    case _ => readBigTuple(first, arity, buffer)
+  }
+
+  def readBigTuple(first: Any, arity: Int, buffer: ChannelBuffer): BigTuple = {
+    val elements = (for (n <- (1 until arity)) yield {
+      readTerm(buffer)
+    }).toSeq
+    new BigTuple(Seq(first) ++ elements)
+  }
+
+  private def atomOrBoolean(str: String) = str match {
+    case "true" => true
+    case "false" => false
+    case str => CachedSymbol(str)
+  }
+
+}

--- a/src/main/scala/scalang/node/ScalaTermEncoder.scala
+++ b/src/main/scala/scalang/node/ScalaTermEncoder.scala
@@ -1,0 +1,295 @@
+//
+// Copyright 2011, Boundary
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+package scalang.node
+
+import org.jboss.netty
+import netty.handler.codec.oneone._
+import netty.channel._
+import java.nio._
+import java.math.BigInteger
+import netty.buffer._
+import scalang._
+import java.util.Formatter
+import java.util.{ List => JList }
+import scalang.util.ByteArray
+import scalang.util.CamelToUnder._
+import com.yammer.metrics.scala._
+import com.boundary.logula.Logging
+
+class ScalaTermEncoder(peer: Symbol, encoder: TypeEncoder = NoneTypeEncoder) extends OneToOneEncoder with Logging with Instrumented {
+
+  val encodeTimer = metrics.timer("encoding", peer.name)
+
+  override def encode(ctx: ChannelHandlerContext, channel: Channel, obj: Any): Object = {
+    log.debug("sending msg %s", obj)
+    encodeTimer.time {
+      val buffer = ChannelBuffers.dynamicBuffer(512)
+      //write distribution header
+      buffer.writeBytes(ByteArray(112, 131))
+      obj match {
+        case Tock =>
+          buffer.clear()
+        case LinkMessage(from, to) =>
+          encodeObject(buffer, (1, from, to))
+        case SendMessage(to, msg) =>
+          encodeObject(buffer, (2, Symbol(""), to))
+          buffer.writeByte(131)
+          encodeObject(buffer, msg)
+        case ExitMessage(from, to, reason) =>
+          encodeObject(buffer, (3, from, to, reason))
+        case UnlinkMessage(from, to) =>
+          encodeObject(buffer, (4, from, to))
+        case RegSend(from, to, msg) =>
+          encodeObject(buffer, (6, from, Symbol(""), to))
+          buffer.writeByte(131)
+          encodeObject(buffer, msg)
+        case Exit2Message(from, to, reason) =>
+          encodeObject(buffer, (8, from, to, reason))
+        case MonitorMessage(monitoring, monitored, ref) =>
+          encodeObject(buffer, (19, monitoring, monitored, ref))
+        case DemonitorMessage(monitoring, monitored, ref) =>
+          encodeObject(buffer, (20, monitoring, monitored, ref))
+        case MonitorExitMessage(monitored, monitoring, ref, reason) =>
+          encodeObject(buffer, (21, monitored, monitoring, ref, reason))
+      }
+
+      buffer
+    }
+  }
+
+  def encodeObject(buffer: ChannelBuffer, obj: Any): Unit = obj match {
+    case encoder(_) =>
+      encoder.encode(obj, buffer)
+    case i: Int if i >= 0 && i <= 255 =>
+      writeSmallInteger(buffer, i)
+    case i: Int =>
+      writeInteger(buffer, i)
+    case l: Long =>
+      writeLong(buffer, l)
+    case f: Float =>
+      writeFloat(buffer, f)
+    case d: Double =>
+      writeFloat(buffer, d)
+    case true =>
+      writeAtom(buffer, 'true)
+    case false =>
+      writeAtom(buffer, 'false)
+    case s: Symbol =>
+      writeAtom(buffer, s)
+    case Reference(node, id, creation) => //we only emit new references
+      buffer.writeByte(90)
+      buffer.writeShort(id.length)
+      writeAtom(buffer, node)
+      buffer.writeInt(creation)
+      for (i <- id) {
+        buffer.writeInt(i)
+      }
+    case Port(node, id, creation) =>
+      buffer.writeByte(89)
+      writeAtom(buffer, node)
+      buffer.writeInt(id)
+      buffer.writeInt(creation)
+    case Pid(node, id, serial, creation) =>
+      buffer.writeByte(88)
+      writeAtom(buffer, node)
+      buffer.writeInt(id)
+      buffer.writeInt(serial)
+      buffer.writeInt(creation)
+    case Fun(pid, module, index, uniq, vars) =>
+      buffer.writeByte(117)
+      buffer.writeInt(vars.length)
+      encodeObject(buffer, pid)
+      writeAtom(buffer, module)
+      encodeObject(buffer, index)
+      encodeObject(buffer, uniq)
+      for (v <- vars) {
+        encodeObject(buffer, v)
+      }
+    case s: String =>
+      buffer.writeByte(107)
+      val bytes = s.getBytes
+      buffer.writeShort(bytes.length)
+      buffer.writeBytes(bytes)
+    case ImproperList(list, tail) =>
+      writeList(buffer, list, tail)
+    case Nil =>
+      buffer.writeByte(106)
+    case l: JList[Any] =>
+      writeJList(buffer, l, Nil)
+    case l: List[Any] =>
+      writeList(buffer, l, Nil)
+    case b: BigInteger =>
+      writeBigInt(buffer, b)
+    case a: Array[Byte] =>
+      writeBinary(buffer, a)
+    case b: ByteBuffer =>
+      writeBinary(buffer, b)
+    case BitString(b, i) =>
+      writeBinary(buffer, b, i)
+    case b: BigTuple =>
+      writeBigTuple(buffer, b)
+    case p: Product =>
+      writeProduct(buffer, p)
+  }
+
+  def writeBinary(buffer: ChannelBuffer, b: ByteBuffer) {
+    val length = b.remaining
+    buffer.writeByte(109)
+    buffer.writeInt(length)
+    buffer.writeBytes(b)
+  }
+
+  def writeBinary(buffer: ChannelBuffer, a: Array[Byte]) {
+    val length = a.length
+    buffer.writeByte(109)
+    buffer.writeInt(length)
+    buffer.writeBytes(a)
+  }
+
+  def writeBinary(buffer: ChannelBuffer, b: ByteBuffer, i: Int) {
+    val length = b.remaining
+    buffer.writeByte(77)
+    buffer.writeInt(length)
+    buffer.writeByte(i)
+    buffer.writeBytes(b)
+  }
+
+  def writeLong(buffer: ChannelBuffer, l: Long) {
+    val sign = if (l < 0) 1 else 0
+    val bytes = ByteBuffer.allocate(8)
+    bytes.order(ByteOrder.LITTLE_ENDIAN)
+    bytes.putLong(l)
+    buffer.writeByte(110)
+    buffer.writeByte(8)
+    buffer.writeByte(sign)
+    bytes.flip
+    buffer.writeBytes(bytes)
+  }
+
+  def writeBigInt(buffer: ChannelBuffer, big: BigInteger) {
+    val bytes = big.toByteArray
+    val sign = if (big.signum < 0) 1 else 0
+    val length = bytes.length
+    if (length < 255) {
+      buffer.writeByte(110)
+      buffer.writeByte(length)
+    } else {
+      buffer.writeByte(111)
+      buffer.writeInt(length)
+    }
+    buffer.writeByte(sign)
+    for (i <- (1 to length)) {
+      buffer.writeByte(bytes(length - i))
+    }
+  }
+
+  def writeList(buffer: ChannelBuffer, list: List[Any], tail: Any) {
+    buffer.writeByte(108)
+    buffer.writeInt(list.size)
+    for (element <- list) {
+      encodeObject(buffer, element)
+    }
+    encodeObject(buffer, tail)
+  }
+
+  def writeJList(buffer: ChannelBuffer, list: JList[Any], tail: Any) {
+    buffer.writeByte(108)
+    buffer.writeInt(list.size)
+    val i = list.iterator()
+    while (i.hasNext) {
+      encodeObject(buffer, i.next())
+    }
+    encodeObject(buffer, tail)
+  }
+
+  def writeAtom(buffer: ChannelBuffer, s: Symbol) {
+    val bytes = s.name.getBytes
+    if (bytes.length < 256) {
+      buffer.writeByte(115)
+      buffer.writeByte(bytes.length)
+    } else {
+      buffer.writeByte(100)
+      buffer.writeShort(bytes.length)
+    }
+    buffer.writeBytes(bytes)
+  }
+
+  def writeSmallInteger(buffer: ChannelBuffer, i: Int) {
+    buffer.writeByte(97)
+    buffer.writeByte(i)
+  }
+
+  def writeInteger(buffer: ChannelBuffer, i: Int) {
+    buffer.writeByte(98)
+    buffer.writeInt(i)
+  }
+
+  def writeFloat(buffer: ChannelBuffer, d: Double) {
+    if (d.isNaN) {
+      writeAtom(buffer, 'nan)
+    } else if (d.isPosInfinity) {
+      writeAtom(buffer, 'infinity)
+    } else if (d.isNegInfinity) {
+      writeAtom(buffer, Symbol("-infinity"))
+    } else {
+      buffer.writeByte(70)
+      buffer.writeLong(java.lang.Double.doubleToLongBits(d))
+    }
+  }
+
+  def writeStringFloat(buffer: ChannelBuffer, d: Double) {
+    val formatter = new Formatter
+    formatter.format("%.20e", d.asInstanceOf[AnyRef])
+    val str = formatter.toString.getBytes
+    buffer.writeByte(99)
+    buffer.writeBytes(str)
+  }
+
+  def writeProduct(buffer: ChannelBuffer, p: Product) {
+    val name = p.productPrefix
+    if (name.startsWith("Tuple")) {
+      writeTuple(buffer, None, p)
+    } else {
+      writeTuple(buffer, Some(name.camelToUnderscore), p)
+    }
+  }
+
+  def writeTuple(buffer: ChannelBuffer, tag: Option[String], p: Product) {
+    val length = tag.size + p.productArity
+    buffer.writeByte(104)
+    buffer.writeByte(length)
+    for (t <- tag) {
+      writeAtom(buffer, Symbol(t))
+    }
+    for (element <- p.productIterator) {
+      encodeObject(buffer, element)
+    }
+  }
+
+  def writeBigTuple(buffer: ChannelBuffer, tuple: BigTuple) {
+    val length = tuple.productArity
+    if (length < 255) {
+      buffer.writeByte(104)
+      buffer.writeByte(length)
+    } else {
+      buffer.writeByte(105)
+      buffer.writeInt(length)
+    }
+    for (element <- tuple.productIterator) {
+      encodeObject(buffer, element)
+    }
+  }
+}

--- a/src/main/scala/scalang/node/SendListenable.scala
+++ b/src/main/scala/scalang/node/SendListenable.scala
@@ -1,0 +1,45 @@
+//
+// Copyright 2011, Boundary
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+package scalang.node
+
+import scalang._
+
+trait SendListenable {
+  @volatile var sendListeners: List[SendListener] = Nil
+
+  def addSendListener(listener: SendListener) {
+    sendListeners = listener :: sendListeners
+  }
+
+  def notifySend(pid: Pid, msg: Any): Any = {
+    for (l <- sendListeners) {
+      l.handleSend(pid, msg)
+    }
+  }
+
+  def notifySend(name: Symbol, msg: Any): Any = {
+    for (l <- sendListeners) {
+      l.handleSend(name, msg)
+    }
+  }
+
+  def notifySend(dest: (Symbol, Symbol), from: Pid, msg: Any): Any = {
+    for (l <- sendListeners) {
+      l.handleSend(dest, from, msg)
+    }
+  }
+
+}

--- a/src/main/scala/scalang/node/SendListener.scala
+++ b/src/main/scala/scalang/node/SendListener.scala
@@ -1,0 +1,24 @@
+//
+// Copyright 2011, Boundary
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+package scalang.node
+
+import scalang._
+
+trait SendListener {
+  def handleSend(to: Pid, msg: Any)
+  def handleSend(to: Symbol, msg: Any)
+  def handleSend(to: (Symbol, Symbol), from: Pid, msg: Any)
+}

--- a/src/main/scala/scalang/node/ServerHandshakeHandler.scala
+++ b/src/main/scala/scalang/node/ServerHandshakeHandler.scala
@@ -1,0 +1,108 @@
+//
+// Copyright 2011, Boundary
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+package scalang.node
+
+import java.net._
+import java.util.concurrent._
+import atomic._
+import org.jboss.{ netty => netty }
+import netty.bootstrap._
+import netty.channel._
+import netty.handler.codec.frame._
+import scalang._
+import util._
+import java.util.ArrayDeque
+import scala.annotation._
+import scala.math._
+import scala.collection.JavaConversions._
+import java.security.{ SecureRandom, MessageDigest }
+
+class ServerHandshakeHandler(name: Symbol, cookie: String, creation: Int, posthandshake: (Symbol, ChannelPipeline) => Unit) extends HandshakeHandler(posthandshake) {
+  states(
+    state('disconnected, {
+      case ConnectedMessage => 'connected
+    }),
+
+    state('connected, {
+      case msg: NameMessage =>
+        receiveName(msg)
+        sendStatus
+        sendChallenge
+        'challenge_sent
+      case msg: NameMessageV5 =>
+        receiveName(msg)
+        sendStatus
+        sendChallengeV5
+        'challenge_sent
+    }),
+
+    state('challenge_sent, {
+      case msg: ChallengeReplyMessage =>
+        verifyChallenge(msg)
+        sendChallengeAck(msg)
+        drainQueue
+        handshakeSucceeded
+        'verified
+    }),
+
+    state('verified, { case _ => 'verified }))
+
+  //state machine callbacks
+  protected def receiveName(msg: NameMessage) {
+    peer = Symbol(msg.name)
+  }
+
+  protected def receiveName(msg: NameMessageV5) {
+    peer = Symbol(msg.name)
+  }
+
+  protected def sendStatus {
+    val channel = ctx.getChannel
+    val future = Channels.future(channel)
+    ctx.sendDownstream(new DownstreamMessageEvent(channel, future, StatusMessage("ok"), null))
+  }
+
+  protected def sendChallenge {
+    val channel = ctx.getChannel
+    val future = Channels.future(channel)
+    challenge = random.nextInt
+    val msg = ChallengeMessage(DistributionFlags.default, challenge, creation, name.name)
+    ctx.sendDownstream(new DownstreamMessageEvent(channel, future, msg, null))
+  }
+
+  protected def sendChallengeV5 {
+    val channel = ctx.getChannel
+    val future = Channels.future(channel)
+    challenge = random.nextInt
+    val msg = ChallengeMessageV5(5, DistributionFlags.defaultV5, challenge, name.name)
+    ctx.sendDownstream(new DownstreamMessageEvent(channel, future, msg, null))
+  }
+
+  protected def verifyChallenge(msg: ChallengeReplyMessage) {
+    val ourDigest = digest(challenge, cookie)
+    if (!digestEquals(ourDigest, msg.digest)) {
+      throw new ErlangAuthException("Peer authentication error.")
+    }
+  }
+
+  protected def sendChallengeAck(msg: ChallengeReplyMessage) {
+    val channel = ctx.getChannel
+    val future = Channels.future(channel)
+    val md5 = digest(msg.challenge, cookie)
+    val msgOut = ChallengeAckMessage(md5)
+    ctx.sendDownstream(new DownstreamMessageEvent(channel, future, msgOut, null))
+  }
+}

--- a/src/main/scala/scalang/node/ServiceLauncher.scala
+++ b/src/main/scala/scalang/node/ServiceLauncher.scala
@@ -1,0 +1,29 @@
+//
+// Copyright 2012, Boundary
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+package scalang.node
+
+import scalang._
+
+class ServiceLauncher[A <: Product, T <: Process](clazz: Class[T], ctx: ServiceContext[A]) extends ProcessHolder(ctx) {
+  val referenceCounter = ctx.referenceCounter
+  var process: Process = null
+
+  def init {
+    val constructor = clazz.getConstructor(classOf[ServiceContext[_]])
+    ctx.adapter = this
+    process = constructor.newInstance(ctx)
+  }
+}

--- a/src/main/scala/scalang/util/BatchPoolExecutor.scala
+++ b/src/main/scala/scalang/util/BatchPoolExecutor.scala
@@ -1,0 +1,40 @@
+package scalang.util
+
+import org.jetlang.core._
+import java.util._
+import java.util.concurrent._
+import overlock.threadpool._
+
+class BatchPoolExecutor(path: String,
+                        name: String,
+                        coreSize: Int,
+                        maxSize: Int,
+                        keepAlive: Long,
+                        unit: TimeUnit,
+                        queue: BlockingQueue[Runnable],
+                        factory: ThreadFactory) extends InstrumentedThreadPoolExecutor(path, name, coreSize, maxSize, keepAlive, unit, queue, factory) with BatchExecutor {
+
+  override def execute(reader: EventReader) {
+
+    // build a job which will run available work sequentially in a separate thread
+
+    val tasks = new ArrayList[Runnable](reader.size())
+    var i = 0
+    while (i < reader.size()) {
+      tasks.add(reader.get(i))
+      i = i + 1
+    }
+
+    val job =
+      new Runnable {
+        def run() {
+          val ti = tasks.iterator()
+          while (ti.hasNext) {
+            ti.next().run()
+          }
+        }
+      }
+
+    execute(job)
+  }
+}

--- a/src/main/scala/scalang/util/ByteArray.scala
+++ b/src/main/scala/scalang/util/ByteArray.scala
@@ -1,0 +1,7 @@
+package scalang.util
+
+object ByteArray {
+  def apply(values: Int*): Array[Byte] = {
+    Array[Byte](values.map(_.toByte): _*)
+  }
+}

--- a/src/main/scala/scalang/util/CamelToUnder.scala
+++ b/src/main/scala/scalang/util/CamelToUnder.scala
@@ -1,0 +1,25 @@
+package scalang.util
+
+import java.lang.Character._
+import scala.collection.mutable.StringBuilder
+
+object CamelToUnder {
+  implicit def stringWrap(str: String) = new CamelToUnder(str)
+}
+
+class CamelToUnder(str: String) {
+  def camelToUnderscore: String = {
+    val b = new StringBuilder
+    for (char <- str) {
+      if (isUpperCase(char) && b.size == 0) {
+        b += toLowerCase(char)
+      } else if (isUpperCase(char)) {
+        b ++= "_"
+        b += toLowerCase(char)
+      } else {
+        b += char
+      }
+    }
+    b.toString
+  }
+}

--- a/src/main/scala/scalang/util/StateMachine.scala
+++ b/src/main/scala/scalang/util/StateMachine.scala
@@ -1,0 +1,47 @@
+package scalang.util
+
+/**
+ * State Machine
+ * example usage:
+ *
+ */
+
+trait StateMachine {
+
+  def start: Symbol
+  val mutex = new Object
+  protected var stateList: List[State] = null
+  @volatile protected var currentState = start
+
+  def event(evnt: Any) {
+    mutex.synchronized {
+      if (currentState == null) {
+        currentState = start
+      }
+      val state = stateList.find(_.name == currentState).getOrElse(throw new UndefinedStateException("state " + currentState + " is undefined"))
+      val nextState = state.event(evnt)
+      stateList.find(_.name == nextState).getOrElse(throw new UndefinedStateException("state " + currentState + " is undefined"))
+      currentState = nextState
+    }
+  }
+
+  protected def states(states: State*) {
+    stateList = states.toList
+  }
+
+  protected def state(name: Symbol, transitions: PartialFunction[Any, Symbol]) = State(name, transitions)
+
+  case class State(name: Symbol, transitions: PartialFunction[Any, Symbol]) {
+    def event(evnt: Any): Symbol = {
+      if (!transitions.isDefinedAt(evnt)) {
+        throw new UnexpectedEventException("State " + name + " does not have a transition for event " + evnt)
+      } else {
+        transitions(evnt)
+      }
+    }
+  }
+
+  class UnexpectedEventException(msg: String) extends Exception(msg)
+
+  class UndefinedStateException(msg: String) extends Exception(msg)
+}

--- a/src/main/scala/scalang/util/ThreadPoolFactory.scala
+++ b/src/main/scala/scalang/util/ThreadPoolFactory.scala
@@ -1,0 +1,98 @@
+package scalang.util
+
+import overlock.threadpool._
+import java.util.concurrent._
+import atomic._
+import org.jetlang.core._
+import org.jboss.netty.handler.execution.{ MemoryAwareThreadPoolExecutor, OrderedMemoryAwareThreadPoolExecutor }
+import org.jboss.netty.util.ObjectSizeEstimator
+
+object ThreadPoolFactory {
+  @volatile var factory: ThreadPoolFactory = new DefaultThreadPoolFactory
+}
+
+trait ThreadPoolFactory {
+
+  /**
+   * This creates threadpool intended for use as the "boss" pool in netty connections.
+   * The boss pool typically will only ever need one thread. It handles bookkeeping for netty.
+   */
+  def createBossPool: Executor
+
+  /**
+   * The netty worker pool. These thread pools deal with the actual connection handling threads
+   * in netty.  If you want to tightly cap the number of threads that netty uses, only return a
+   * single instance from this method.
+   */
+  def createWorkerPool: Executor
+
+  def createExecutorPool: Executor
+
+  /**
+   * The jetlang actor pool.  This thread pool will be responsible for executing any actors
+   * that are launched with an unthreaded batch executor.
+   */
+  def createActorPool: Executor
+
+  /**
+   * Batch exector for pool backed actors.  If this returns the default unthreaded executor then
+   * only one thread will be active in an actor's onMessage method at a time.  If this returns a
+   * a threadpool backed batch executor then multiple threads will be active in a single actor.
+   */
+  def createBatchExecutor(name: String, reentrant: Boolean): BatchExecutor
+
+  def createBatchExecutor(reentrant: Boolean): BatchExecutor
+}
+
+object StupidObjectSizeEstimator extends ObjectSizeEstimator {
+  def estimateSize(o: Any) = 1
+}
+
+class DefaultThreadPoolFactory extends ThreadPoolFactory {
+  val cpus = Runtime.getRuntime.availableProcessors
+  val max_threads = if ((2 * cpus) < 8) 8 else 2 * cpus
+  val max_memory = Runtime.getRuntime.maxMemory / 2
+  //100 mb
+  /*lazy val bossPool = new OrderedMemoryAwareThreadPoolExecutor(max_threads, 104857600, 104857600, 1000, TimeUnit.SECONDS, new NamedThreadFactory("boss"))
+  //500 mb
+  lazy val workerPool = new OrderedMemoryAwareThreadPoolExecutor(max_threads, 524288000, 524288000, 1000, TimeUnit.SECONDS, new NamedThreadFactory("worker"))
+  lazy val actorPool = new MemoryAwareThreadPoolExecutor(max_threads, 100, 100, 1000, TimeUnit.SECONDS, StupidObjectSizeEstimator, new NamedThreadFactory("actor"))
+  **/
+  lazy val bossPool = ThreadPool.instrumentedFixed("scalang", "boss", max_threads)
+  lazy val workerPool = ThreadPool.instrumentedFixed("scalang", "worker", max_threads)
+  lazy val executorPool = new OrderedMemoryAwareThreadPoolExecutor(max_threads, max_memory, max_memory, 1000, TimeUnit.SECONDS, new NamedThreadFactory("executor"))
+  lazy val actorPool = ThreadPool.instrumentedFixed("scalang", "actor", max_threads)
+  lazy val batchExecutor = new BatchExecutorImpl
+
+  val poolNameCounter = new AtomicInteger(0)
+
+  def createBossPool: Executor = {
+    bossPool
+  }
+
+  def createWorkerPool: Executor = {
+    workerPool
+  }
+
+  def createExecutorPool: Executor = {
+    executorPool
+  }
+
+  def createActorPool: Executor = {
+    actorPool
+  }
+
+  def createBatchExecutor(name: String, reentrant: Boolean): BatchExecutor = {
+    if (reentrant) {
+      val queue = new LinkedBlockingQueue[Runnable]
+      val pool = new BatchPoolExecutor("scalang", name, max_threads, max_threads, 60l, TimeUnit.SECONDS, queue, new NamedThreadFactory(name))
+      pool
+    } else {
+      batchExecutor
+    }
+  }
+
+  def createBatchExecutor(reentrant: Boolean): BatchExecutor = {
+    createBatchExecutor("pool-" + poolNameCounter.getAndIncrement, reentrant)
+  }
+}

--- a/src/main/scala/scalang/util/UnderToCamel.scala
+++ b/src/main/scala/scalang/util/UnderToCamel.scala
@@ -1,0 +1,26 @@
+package scalang.util
+
+import java.lang.Character._
+import scala.collection.mutable.StringBuilder
+
+object UnderToCamel {
+  implicit def underStringWrap(str: String) = new UnderToCamel(str)
+}
+
+class UnderToCamel(str: String) {
+  def underToCamel: String = {
+    val b = new StringBuilder
+    var nextUpper = true
+    for (char <- str) {
+      if (char == '_') {
+        nextUpper = true
+      } else if (nextUpper) {
+        b += toUpperCase(char)
+        nextUpper = false
+      } else {
+        b += char
+      }
+    }
+    b.toString
+  }
+}


### PR DESCRIPTION
There is no need to host many of the customized dependencies of Clouseau in separate repositories as well as produce packages for them separately.  They are not used by other applications and they come with a lot of unused parts that are better to be trimmed anyway.

The following trees are being added here:

- https://github.com/boundary/logula @ `logula_slf4j_2.9.1-2.1.3-p01`
- https://github.com/cloudant/JCTools @ 010666e9
- https://github.com/cloudant/overlock @ cf6d7f71
- https://github.com/cloudant/scalang @ 15c8e17b

From `JCTools`, only specific classes are included from the `jctools-core` module.