### PR TITLE
feat(`clouseau`): update Lucene to 10.4.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -26,7 +26,7 @@ val versions: Map[String, String] = Map(
   "zio.metrics" -> "2.3.1",
   "jmx"         -> "1.14.5",
   "reflect"     -> "2.13.16",
-  "lucene"      -> "10.3.2",
+  "lucene"      -> "10.4.0",
   "tinylog"     -> "2.7.0"
 )
 

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "4.0.0-RC1"
+ThisBuild / version := "4.0.0-RC2-SNAPSHOT"


### PR DESCRIPTION
Lucene 10.4.0 was released on February 25, 2026.  See [the documentation](https://lucene.apache.org/core/10_4_0/) for the release notes.
