### PR TITLE
chore: improve code formatting support

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -22,6 +22,12 @@ jobs:
         with:
           install: true
 
+      - name: Lint
+        run: |
+          source scripts/console.sh
+          source scripts/tools.sh
+          COURSIER="mise exec -- cs" tools::activate_tools
+          mise exec -- make ci-lint
       - name: Unit tests
         uses: nick-fields/retry@v3
         with:

--- a/Makefile
+++ b/Makefile
@@ -130,9 +130,9 @@ ERL_SRCS?=$(shell git ls-files -- "*/rebar.config" "*.[e,h]rl" "*.app.src" "*.es
 .PHONY: check-fmt
 # target: check-fmt - Check mis-formatted code
 check-fmt: $(ARTIFACTS_DIR)
-	@scalafmt --test | tee $(ARTIFACTS_DIR)/scalafmt.log
-	@ec | tee $(ARTIFACTS_DIR)/editor-config.log
-	@erlfmt --verbose --check -- $(ERL_SRCS) | tee $(ARTIFACTS_DIR)/erlfmt.log
+	@set -o pipefail; scalafmt --test | tee $(ARTIFACTS_DIR)/scalafmt.log
+	@set -o pipefail; ec | tee $(ARTIFACTS_DIR)/editor-config.log
+	@set -o pipefail; erlfmt --verbose --check -- $(ERL_SRCS) | tee $(ARTIFACTS_DIR)/erlfmt.log
 
 .PHONY: erlfmt-format
 # target: erlfmt-format - Format Erlang code automatically

--- a/Makefile
+++ b/Makefile
@@ -139,6 +139,15 @@ check-fmt: $(ARTIFACTS_DIR)
 erlfmt-format:
 	@erlfmt --write -- $(ERL_SRCS)
 
+.PHONY: scalafmt-format
+# target: scalafmt-format - Format Scala code automatically
+scalafmt-format:
+	@scalafmt --quiet
+
+.PHONY: format-code
+# target: format-code - Format source code automatically
+format-code: erlfmt-format scalafmt-format
+
 .PHONY: check-deps
 # target: check-deps - Detect publicly disclosed vulnerabilities
 check-deps: build $(ARTIFACTS_DIR)

--- a/clouseau/src/test/scala/com/cloudant/ziose/clouseau/SupportedAnalyzersSpec.scala
+++ b/clouseau/src/test/scala/com/cloudant/ziose/clouseau/SupportedAnalyzersSpec.scala
@@ -127,8 +127,9 @@ class SupportedAnalyzersSpec extends JUnitRunnableSpec {
       },
       test("perfield, field in object form") {
         val options = {
-          AnalyzerOptions.from(Map("name" -> "perfield", "default" -> "standard",
-            "fields" -> List("foo" -> List(("name", "english")))))
+          AnalyzerOptions.from(
+            Map("name" -> "perfield", "default" -> "standard", "fields" -> List("foo" -> List(("name", "english"))))
+          )
         }
         assert(options)(isSome) &&
         assert(createAnalyzer(options.get).toString)(

--- a/scripts/tools.sh
+++ b/scripts/tools.sh
@@ -2,6 +2,7 @@
 SELF_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 BIN_DIR=${SELF_DIR}/../bin
+: "${COURSIER:=coursier}"
 
 # call it as
 # result=( $(tools::requires "${os}") )
@@ -194,7 +195,7 @@ function tools::install_with_coursier() {
   local install_args=$(tools::get_dep "${1}" "install_args")
   local id=$(tools::get_dep "${1}" "id")
   (console::infoLn "installing '${1}'... ")
-  status=$(coursier bootstrap ${id}:${version} \
+  status=$(${COURSIER} bootstrap ${id}:${version} \
     ${install_args} --standalone -o "${BIN_DIR}/${binary}-${version}")
   if [[ $status -eq 0 ]]; then
     (console::infoLn "'${1}' is installed")


### PR DESCRIPTION
Since the project uses a code format implemented by `scalafmt`, it might be useful to provide a dedicated `make(1)` target, `scalafmt-format` for developers to invoke the command.  This is created in line with the existing `erlfmt-format` that works with Erlang sources.

While here, add an extra `format-code` target that calls both `scalafmt-format` and `erlfmt-format` for convenience.  Also, extend the CI with calling the linters for running source code checks on the pull requests.