### PR TITLE
Stop building on every push

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,9 +1,6 @@
 name: Build 3.x
 
 on:
-  push:
-    branches:
-      - '*'
   pull_request:
     branches:
       - main


### PR DESCRIPTION
When testing workflows, building the project on every push was convenient but now it's redundant for a normal PR-to-`main` based workflow.