### PR TITLE
Fix logger timestamp formatting.

### DIFF
--- a/clouseau/src/main/scala/com/cloudant/ziose/clouseau/LoggerFactory.scala
+++ b/clouseau/src/main/scala/com/cloudant/ziose/clouseau/LoggerFactory.scala
@@ -128,7 +128,7 @@ object LoggerFactory {
     "SLF4J-LOGGER"      -> level
   )
 
-  private val timeStampFormat = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:MM:ss.SSS'Z'").withZone(ZoneOffset.UTC)
+  private val timeStampFormat = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'").withZone(ZoneOffset.UTC)
 
   @inline
   private def bracket(content: zio.logging.LogFormat) = text("[") + content + text("]")


### PR DESCRIPTION
Previously, the month was output in the minute position.
