### PR TITLE
fix(`clouseau-ctrl`): handle when no node name could be discovered

### DIFF
--- a/clouseau-ctrl/src/clouseau_ctrl.erl
+++ b/clouseau-ctrl/src/clouseau_ctrl.erl
@@ -163,6 +163,10 @@ create_ctx(#{
     script_name := ScriptName,
     format := Format
 }) ->
+    case Name of
+        undefined -> fail("No node name has been specified!", []);
+        _ -> ok
+    end,
     % elp:ignore atoms_exhaustion - Atom exhastion is not an issue for CLIs (invoked once)
     RemoteNode = list_to_atom(Name ++ "@" ++ Host),
     % elp:ignore atoms_exhaustion - Atom exhastion is not an issue for CLIs (invoked once)


### PR DESCRIPTION
It is easy to forget about setting the node name for Clouseau on invoking the `clouseau-ctrl` utility, and the respective help message does not either imply that it is mandatory.  At the same time, once it is forgotten, the resulting error (with a stack trace) is not so user-friendly.

Add a pre-check for the node name before making any attempt to use that and bail out if it is still undefined.