### PR TITLE
chore: switch over to `cloudant.github.io` for the fork of Apache Lucene

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
     <repository>
       <id>CloudantPublicRepo</id>
       <name>Cloudant Public Repo</name>
-      <url>https://maven.cloudant.com/repo/</url>
+      <url>https://cloudant.github.io/maven/repo/</url>
     </repository>
   </repositories>
 


### PR DESCRIPTION
The site `maven.cloudant.com` is going to be closed down by March 2025.  To keep building Clouseau from source working, the artifacts for the Cloudant-custom fork of Apache Lucene have been moved to https://cloudant.github.io/maven .  Note that all the other dependencies are now either retrieved from Maven Central or have been imported into the source tree.