### PR TITLE
Restore object form of fields in perfield analyzer definition

### DIFF
--- a/clouseau/src/main/scala/com/cloudant/ziose/clouseau/SupportedAnalyzers.scala
+++ b/clouseau/src/main/scala/com/cloudant/ziose/clouseau/SupportedAnalyzers.scala
@@ -362,11 +362,9 @@ object SupportedAnalyzers {
       }
 
       def parseFields(fields: List[_]): List[(String, Option[Map[String, Any]])] =
-        // anaylyzerName can be a String or a single String element wrapped in a List
-        // the latter is a corner case which we should deprecate
         fields.collect {
           case (field: String, analyzerName: String) => (field, Some(Map("name" -> analyzerName)))
-          case (field: String, List(analyzerName: String)) => (field, Some(Map("name" -> analyzerName)))
+          case (field: String, options: List[_]) => (field, Some(AnalyzerOptions.fromKVsList(options).toMap))
           case (field: String, _) => (field, None)
         }
 

--- a/clouseau/src/test/scala/com/cloudant/ziose/clouseau/SupportedAnalyzersSpec.scala
+++ b/clouseau/src/test/scala/com/cloudant/ziose/clouseau/SupportedAnalyzersSpec.scala
@@ -125,6 +125,25 @@ class SupportedAnalyzersSpec extends JUnitRunnableSpec {
           containsString("foo -> org.apache.lucene.analysis.en.EnglishAnalyzer")
         )
       },
+      test("perfield, field in object form") {
+        val options = {
+          AnalyzerOptions.from(Map("name" -> "perfield", "default" -> "standard",
+            "fields" -> List("foo" -> List(("name", "english")))))
+        }
+        assert(options)(isSome) &&
+        assert(createAnalyzer(options.get).toString)(
+          containsString("foo -> org.apache.lucene.analysis.en.EnglishAnalyzer")
+        )
+      },
+      test("perfield, default in object form") {
+        val options = {
+          AnalyzerOptions.from(Map("name" -> "perfield", "default" -> List(("name", "english"))))
+        }
+        assert(options)(isSome) &&
+        assert(createAnalyzer(options.get).toString)(
+          containsString("default=org.apache.lucene.analysis.en.EnglishAnalyzer")
+        )
+      },
       test("arabic") {
         val options = AnalyzerOptions.from("arabic")
         assert(options)(isSome) &&


### PR DESCRIPTION
An analyzer, even one nested inside the "default" or "fields" section of a "perfield" analyzer can be expressed as an object.

Without this fix indexes have silently used StandardAnalyzer when users have declared other analyzers.

This significant regression was introduced in
https://github.com/cloudant-labs/clouseau/pull/84 and specifically this false assumption "The analyzer name is either a String or a single String element wrapped in the List."