### PR TITLE
Commit after setting the purge sequence

### DIFF
--- a/clouseau/src/main/scala/com/cloudant/ziose/clouseau/IndexService.scala
+++ b/clouseau/src/main/scala/com/cloudant/ziose/clouseau/IndexService.scala
@@ -198,6 +198,7 @@ class IndexService(ctx: ServiceContext[IndexServiceArgs])(implicit adapter: Adap
       'ok
     case SetPurgeSeqMsg(newPurgeSeq: Long) =>
       pendingPurgeSeq = newPurgeSeq
+      commit(pendingSeq,  pendingPurgeSeq)
       logger.debug(prefix_name("purge sequence is now %d".format(newPurgeSeq)))
       'ok
     case 'info =>


### PR DESCRIPTION
This is a companion PR for Dreyfus [1]

The purge sequence value when set via the API is not committed, it's just stored in memory only until commit time. With the PR [1], if we update the checkpoint document on the db side, and purges get removed by the compactor, then, the index service also crashes before it commits, it's possible that the index would miss some purges. So to keep them in sync ensure that always commit after updating the purge sequence value. We'll first set the purge sequence in the index the update the checkpoint document. We'll make sure to call the set_purge_seq only when it gets updated or initialized and when the index is created (and initialized).

[1] https://github.com/apache/couchdb/pull/5920