### PR TITLE
fix(`ci`): support retries and remove showing broken redundant logs

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -12,8 +12,6 @@ jobs:
   build:
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    env:
-      CLOUSEAU_LOG: deps/couchdb.main/dev/logs/clouseau1.log
     steps:
       - uses: actions/checkout@v4
       - run: git config advice.detachedHead false
@@ -45,16 +43,16 @@ jobs:
           max_attempts: 3
           command: mise exec -- make concurrent-zeunit-tests
       - name: Syslog tests
-        run: mise exec -- make syslog-tests || cat $CLOUSEAU_LOG
+        run: mise exec -- make syslog-tests
       - name: Elixir tests
         uses: nick-fields/retry@v3
         with:
           timeout_minutes: 5
           max_attempts: 3
-          command: mise exec -- make ci-elixir || cat $CLOUSEAU_LOG
+          command: mise exec -- make ci-elixir
       - name: Metrics tests (mango)
         uses: nick-fields/retry@v3
         with:
           timeout_minutes: 5
           max_attempts: 3
-          command: mise exec -- make metrics-tests || cat $CLOUSEAU_LOG
+          command: mise exec -- make metrics-tests

--- a/Makefile
+++ b/Makefile
@@ -370,6 +370,7 @@ collectd/clouseau.class: collectd/clouseau.java
 .PHONY: metrics-tests
 # target: metrics-tests - Run JMX metrics collection tests
 metrics-tests: $(JAR_ARTIFACTS) collectd/clouseau.class epmd FORCE
+	@cli stop $@ || true
 	@chmod 600 jmxremote.password
 	@cli start $@ \
 		"java \
@@ -508,6 +509,7 @@ ci-zeunit: zeunit $(CI_ARTIFACTS_DIR)
 ci-concurrent-zeunit: concurrent-zeunit-tests
 
 ci-mango: $(JAR_ARTIFACTS) couchdb epmd FORCE
+	@cli stop $@ || true
 	@cli start $@ "java $(_JAVA_COOKIE) -jar $<"
 	@sleep 5
 	@cli await $(node_name) "$(ERLANG_COOKIE)"
@@ -515,6 +517,7 @@ ci-mango: $(JAR_ARTIFACTS) couchdb epmd FORCE
 	@cli stop $@
 
 ci-elixir: $(JAR_ARTIFACTS) couchdb epmd FORCE
+	@cli stop $@ || true
 	@cli start $@ "java $(_JAVA_COOKIE) -jar $<"
 	@cli await $(node_name) "$(ERLANG_COOKIE)"
 	@$(TIMEOUT) $(TIMEOUT_ELIXIR_SEARCH) $(MAKE) elixir-search || $(MAKE) test-failed ID=$@


### PR DESCRIPTION
There is no need to explicitly dump the logs for Clouseau on failure since that is already done by the respective `make` targets (via the `cli` tool).  While there, work around a problem with failed retry attempts on timeout due to Clouseau nodes left behind.

Best served after #118 (rebase due).