### PR TITLE
reply to SetPurgeSeqMsg after commit

### DIFF
--- a/clouseau/src/main/scala/com/cloudant/ziose/clouseau/ClouseauTypeFactory.scala
+++ b/clouseau/src/main/scala/com/cloudant/ziose/clouseau/ClouseauTypeFactory.scala
@@ -251,14 +251,6 @@ object ClouseauTypeFactory extends TypeFactory {
       case pid: EPid     => Some(Pid.toScala(pid))
       case ref: ERef     => Some(Reference.toScala(ref))
       case byte: ENumber => byte.toInt
-      case ETuple(EAtom("committed"), newUpdateSeq: ENumber, newPurgeSeq: ENumber) => {
-        (newUpdateSeq.toLong, newPurgeSeq.toLong) match {
-          case (Some(newUpdateSeq), Some(newPurgeSeq)) =>
-            Some((Symbol("committed"), newUpdateSeq, newPurgeSeq))
-          case _ =>
-            None
-        }
-      }
       case ETuple(from: EPid, EListImproper(EAtom("alias"), ref: ERef)) =>
         Some((Pid.toScala(from), List(Symbol("alias"), Reference.toScala(ref))))
       case ETuple(from: EPid, ref: ERef) =>

--- a/clouseau/src/main/scala/com/cloudant/ziose/clouseau/IndexService.scala
+++ b/clouseau/src/main/scala/com/cloudant/ziose/clouseau/IndexService.scala
@@ -69,6 +69,7 @@ import zio.Duration
 
 case class IndexServiceArgs(config: Configuration, name: String, queryParser: QueryParser, writer: IndexWriter)
 case class HighlightParameters(highlighter: Highlighter, highlightFields: List[String], highlightNumber: Int, analyzers: List[Analyzer])
+case class CommitWaiter(tag: (Pid, Any), min_purge_seq: Long)
 
 // These must match the records in dreyfus.
 case class TopDocs(updateSeq: Long, totalHits: Long, hits: List[Hit])
@@ -88,6 +89,7 @@ class IndexService(ctx: ServiceContext[IndexServiceArgs])(implicit adapter: Adap
   var forceRefresh = false
   var idle = true
   var concurrentRequests = new AtomicInteger(0)
+  var commitWaiters = List[CommitWaiter]()
 
   def reader = lazyReader.getOrElse(throw InvalidReader)
   def setReader(reader: DirectoryReader) =
@@ -197,9 +199,14 @@ class IndexService(ctx: ServiceContext[IndexServiceArgs])(implicit adapter: Adap
       logger.debug(prefix_name("Pending sequence is now %d".format(newSeq)))
       'ok
     case SetPurgeSeqMsg(newPurgeSeq: Long) =>
+      if (newPurgeSeq <= purgeSeq) {
+        return 'ok
+      }
       pendingPurgeSeq = newPurgeSeq
       logger.debug(prefix_name("purge sequence is now %d".format(newPurgeSeq)))
-      'ok
+      commitWaiters = CommitWaiter(tag, newPurgeSeq) :: commitWaiters
+      self ! 'maybe_commit
+      'noreply
     case 'info =>
       ('ok, getInfo)
     case ('create_snapshot, snapshotDir: String) =>
@@ -241,14 +248,22 @@ class IndexService(ctx: ServiceContext[IndexServiceArgs])(implicit adapter: Adap
       exit('deleted)
     case 'maybe_commit =>
       commit(pendingSeq, pendingPurgeSeq)
-    case ('committed, newUpdateSeq: Long, newPurgeSeq: Long) =>
-      updateSeq = newUpdateSeq
-      purgeSeq = newPurgeSeq
+    case ('committed, newUpdateSeq: Number, newPurgeSeq: Number) =>
+      updateSeq = newUpdateSeq.longValue
+      purgeSeq = newPurgeSeq.longValue
       forceRefresh = true
       committing = false
       logger.debug(prefix_name("Committed update sequence %d and purge sequence %d".format(newUpdateSeq, newPurgeSeq)))
-    case 'commit_failed =>
+      val(completed, waiting) = commitWaiters.partition(w => w.min_purge_seq <= purgeSeq)
+      completed.foreach(w => Service.reply(w.tag, 'ok))
+      commitWaiters = waiting
+      self ! 'maybe_commit
+    case ('commit_failed, failedUpdateSeq: Number, failedPurgeSeq: Number) =>
       committing = false
+      val(failed, waiting) = commitWaiters.partition(w => w.min_purge_seq <= failedPurgeSeq.longValue)
+      failed.foreach(w => Service.reply(w.tag, ('error, 'commit_failed)))
+      commitWaiters = waiting
+      self ! 'maybe_commit
   }
 
   def countFields() = {
@@ -295,11 +310,11 @@ class IndexService(ctx: ServiceContext[IndexServiceArgs])(implicit adapter: Adap
     ()
   }
 
-  private def commit(newUpdateSeq: Long, newPurgeSeq: Long) = {
+  private def commit(newUpdateSeq: Long, newPurgeSeq: Long) {
     if (!committing && (newUpdateSeq > updateSeq || newPurgeSeq > purgeSeq)) {
       committing = true
       val index = self
-      node.spawn(_ => {
+      node.spawn(worker => {
         ctx.args.writer.setCommitData((ctx.args.writer.getCommitData.asScala +
           ("update_seq" -> newUpdateSeq.toString) +
           ("purge_seq" -> newPurgeSeq.toString)).asJava)
@@ -311,10 +326,10 @@ class IndexService(ctx: ServiceContext[IndexServiceArgs])(implicit adapter: Adap
         } catch {
           case e: AlreadyClosedException =>
             logger.error(prefix_name("Commit failed to closed writer"), e)
-            index ! 'commit_failed
+            index ! ('commit_failed, newUpdateSeq, newPurgeSeq)
           case e: IOException =>
             logger.error(prefix_name("Failed to commit changes"), e)
-            index ! 'commit_failed
+            index ! ('commit_failed, newUpdateSeq, newPurgeSeq)
         }
       })
     }

--- a/zeunit/test/clouseau_rpc_tests.erl
+++ b/zeunit/test/clouseau_rpc_tests.erl
@@ -9,8 +9,7 @@ clouseau_rpc_without_docs_test_() ->
     {"clouseau rpc tests without docs",
         {foreachx, fun setup/1, fun teardown/2, [
             ?TDEF_FEX(ioq, t_get_update_seq),
-            ?TDEF_FEX(ioq, t_set_purge_seq),
-            ?TDEF_FEX(ioq, t_get_purge_seq),
+            ?TDEF_FEX(ioq, t_set_get_purge_seq),
             ?TDEF_FEX(ioq, t_delete),
             ?TDEF_FEX(ioq, t_commit),
 
@@ -19,8 +18,7 @@ clouseau_rpc_without_docs_test_() ->
             ?TDEF_FEX(ioq, t_group1),
 
             ?TDEF_FEX(gen_server, t_get_update_seq),
-            ?TDEF_FEX(gen_server, t_set_purge_seq),
-            ?TDEF_FEX(gen_server, t_get_purge_seq),
+            ?TDEF_FEX(gen_server, t_set_get_purge_seq),
             ?TDEF_FEX(gen_server, t_delete),
             ?TDEF_FEX(gen_server, t_commit),
 
@@ -61,14 +59,25 @@ t_get_update_seq(_, IndexPid) ->
     {ok, Seq} = clouseau_rpc:get_update_seq(IndexPid),
     ?assertEqual(0, Seq).
 
-t_set_purge_seq(_, IndexPid) ->
-    {ok, Seq} = clouseau_rpc:get_update_seq(IndexPid),
-    Response = clouseau_rpc:set_purge_seq(IndexPid, Seq),
-    ?assertEqual(ok, Response).
+t_set_get_purge_seq(_, IndexPid) ->
+    ?assertEqual(ok, clouseau_rpc:set_purge_seq(IndexPid, 0)),
+    ?assertEqual({ok, 0}, clouseau_rpc:get_purge_seq(IndexPid)),
 
-t_get_purge_seq(_, IndexPid) ->
-    {ok, Seq} = clouseau_rpc:get_purge_seq(IndexPid),
-    ?assertEqual(0, Seq).
+    ?assertEqual(ok, clouseau_rpc:set_purge_seq(IndexPid, 1)),
+    ?assertEqual({ok, 1}, clouseau_rpc:get_purge_seq(IndexPid)),
+
+    % Set the same value
+    ?assertEqual(ok, clouseau_rpc:set_purge_seq(IndexPid, 1)),
+    ?assertEqual({ok, 1}, clouseau_rpc:get_purge_seq(IndexPid)),
+
+    % Try to regress the value
+    ?assertEqual(ok, clouseau_rpc:set_purge_seq(IndexPid, 0)),
+    ?assertEqual({ok, 1}, clouseau_rpc:get_purge_seq(IndexPid)),
+
+    % Try a long value
+    LongVal = 1 bsl 60,
+    ?assertEqual(ok, clouseau_rpc:set_purge_seq(IndexPid, LongVal)),
+    ?assertEqual({ok, LongVal}, clouseau_rpc:get_purge_seq(IndexPid)).
 
 t_delete(_, IndexPid) ->
     Response = clouseau_rpc:delete(IndexPid, ?Ddoc),


### PR DESCRIPTION
We update the purge checkpoint doc after clouseau_rpc:set but this isn't safe as we've not committed.

on receipt of SetPurgeMsg start an async commit and delay the gen_server call reply till it happens.
