### PR TITLE
Integrate Prometheus to Clouseau

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -119,6 +119,20 @@ epmd:
 clouseau1 clouseau2 clouseau3: epmd
 	@sbt run -Dnode=$@ $(_JAVA_COOKIE)
 
+PROMETHEUS_BIN := $(shell which prometheus)
+PROMETHEUS_CONFIG := clouseau/src/main/resources/prometheus.yml
+
+.PHONY: prometheus
+# target: prometheus - Start Prometheus with local instance of clouseau1 node
+prometheus:
+	@if [ -z "$(PROMETHEUS_BIN)" ]; then \
+		echo "Error: Prometheus not found in PATH. Please install Prometheus or add its location to the PATH environment variable."; \
+		exit 1; \
+	fi
+	@echo "Prometheus found at: $(PROMETHEUS_BIN)"
+	@echo "Start Prometheus with config: $(PROMETHEUS_CONFIG)"
+	@$(PROMETHEUS_BIN) --config.file=$(PROMETHEUS_CONFIG)
+
 $(ARTIFACTS_DIR):
 	@mkdir -p $@
 

--- a/build.sbt
+++ b/build.sbt
@@ -22,9 +22,10 @@ updateOptions := updateOptions.value.withCachedResolution(true)
 val versions: Map[String, String] = Map(
   "zio"         -> "2.1.16",
   "zio.config"  -> "4.0.4",
+  "zio.http"    -> "3.7.4",
   "zio.logging" -> "2.5.0",
   "zio.metrics" -> "2.3.1",
-  "jmx"         -> "1.14.5",
+  "micrometer"  -> "1.14.5",
   "reflect"     -> "2.13.16",
   "lucene"      -> "4.6.1-cloudant1",
   "tinylog"     -> "2.7.0"
@@ -153,12 +154,14 @@ lazy val commonSettings = Seq(
     "dev.zio"       %% "zio-config"                        % versions("zio.config"),
     "dev.zio"       %% "zio-config-magnolia"               % versions("zio.config"),
     "dev.zio"       %% "zio-config-typesafe"               % versions("zio.config"),
+    "dev.zio"       %% "zio-http"                          % versions("zio.http"),
     "dev.zio"       %% "zio-logging"                       % versions("zio.logging"),
     // This is needed because micrometer (see below) uses SLF4J
     "dev.zio"       %% "zio-logging-slf4j-bridge"          % versions("zio.logging"),
     "dev.zio"       %% "zio-metrics-connectors-micrometer" % versions("zio.metrics"),
+    "dev.zio"       %% "zio-metrics-connectors-prometheus" % versions("zio.metrics"),
     "dev.zio"       %% "zio-streams"                       % versions("zio"),
-    "io.micrometer"  % "micrometer-registry-jmx"           % versions("jmx"),
+    "io.micrometer"  % "micrometer-registry-jmx"           % versions("micrometer"),
     "org.scala-lang" % "scala-reflect"                     % versions("reflect"),
     "org.tinylog"    % "tinylog-api"                       % versions("tinylog"),
     "org.tinylog"    % "tinylog-impl"                      % versions("tinylog"),

--- a/clouseau/src/main/resources/prometheus.yml
+++ b/clouseau/src/main/resources/prometheus.yml
@@ -1,0 +1,10 @@
+global:
+  scrape_interval: 15s
+
+scrape_configs:
+  - job_name: "prometheus"
+    static_configs:
+      - targets: [ "localhost:9090" ]
+  - job_name: "clouseau"
+    static_configs:
+      - targets: [ 'localhost:8080' ]

--- a/clouseau/src/main/scala/com/cloudant/ziose/clouseau/prometheus/PrometheusPublisherRoutes.scala
+++ b/clouseau/src/main/scala/com/cloudant/ziose/clouseau/prometheus/PrometheusPublisherRoutes.scala
@@ -1,0 +1,15 @@
+package com.cloudant.ziose.clouseau.prometheus
+
+import zio.ZIO
+import zio.http.{Method, Response, Routes, handler}
+import zio.metrics.connectors.prometheus.PrometheusPublisher
+
+object PrometheusPublisherRoutes {
+  def apply(): Routes[PrometheusPublisher, Nothing] = {
+    Routes(
+      Method.GET / "metrics" -> handler(
+        ZIO.serviceWithZIO[PrometheusPublisher](_.get.map(Response.text))
+      )
+    )
+  }
+}


### PR DESCRIPTION
```bash
make clouseau1
make prometheus
```

Check metrics:
- http://localhost:8080/metrics
- http://localhost:9090

Example output of http://localhost:8080/metrics
```
# TYPE com_cloudant_ziose_clouseau_InitService|spawned_failure counter
# HELP com_cloudant_ziose_clouseau_InitService|spawned_failure
com_cloudant_ziose_clouseau_InitService|spawned_failure 0.0 1768926446035
# TYPE jvm_threads_deadlocked_monitor gauge
# HELP jvm_threads_deadlocked_monitor
jvm_threads_deadlocked_monitor 0.0 1768926446035
# TYPE jvm_classes_unloaded_total gauge
# HELP jvm_classes_unloaded_total
jvm_classes_unloaded_total 0.0 1768926446035
# TYPE jvm_memory_pool_bytes_committed gauge
# HELP jvm_memory_pool_bytes_committed
jvm_memory_pool_bytes_committed{pool="CodeHeap 'non-nmethods'",} 2555904.0 1768926446035
# TYPE jvm_memory_pool_bytes_used gauge
# HELP jvm_memory_pool_bytes_used
jvm_memory_pool_bytes_used{pool="CodeHeap 'non-nmethods'",} 1549056.0 1768926446035
# TYPE jvm_classes_loaded gauge
# HELP jvm_classes_loaded
jvm_classes_loaded 7471.0 1768926446035
# TYPE zio_fiber_lifetimes histogram
# HELP zio_fiber_lifetimes
zio_fiber_lifetimes_bucket{le="0.001",} 0.0 1768926446035
zio_fiber_lifetimes_bucket{le="0.002",} 0.0 1768926446035
zio_fiber_lifetimes_bucket{le="0.004",} 1.0 1768926446035
zio_fiber_lifetimes_bucket{le="0.008",} 1.0 1768926446035
zio_fiber_lifetimes_bucket{le="0.016",} 1.0 1768926446035
zio_fiber_lifetimes_bucket{le="0.032",} 1.0 1768926446035
zio_fiber_lifetimes_bucket{le="0.064",} 2.0 1768926446035
zio_fiber_lifetimes_bucket{le="0.128",} 2.0 1768926446035
zio_fiber_lifetimes_bucket{le="0.256",} 2.0 1768926446035
zio_fiber_lifetimes_bucket{le="0.512",} 2.0 1768926446035
zio_fiber_lifetimes_bucket{le="1.024",} 2.0 1768926446035
zio_fiber_lifetimes_bucket{le="2.048",} 2.0 1768926446035
zio_fiber_lifetimes_bucket{le="4.096",} 2.0 1768926446035
zio_fiber_lifetimes_bucket{le="8.192",} 2.0 1768926446035
zio_fiber_lifetimes_bucket{le="16.384",} 2.0 1768926446035
zio_fiber_lifetimes_bucket{le="32.768",} 2.0 1768926446035
zio_fiber_lifetimes_bucket{le="65.536",} 2.0 1768926446035
zio_fiber_lifetimes_bucket{le="131.072",} 2.0 1768926446035
zio_fiber_lifetimes_bucket{le="262.144",} 2.0 1768926446035
zio_fiber_lifetimes_bucket{le="524.288",} 2.0 1768926446035
zio_fiber_lifetimes_bucket{le="+Inf",} 2.0 1768926446035

zio_fiber_lifetimes_sum 0.062 1768926446035
zio_fiber_lifetimes_count 2.0 1768926446035
zio_fiber_lifetimes_min 0.003 1768926446035
zio_fiber_lifetimes_max 0.059 1768926446035
# TYPE jvm_threads_deadlocked gauge
# HELP jvm_threads_deadlocked
jvm_threads_deadlocked 0.0 1768926446035
# TYPE jvm_memory_bytes_committed gauge
# HELP jvm_memory_bytes_committed
jvm_memory_bytes_committed{area="heap",} 6.7108864E7 1768926446035
# TYPE com_cloudant_ziose_clouseau_InitService|spawned_success counter
# HELP com_cloudant_ziose_clouseau_InitService|spawned_success
com_cloudant_ziose_clouseau_InitService|spawned_success 0.0 1768926446035
# TYPE jvm_threads_daemon gauge
# HELP jvm_threads_daemon
jvm_threads_daemon 22.0 1768926446035
# TYPE jvm_gc_collection_seconds_count gauge
# HELP jvm_gc_collection_seconds_count
jvm_gc_collection_seconds_count{gc="G1 Young Generation",} 6.0 1768926446035
# TYPE process_max_fds gauge
# HELP process_max_fds
process_max_fds 10240.0 1768926446035
# TYPE jvm_threads_current gauge
# HELP jvm_threads_current
jvm_threads_current 24.0 1768926446035
# TYPE jvm_memory_bytes_init gauge
# HELP jvm_memory_bytes_init
jvm_memory_bytes_init{area="heap",} 4.02653184E8 1768926446035
# TYPE jvm_gc_collection_seconds_sum gauge
# HELP jvm_gc_collection_seconds_sum
jvm_gc_collection_seconds_sum{gc="G1 Young Generation",} 0.01 1768926446035
# TYPE process_cpu_seconds_total gauge
# HELP process_cpu_seconds_total
process_cpu_seconds_total 2.211653 1768926446035
# TYPE jvm_info gauge
# HELP jvm_info
jvm_info{version="21.0.2+13-58",vendor="Oracle Corporation",runtime="OpenJDK Runtime Environment",} 1.0 1768926446035
# TYPE jvm_memory_bytes_max gauge
# HELP jvm_memory_bytes_max
jvm_memory_bytes_max{area="heap",} 6.442450944E9 1768926446035
# TYPE jvm_memory_bytes_used gauge
# HELP jvm_memory_bytes_used
jvm_memory_bytes_used{area="heap",} 3.3502912E7 1768926446035
# TYPE jvm_memory_objects_pending_finalization gauge
# HELP jvm_memory_objects_pending_finalization
jvm_memory_objects_pending_finalization 0.0 1768926446035
# TYPE jvm_buffer_pool_used_buffers gauge
# HELP jvm_buffer_pool_used_buffers
jvm_buffer_pool_used_buffers{pool="mapped",} 0.0 1768926446035
# TYPE com_cloudant_ziose_clouseau_IndexManagerService|lru_evictions counter
# HELP com_cloudant_ziose_clouseau_IndexManagerService|lru_evictions
com_cloudant_ziose_clouseau_IndexManagerService|lru_evictions 0.0 1768926446035
# TYPE jvm_threads_peak gauge
# HELP jvm_threads_peak
jvm_threads_peak 24.0 1768926446035
# TYPE jvm_buffer_pool_capacity_bytes gauge
# HELP jvm_buffer_pool_capacity_bytes
jvm_buffer_pool_capacity_bytes{pool="mapped",} 0.0 1768926446035
# TYPE jvm_memory_pool_bytes_max gauge
# HELP jvm_memory_pool_bytes_max
jvm_memory_pool_bytes_max{pool="CodeHeap 'non-nmethods'",} 5849088.0 1768926446035
# TYPE jvm_threads_state gauge
# HELP jvm_threads_state
jvm_threads_state{state="NEW",} 0.0 1768926446035
# TYPE jvm_threads_started_total gauge
# HELP jvm_threads_started_total
jvm_threads_started_total 24.0 1768926446035
# TYPE jvm_buffer_pool_used_bytes gauge
# HELP jvm_buffer_pool_used_bytes
jvm_buffer_pool_used_bytes{pool="mapped",} 0.0 1768926446035
# TYPE zio_fiber_successes counter
# HELP zio_fiber_successes
zio_fiber_successes 2.0 1768926446035
# TYPE jvm_memory_pool_allocated_bytes_total counter
# HELP jvm_memory_pool_allocated_bytes_total
jvm_memory_pool_allocated_bytes_total{pool="CodeHeap 'non-nmethods'",} 1549056.0 1768926446035
jvm_memory_pool_allocated_bytes_total{pool="G1 Eden Space",} 9.6468992E7 1768926446035
jvm_memory_pool_allocated_bytes_total{pool="CodeHeap 'profiled nmethods'",} 6893440.0 1768926446035
jvm_memory_pool_allocated_bytes_total{pool="G1 Old Gen",} 1.0759616E7 1768926446035
jvm_memory_pool_allocated_bytes_total{pool="Compressed Class Space",} 5572440.0 1768926446035
jvm_memory_pool_allocated_bytes_total{pool="CodeHeap 'non-profiled nmethods'",} 1809024.0 1768926446035
jvm_memory_pool_allocated_bytes_total{pool="Metaspace",} 4.4854576E7 1768926446035
jvm_memory_pool_allocated_bytes_total{pool="G1 Survivor Space",} 8976648.0 1768926446035
# TYPE com_cloudant_ziose_clouseau_IndexManagerService|lru_misses counter
# HELP com_cloudant_ziose_clouseau_IndexManagerService|lru_misses
com_cloudant_ziose_clouseau_IndexManagerService|lru_misses 0.0 1768926446035
# TYPE process_start_time_seconds gauge
# HELP process_start_time_seconds
process_start_time_seconds 1.768926407623E9 1768926446035
# TYPE jvm_memory_pool_bytes_init gauge
# HELP jvm_memory_pool_bytes_init
jvm_memory_pool_bytes_init{pool="CodeHeap 'non-nmethods'",} 2555904.0 1768926446035
# TYPE process_open_fds gauge
# HELP process_open_fds
process_open_fds 115.0 1768926446035
# TYPE jvm_classes_loaded_total gauge
# HELP jvm_classes_loaded_total
jvm_classes_loaded_total 7470.0 1768926446035
```