### PR TITLE
fix(`otp`): shorten the ping period for monitoring the CouchDB node

### DIFF
--- a/otp/src/main/scala/com/cloudant/ziose/otp/OTPNode.scala
+++ b/otp/src/main/scala/com/cloudant/ziose/otp/OTPNode.scala
@@ -116,8 +116,8 @@ object OTPNode {
     private val queue: Queue[Envelope[Command[_], _, _]],
     accessKey: AccessKey
   ) {
-    val DEFAULT_PING_TIMEOUT: Duration                 = 61.seconds
-    val DEFAULT_REMOTE_NODE_MONITOR_INTERVAL: Duration = 61.seconds
+    val DEFAULT_PING_TIMEOUT: Duration                 = 1.seconds
+    val DEFAULT_REMOTE_NODE_MONITOR_INTERVAL: Duration = 1.seconds
     def release(): Unit                                = close()
     def createMbox(name: String): OtpMbox              = node.createMbox(name)
     def close(): Unit                                  = node.close()


### PR DESCRIPTION
It is not recommended to specify very long timeout when calling the `OtpNode#ping` method.  There is only a single attempt is made to connect to the remote node.  This is also a blocking call where it is not so useful to keep it waiting for a long time.