### PR TITLE
Fix NullPointerException in `recursivelyDelete`

### DIFF
--- a/src/main/scala/com/cloudant/clouseau/IndexCleanupService.scala
+++ b/src/main/scala/com/cloudant/clouseau/IndexCleanupService.scala
@@ -73,7 +73,8 @@ class IndexCleanupService(ctx: ServiceContext[ConfigurationArgs]) extends Servic
 
   private def recursivelyDelete(fileOrDir: File, deleteDir: Boolean): Unit = {
     if (fileOrDir.isDirectory) {
-      for (file <- fileOrDir.listFiles)
+      // Wrap file list in `Option` to handle `null` case
+      for (file <- Option(fileOrDir.listFiles).getOrElse(Array()))
         recursivelyDelete(file, deleteDir)
       if (deleteDir)
         fileOrDir.delete


### PR DESCRIPTION
While testing the ZIO-based `3.0.0` I noticed the following stack trace in code that is shared between code bases:
```
2025-08-31T22:08:03.280Z [DEBUG][zio-fiber-866023575][Actor.scala:165][zio-logger] Fiber zio-fiber-866023575 did not handle an error Exception in thread "zio-fiber-866023575" java.lang.NullPointerException: null
	at java.base/java.lang.reflect.Array.getLength(Native Method)
	at scala.collection.ArrayOps$.foreach$extension(ArrayOps.scala:1321)
	at com.cloudant.ziose.clouseau.IndexCleanupService.recursivelyDelete(IndexCleanupService.scala:79)
	at com.cloudant.ziose.clouseau.IndexCleanupService.$anonfun$recursivelyDelete$1(IndexCleanupService.scala:80)
	at com.cloudant.ziose.clouseau.IndexCleanupService.$anonfun$recursivelyDelete$1$adapted(IndexCleanupService.scala:79)
	at scala.collection.ArrayOps$.foreach$extension(ArrayOps.scala:1324)
	at com.cloudant.ziose.clouseau.IndexCleanupService.recursivelyDelete(IndexCleanupService.scala:79)
	at com.cloudant.ziose.clouseau.IndexCleanupService.handleCast(IndexCleanupService.scala:37)
	at com.cloudant.ziose.scalang.Service.$anonfun$onMessage$6(Service.scala:480)
	at com.cloudant.ziose.core.AddressableActor.handleActorMessage(Actor.scala:198)
	at com.cloudant.ziose.core.AddressableActor.tryCatch(Actor.scala:223)
	at com.cloudant.ziose.core.AddressableActor.handleActorMessage(Actor.scala:198)
	at com.cloudant.ziose.core.AddressableActor.start.loop(Actor.scala:152)
	at com.cloudant.ziose.core.AddressableActor.start.loop(Actor.scala:157)
	at com.cloudant.ziose.core.AddressableActor.start.loop(Actor.scala:149)
	at com.cloudant.ziose.core.AddressableActor.start(Actor.scala:165)
```
This wraps the output of `listFiles` in an `Option` to return an empty `Array`, which is safe to iterate over.