### PR TITLE
Fix partition timeout feature

### DIFF
--- a/clouseau/src/main/scala/com/cloudant/ziose/clouseau/ClouseauTypeFactory.scala
+++ b/clouseau/src/main/scala/com/cloudant/ziose/clouseau/ClouseauTypeFactory.scala
@@ -87,6 +87,8 @@ object ClouseauTypeFactory extends TypeFactory {
         for (fieldE <- fields) {
           val fieldS = adapter.toScala(fieldE)
           fieldS match {
+            case ("_partition", value: String, options: List[(String, Any) @unchecked]) =>
+              doc.add(new StringField("_partition", value, Store.NO))
             case (name: String, value: String, options: List[(String, Any) @unchecked]) =>
               if (value.nonEmpty) {
                 val map = options.collect { case t @ (key: String, value: Any) => t }.toMap

--- a/clouseau/src/main/scala/com/cloudant/ziose/clouseau/IndexService.scala
+++ b/clouseau/src/main/scala/com/cloudant/ziose/clouseau/IndexService.scala
@@ -98,15 +98,7 @@ class IndexService(ctx: ServiceContext[IndexServiceArgs])(implicit adapter: Adap
 
   // Start committer heartbeat
   val commitInterval = ctx.args.config.getInt("commit_interval_secs", 30)
-  val timeAllowed = new QueryTimeoutImpl(ctx.args.config.getLong("clouseau.search_allowed_timeout_msecs", 5000)) {
-    override def shouldExit(): Boolean = {
-      val result = super.shouldExit()
-      if (result) {
-        parSearchTimeOutCount += 1
-      }
-      result
-    }
-  }
+  val timeAllowed = ctx.args.config.getLong("clouseau.search_allowed_timeout_msecs", 5000)
   val countFieldsEnabled = ctx.args.config.getBoolean("clouseau.count_fields", false)
 
   val concurrentSearchEnabled = ctx.args.config.getBoolean("clouseau.concurrent_search_enabled", false)
@@ -399,11 +391,15 @@ class IndexService(ctx: ServiceContext[IndexServiceArgs])(implicit adapter: Adap
           }
 
           if (partition.isDefined) {
-            searcher.setTimeout(timeAllowed)
+            searcher.setTimeout(queryTimeout)
           }
 
           val reduces = searchTimer.time {
               searcher.search(query, collectorManager)
+          }
+
+          if (searcher.timedOut) {
+            throw new ParseException("Query exceeded allowed time: " + timeAllowed + "ms.")
           }
 
           if (logger.isDebugEnabled()) {
@@ -433,6 +429,18 @@ class IndexService(ctx: ServiceContext[IndexServiceArgs])(implicit adapter: Adap
         }
       case error =>
         error
+    }
+  }
+
+  private def queryTimeout = {
+    new QueryTimeoutImpl(timeAllowed) {
+      override def shouldExit(): Boolean = {
+        val result = super.shouldExit()
+        if (result) {
+          parSearchTimeOutCount += 1
+        }
+        result
+      }
     }
   }
 


### PR DESCRIPTION
We had a singleton QueryTimeoutImpl so after 5 seconds all searches timeout. This is manifested by immediately returning 0 hits(!!)

So, create a new QueryTimeoutImpl for each query and also check .timedOut and throw an error if exceeded