### PR TITLE
fix(`clouseau`): indexing for document fields of unrecognized types

### DIFF
--- a/clouseau/src/main/scala/com/cloudant/ziose/clouseau/ClouseauTypeFactory.scala
+++ b/clouseau/src/main/scala/com/cloudant/ziose/clouseau/ClouseauTypeFactory.scala
@@ -122,33 +122,17 @@ object ClouseauTypeFactory extends TypeFactory {
               if (isFacet(map)) {
                 doc.add(new DoubleDocValuesField(name, value))
               }
-            case (name: String, value: Integer, options: List[(String, Any) @unchecked]) =>
-              val map         = options.collect { case t @ (_: String, _: Any) => t }.toMap
-              val doubleValue = value.doubleValue
-              doc.add(new DoubleField(name, doubleValue, toStore(map)))
-              if (isFacet(map)) {
-                doc.add(new DoubleDocValuesField(name, doubleValue))
-              }
-            case (name: String, value: Float, options: List[(String, Any) @unchecked]) =>
-              val map         = options.collect { case t @ (_: String, _: Any) => t }.toMap
-              val doubleValue = value.doubleValue
-              doc.add(new DoubleField(name, doubleValue, toStore(map)))
-              if (isFacet(map)) {
-                doc.add(new DoubleDocValuesField(name, doubleValue))
-              }
-            case (name: String, value: Long, options: List[(String, Any) @unchecked]) =>
-              val map         = options.collect { case t @ (_: String, _: Any) => t }.toMap
-              val doubleValue = value.doubleValue
-              doc.add(new DoubleField(name, doubleValue, toStore(map)))
-              if (isFacet(map)) {
-                doc.add(new DoubleDocValuesField(name, doubleValue))
-              }
-            case (name: String, value: BigInt, options: List[(String, Any) @unchecked]) =>
-              val map         = options.collect { case t @ (_: String, _: Any) => t }.toMap
-              val doubleValue = value.doubleValue
-              doc.add(new DoubleField(name, doubleValue, toStore(map)))
-              if (isFacet(map)) {
-                doc.add(new DoubleDocValuesField(name, doubleValue))
+            case (name: String, value: Any, options: List[(String, Any) @unchecked]) =>
+              val map = options.collect { case t @ (_: String, _: Any) => t }.toMap
+              toDouble(value) match {
+                case Some(doubleValue) =>
+                  doc.add(new DoubleField(name, doubleValue, toStore(map)))
+                  if (isFacet(map)) {
+                    doc.add(new DoubleDocValuesField(name, doubleValue))
+                  }
+                case None =>
+                  logger.warn("Unrecognized value: %s".format(value))
+                  'ok
               }
           }
         }

--- a/clouseau/src/test/scala/com/cloudant/ziose/clouseau/IndexServiceSpec.scala
+++ b/clouseau/src/test/scala/com/cloudant/ziose/clouseau/IndexServiceSpec.scala
@@ -445,6 +445,22 @@ class IndexServiceSpec extends JUnitRunnableSpec {
       test("be able to search uppercase _id with perfield") {
         isSearchable("FOO", "FOO", AnalyzerOptions.fromMap(Map("name" -> "perfield", "default" -> "english")))
       },
+      test("be able to ignore null values on indexing") {
+        for {
+          index <- startIndex(defaultConfig, standardAnalyzer)
+          val document = List(
+            ("field1", "bar", List()),
+            ("field2", 'null, List()),
+            ("field3", 'null, List()),
+            ("field4", "bar", List())
+          )
+          result <- updateD(index, "foo", document)
+          _      <- stopIndex(index)
+        } yield assertTrue(
+          result.isDefined,
+          adapter.toScala(result.get) == 'ok
+        )
+      },
       test("perform sorting") {
         for {
           index   <- startIndex(defaultConfig, standardAnalyzer)


### PR DESCRIPTION
In 312656f3, a distinction between each supported type has been introduced but there was no case defined for values with unrecognized types.  This change broke the compatibility with the 2.x line of releases because such instances will make the process crash, while originally there should have been only a warning issued in the logs and the field in question should have been ignored.

Restore this case from the 2.x code base and while there, merge all the similar cases (about handling fields with various number types) since they share the same body.  They could be broken down to further cases later if there is a specific reason to do so.