### PR TITLE
fix(`ci`): mitigate flakiness

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -25,16 +25,36 @@ jobs:
           install: true
 
       - name: Unit tests
-        run: mise exec -- make test
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 5
+          max_attempts: 3
+          command: mise exec -- make test
       - name: Restart test
         run: mise exec -- make restart-test
       - name: RPC tests (zeunit)
-        run: mise exec -- make zeunit
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 5
+          max_attempts: 3
+          command: mise exec -- make zeunit
       - name: Concurrent RPC tests (zeunit)
-        run: mise exec -- make concurrent-zeunit-tests
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 5
+          max_attempts: 3
+          command: mise exec -- make concurrent-zeunit-tests
       - name: Syslog tests
         run: mise exec -- make syslog-tests || cat $CLOUSEAU_LOG
       - name: Elixir tests
-        run: mise exec -- make ci-elixir || cat $CLOUSEAU_LOG
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 5
+          max_attempts: 3
+          command: mise exec -- make ci-elixir || cat $CLOUSEAU_LOG
       - name: Metrics tests (mango)
-        run: mise exec -- make metrics-tests || cat $CLOUSEAU_LOG
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 5
+          max_attempts: 3
+          command: mise exec -- make metrics-tests || cat $CLOUSEAU_LOG

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ ARTIFACTS_DIR=$(BUILD_DIR)/artifacts
 CI_ARTIFACTS_DIR=$(BUILD_DIR)/ci-artifacts
 
 COUCHDB_REPO?=https://github.com/apache/couchdb
-COUCHDB_COMMIT?=main
+COUCHDB_COMMIT?=3.5.1
 COUCHDB_ROOT?=deps/couchdb
 COUCHDB_CONFIGURE_ARGS?=--dev --disable-spidermonkey
 


### PR DESCRIPTION
Certain CI steps happen to be flaky and sometimes it might make sense to simply retry them to overcome intermittent meta-issues.  For that purpose, call the commands for those steps via the [`retry` GitHub action](https://github.com/marketplace/actions/retry-step).

In parallel to that, pin the upstream CouchDB version to that of the latest release (of the time of writing, i.e. 3.5.1), because `main` recently had regressions which suggested the idea that we shall base our CI on a version other than the bleeding edge, so that we would be somewhat more protected from their breakages.