### PR TITLE
chore: replace CI `asdf`+`direnv` with `mise`

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -17,23 +17,24 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: git config advice.detachedHead false
-      - name: Install asdf & tools
-        uses: asdf-vm/actions/install@v4
-      - name: Add shims to PATH
-        run: echo "${ASDF_DATA_DIR:-$HOME/.asdf}/shims" >> $GITHUB_PATH
-      - run: direnv allow
+      - name: Comment out tools not available in mise
+        run: sed -i 's/^spotbugs /#spotbugs /' .tool-versions
+      - name: Install mise & tools
+        uses: jdx/mise-action@v2
+        with:
+          install: true
 
       - name: Unit tests
-        run: make test
+        run: mise exec -- make test
       - name: Restart test
-        run: eval "$(direnv export bash)" && make restart-test
+        run: mise exec -- make restart-test
       - name: RPC tests (zeunit)
-        run: eval "$(direnv export bash)" && make zeunit
+        run: mise exec -- make zeunit
       - name: Concurrent RPC tests (zeunit)
-        run: eval "$(direnv export bash)" && make concurrent-zeunit-tests
+        run: mise exec -- make concurrent-zeunit-tests
       - name: Syslog tests
-        run: eval "$(direnv export bash)" && make syslog-tests || cat $CLOUSEAU_LOG
+        run: mise exec -- make syslog-tests || cat $CLOUSEAU_LOG
       - name: Elixir tests
-        run: eval "$(direnv export bash)" && make ci-elixir || cat $CLOUSEAU_LOG
+        run: mise exec -- make ci-elixir || cat $CLOUSEAU_LOG
       - name: Metrics tests (mango)
-        run: eval "$(direnv export bash)" && make metrics-tests || cat $CLOUSEAU_LOG
+        run: mise exec -- make metrics-tests || cat $CLOUSEAU_LOG

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,19 +19,20 @@ jobs:
         run: |
           echo "RELEASE_TAG=${GITHUB_REF:10}" >> $GITHUB_ENV
           echo "RELEASE_NAME=$GITHUB_WORKFLOW" >> $GITHUB_ENV
-      - name: Install asdf & tools
-        uses: asdf-vm/actions/install@v4
-      - name: Add shims to PATH
-        run: echo "${ASDF_DATA_DIR:-$HOME/.asdf}/shims" >> $GITHUB_PATH
-      - run: direnv allow
+      - name: Comment out tools not available in mise
+        run: sed -i 's/^spotbugs /#spotbugs /' .tool-versions
+      - name: Install mise & tools
+        uses: jdx/mise-action@v2
+        with:
+          install: true
 
       - name: Test
-        run: make test
+        run: mise exec -- make test
       - name: Generate artifacts
-        run: eval "$(direnv export bash)" && make artifacts
+        run: mise exec -- make artifacts
       - name: List artifacts
         run: ls artifacts
       - name: Create release
-        run: eval "$(direnv export bash)" && make release
+        run: mise exec -- make release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.mise.toml
+++ b/.mise.toml
@@ -1,0 +1,11 @@
+# mise configuration
+# See: https://mise.jdx.dev/configuration.html
+
+[settings]
+# Ignore these tools from .tool-versions (for asdf compatibility)
+legacy_version_file_disable_tools = ["direnv"]
+
+[env]
+_.path = ["./scripts", "./bin"]
+ERL_EPMD_ADDRESS = "127.0.0.1"
+GH_HOST = "github.com"


### PR DESCRIPTION
Replace asdf-vm/actions/install with jdx/mise-action in build and release workflows. This simplifies CI setup by consolidating tool version management and environment configuration into a single tool.

Local developers can continue using asdf+direnv as .tool-versions remains compatible with both tools. The workflows handle mise-specific adjustments automatically via sed.