### PR TITLE
Use a different method to return version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -352,6 +352,15 @@
         <version>2.4</version>
       </extension>
     </extensions>
+    <resources>
+      <resource>
+       <directory>src/main/resources</directory>
+       <filtering>true</filtering>
+       <includes>
+         <include>**/version.properties</include>
+       </includes>
+      </resource>
+    </resources>
   </build>
 
   <reporting>

--- a/src/main/resources/version.properties
+++ b/src/main/resources/version.properties
@@ -1,0 +1,1 @@
+version: ${project.version}

--- a/src/main/scala/com/cloudant/clouseau/IndexManagerService.scala
+++ b/src/main/scala/com/cloudant/clouseau/IndexManagerService.scala
@@ -25,6 +25,7 @@ import scalang._
 import com.yammer.metrics.scala._
 import scala.collection.JavaConverters._
 import java.util.HashSet
+import java.util.Properties
 
 class IndexManagerService(ctx: ServiceContext[ConfigurationArgs]) extends Service(ctx) with Instrumented {
 
@@ -100,6 +101,9 @@ class IndexManagerService(ctx: ServiceContext[ConfigurationArgs]) extends Servic
   }
 
   val logger = LoggerFactory.getLogger("clouseau.main")
+  val properties = new Properties()
+  properties.load(getClass.getClassLoader.getResourceAsStream("version.properties"))
+  val version = properties.getProperty("version")
   val rootDir = new File(ctx.args.config.getString("clouseau.dir", "target/indexes"))
   val openTimer = metrics.timer("opens")
   val lru = new LRU()
@@ -161,7 +165,7 @@ class IndexManagerService(ctx: ServiceContext[ConfigurationArgs]) extends Servic
       lru.closeByPath(path)
       'ok
     case 'version =>
-      ('ok, getClass.getPackage.getImplementationVersion)
+      ('ok, version)
     case ('create_snapshot, indexName: String, snapshotDir: String) =>
       lru.get(indexName) match {
         case null =>


### PR DESCRIPTION
The `getImplementationVersion` method can return version information only if it is run from a class inside a JAR file.  Choose a different method for retrieving version information so that reporting the version (over the Erlang Distribution Protocol) could work when the code is run directly from the source code directory (via `mvn scala:run`).