### PR TITLE
clouseau: implement message forwarding for individual indexers

### DIFF
--- a/clouseau/src/main/scala/com/cloudant/ziose/clouseau/ClouseauTypeFactory.scala
+++ b/clouseau/src/main/scala/com/cloudant/ziose/clouseau/ClouseauTypeFactory.scala
@@ -31,7 +31,6 @@ case class SearchRequest(options: Map[Symbol, Any])            extends ClouseauM
 case class SetPurgeSeqMsg(seq: Long)                           extends ClouseauMessage
 case class SetUpdateSeqMsg(seq: Long)                          extends ClouseauMessage
 case class UpdateDocMsg(id: String, doc: Document)             extends ClouseauMessage
-case class ForwardByPathMsg(path: String, msg: Any)            extends ClouseauMessage
 
 object ClouseauTypeFactory extends TypeFactory {
   type T = ClouseauMessage
@@ -152,8 +151,6 @@ object ClouseauTypeFactory extends TypeFactory {
         seq.toLong.map(SetPurgeSeqMsg)
       case ETuple(EAtom("set_update_seq"), seq: ENumber) =>
         seq.toLong.map(SetUpdateSeqMsg)
-      case ETuple(EAtom("forward"), path: EBinary, msg) =>
-        Some(ForwardByPathMsg(path.asString, msg))
       // most of the messages would be matching here so we can handle them elsewhere
       case other => None
     }

--- a/clouseau/src/main/scala/com/cloudant/ziose/clouseau/ClouseauTypeFactory.scala
+++ b/clouseau/src/main/scala/com/cloudant/ziose/clouseau/ClouseauTypeFactory.scala
@@ -153,11 +153,9 @@ object ClouseauTypeFactory extends TypeFactory {
       case ETuple(EAtom("set_update_seq"), seq: ENumber) =>
         seq.toLong.map(SetUpdateSeqMsg)
       case ETuple(EAtom("forward"), path: EBinary, msg) =>
-        parse(msg).map({ parsedMessage => ForwardByPathMsg(path.asString, parsedMessage) })
+        Some(ForwardByPathMsg(path.asString, msg))
       // most of the messages would be matching here so we can handle them elsewhere
-      case other =>
-        println(s"not parsed: $other")
-        None
+      case other => None
     }
   }
 

--- a/clouseau/src/main/scala/com/cloudant/ziose/clouseau/ClouseauTypeFactory.scala
+++ b/clouseau/src/main/scala/com/cloudant/ziose/clouseau/ClouseauTypeFactory.scala
@@ -31,6 +31,7 @@ case class SearchRequest(options: Map[Symbol, Any])            extends ClouseauM
 case class SetPurgeSeqMsg(seq: Long)                           extends ClouseauMessage
 case class SetUpdateSeqMsg(seq: Long)                          extends ClouseauMessage
 case class UpdateDocMsg(id: String, doc: Document)             extends ClouseauMessage
+case class ForwardByPathMsg(path: String, msg: Any)            extends ClouseauMessage
 
 object ClouseauTypeFactory extends TypeFactory {
   type T = ClouseauMessage
@@ -151,6 +152,8 @@ object ClouseauTypeFactory extends TypeFactory {
         seq.toLong.map(SetPurgeSeqMsg)
       case ETuple(EAtom("set_update_seq"), seq: ENumber) =>
         seq.toLong.map(SetUpdateSeqMsg)
+      case ETuple(EAtom("forward"), path: EBinary, msg) =>
+        parse(msg).map({ parsedMessage => ForwardByPathMsg(path.asString, parsedMessage) })
       // most of the messages would be matching here so we can handle them elsewhere
       case other => None
     }

--- a/clouseau/src/main/scala/com/cloudant/ziose/clouseau/ClouseauTypeFactory.scala
+++ b/clouseau/src/main/scala/com/cloudant/ziose/clouseau/ClouseauTypeFactory.scala
@@ -155,7 +155,9 @@ object ClouseauTypeFactory extends TypeFactory {
       case ETuple(EAtom("forward"), path: EBinary, msg) =>
         parse(msg).map({ parsedMessage => ForwardByPathMsg(path.asString, parsedMessage) })
       // most of the messages would be matching here so we can handle them elsewhere
-      case other => None
+      case other =>
+        println(s"not parsed: $other")
+        None
     }
   }
 

--- a/clouseau/src/main/scala/com/cloudant/ziose/clouseau/IndexManagerService.scala
+++ b/clouseau/src/main/scala/com/cloudant/ziose/clouseau/IndexManagerService.scala
@@ -192,7 +192,7 @@ class IndexManagerService(ctx: ServiceContext[ConfigurationArgs])(implicit adapt
         case pid =>
           ('ok, pid)
       }
-    case ForwardByPathMsg(path: String, msg: Any) =>
+    case ('forward, path: String, msg: Any) =>
       lru.get(path) match {
         case null =>
           // TODO: re-open index? it should not happen

--- a/clouseau/src/main/scala/com/cloudant/ziose/clouseau/IndexManagerService.scala
+++ b/clouseau/src/main/scala/com/cloudant/ziose/clouseau/IndexManagerService.scala
@@ -192,6 +192,14 @@ class IndexManagerService(ctx: ServiceContext[ConfigurationArgs])(implicit adapt
         case pid =>
           ('ok, pid)
       }
+    case ForwardByPathMsg(path: String, msg: Any) =>
+      lru.get(path) match {
+        case null =>
+          // TODO: re-open index? it should not happen
+          ('forwarding_error, 'index_unavailable)
+        case pid =>
+          call(pid, msg)
+      }
     case ('get_root_dir) =>
       ('ok, rootDir.getAbsolutePath())
     case DeleteDocMsg(path: String) =>

--- a/zeunit/src/clouseau_rpc.erl
+++ b/zeunit/src/clouseau_rpc.erl
@@ -79,5 +79,10 @@ version() ->
 clouseau() ->
     ?NodeZ.
 
-rpc(Ref, Msg) ->
+rpc(Key, Message) ->
+    {Ref, Msg} =
+        case Key of
+            {forwarded, Path, _Pid} -> {{main, clouseau()}, {forward, Path, Message}};
+            Pid -> {Pid, Message}
+        end,
     util:call(Ref, Msg).

--- a/zeunit/test/clouseau_rpc_tests.erl
+++ b/zeunit/test/clouseau_rpc_tests.erl
@@ -24,7 +24,25 @@ clouseau_rpc_without_docs_test_() ->
 
             ?TDEF_FEX(gen_server, t_info),
             ?TDEF_FEX(gen_server, t_search),
-            ?TDEF_FEX(gen_server, t_group1)
+            ?TDEF_FEX(gen_server, t_group1),
+
+            ?TDEF_FEX({forwarded, ioq}, t_get_update_seq),
+            ?TDEF_FEX({forwarded, ioq}, t_set_get_purge_seq),
+            ?TDEF_FEX({forwarded, ioq}, t_delete),
+            ?TDEF_FEX({forwarded, ioq}, t_commit),
+
+            ?TDEF_FEX({forwarded, ioq}, t_info),
+            ?TDEF_FEX({forwarded, ioq}, t_search),
+            ?TDEF_FEX({forwarded, ioq}, t_group1),
+
+            ?TDEF_FEX({forwarded, gen_server}, t_get_update_seq),
+            ?TDEF_FEX({forwarded, gen_server}, t_set_get_purge_seq),
+            ?TDEF_FEX({forwarded, gen_server}, t_delete),
+            ?TDEF_FEX({forwarded, gen_server}, t_commit),
+
+            ?TDEF_FEX({forwarded, gen_server}, t_info),
+            ?TDEF_FEX({forwarded, gen_server}, t_search),
+            ?TDEF_FEX({forwarded, gen_server}, t_group1)
         ]}}.
 
 clouseau_rpc_simple_test_() ->
@@ -40,7 +58,19 @@ clouseau_rpc_simple_test_() ->
             ?TDEF_FEX(gen_server, t_get_root_dir),
             ?TDEF_FEX(gen_server, t_open_index),
             ?TDEF_FEX(gen_server, t_analyze),
-            ?TDEF_FEX(gen_server, t_version)
+            ?TDEF_FEX(gen_server, t_version),
+
+            ?TDEF_FEX({forwarded, ioq}, t_disk_size),
+            ?TDEF_FEX({forwarded, ioq}, t_get_root_dir),
+            ?TDEF_FEX({forwarded, ioq}, t_open_index),
+            ?TDEF_FEX({forwarded, ioq}, t_analyze),
+            ?TDEF_FEX({forwarded, ioq}, t_version),
+
+            ?TDEF_FEX({forwarded, gen_server}, t_disk_size),
+            ?TDEF_FEX({forwarded, gen_server}, t_get_root_dir),
+            ?TDEF_FEX({forwarded, gen_server}, t_open_index),
+            ?TDEF_FEX({forwarded, gen_server}, t_analyze),
+            ?TDEF_FEX({forwarded, gen_server}, t_version)
         ]}}.
 
 clouseau_rpc_gen_server_cast_test_() ->
@@ -52,44 +82,52 @@ clouseau_rpc_gen_server_cast_test_() ->
 
             ?TDEF_FEX(gen_server, t_cleanup_1),
             ?TDEF_FEX(gen_server, t_cleanup_2),
-            ?TDEF_FEX(gen_server, t_rename)
+            ?TDEF_FEX(gen_server, t_rename),
+
+            ?TDEF_FEX({forwarded, ioq}, t_cleanup_1),
+            ?TDEF_FEX({forwarded, ioq}, t_cleanup_2),
+            ?TDEF_FEX({forwarded, ioq}, t_rename),
+
+            ?TDEF_FEX({forwarded, gen_server}, t_cleanup_1),
+            ?TDEF_FEX({forwarded, gen_server}, t_cleanup_2),
+            ?TDEF_FEX({forwarded, gen_server}, t_rename)
         ]}}.
 
-t_get_update_seq(_, IndexPid) ->
-    {ok, Seq} = clouseau_rpc:get_update_seq(IndexPid),
+t_get_update_seq(_, IndexKey) ->
+    {ok, Seq} = clouseau_rpc:get_update_seq(IndexKey),
     ?assertEqual(0, Seq).
 
-t_set_get_purge_seq(_, IndexPid) ->
-    ?assertEqual(ok, clouseau_rpc:set_purge_seq(IndexPid, 0)),
-    ?assertEqual({ok, 0}, clouseau_rpc:get_purge_seq(IndexPid)),
+t_set_get_purge_seq(_, IndexKey) ->
+    ?assertEqual(ok, clouseau_rpc:set_purge_seq(IndexKey, 0)),
+    ?assertEqual({ok, 0}, clouseau_rpc:get_purge_seq(IndexKey)),
 
-    ?assertEqual(ok, clouseau_rpc:set_purge_seq(IndexPid, 1)),
-    ?assertEqual({ok, 1}, clouseau_rpc:get_purge_seq(IndexPid)),
+    ?assertEqual(ok, clouseau_rpc:set_purge_seq(IndexKey, 1)),
+    ?assertEqual({ok, 1}, clouseau_rpc:get_purge_seq(IndexKey)),
 
     % Set the same value
-    ?assertEqual(ok, clouseau_rpc:set_purge_seq(IndexPid, 1)),
-    ?assertEqual({ok, 1}, clouseau_rpc:get_purge_seq(IndexPid)),
+    ?assertEqual(ok, clouseau_rpc:set_purge_seq(IndexKey, 1)),
+    ?assertEqual({ok, 1}, clouseau_rpc:get_purge_seq(IndexKey)),
 
     % Try to regress the value
-    ?assertEqual(ok, clouseau_rpc:set_purge_seq(IndexPid, 0)),
-    ?assertEqual({ok, 1}, clouseau_rpc:get_purge_seq(IndexPid)),
+    ?assertEqual(ok, clouseau_rpc:set_purge_seq(IndexKey, 0)),
+    ?assertEqual({ok, 1}, clouseau_rpc:get_purge_seq(IndexKey)),
 
     % Try a long value
     LongVal = 1 bsl 60,
-    ?assertEqual(ok, clouseau_rpc:set_purge_seq(IndexPid, LongVal)),
-    ?assertEqual({ok, LongVal}, clouseau_rpc:get_purge_seq(IndexPid)).
+    ?assertEqual(ok, clouseau_rpc:set_purge_seq(IndexKey, LongVal)),
+    ?assertEqual({ok, LongVal}, clouseau_rpc:get_purge_seq(IndexKey)).
 
-t_delete(_, IndexPid) ->
-    Response = clouseau_rpc:delete(IndexPid, ?Ddoc),
+t_delete(_, IndexKey) ->
+    Response = clouseau_rpc:delete(IndexKey, ?Ddoc),
     ?assertEqual(ok, Response).
 
-t_commit(_, IndexPid) ->
+t_commit(_, IndexKey) ->
     NewCommitSeq = 1,
-    Response = clouseau_rpc:commit(IndexPid, NewCommitSeq),
+    Response = clouseau_rpc:commit(IndexKey, NewCommitSeq),
     ?assertEqual(ok, Response).
 
-t_info(_, IndexPid) ->
-    {ok, Info} = clouseau_rpc:info(IndexPid),
+t_info(_, IndexKey) ->
+    {ok, Info} = clouseau_rpc:info(IndexKey),
     Expected = [
         {disk_size, 0},
         {doc_count, 0},
@@ -100,7 +138,7 @@ t_info(_, IndexPid) ->
     ],
     ?assertEqual(Expected, Info).
 
-t_search(_, IndexPid) ->
+t_search(_, IndexKey) ->
     Args = [
         {query, <<"*:*">>},
         {partition, nil},
@@ -118,18 +156,18 @@ t_search(_, IndexPid) ->
         {highlight_number, 1},
         {highlight_size, 0}
     ],
-    {ok, Response} = clouseau_rpc:search(IndexPid, Args),
+    {ok, Response} = clouseau_rpc:search(IndexKey, Args),
     Expected = {top_docs, 0, 0, [], undefined, undefined},
     ?assertEqual(Expected, Response).
 
-t_group1(_, IndexPid) ->
+t_group1(_, IndexKey) ->
     Query = <<"*:*">>,
     GroupBy = <<"title">>,
     Refresh = true,
     Sort = relevance,
     Offset = 0,
     Limit = 10,
-    {ok, Response} = clouseau_rpc:group1(IndexPid, Query, GroupBy, Refresh, Sort, Offset, Limit),
+    {ok, Response} = clouseau_rpc:group1(IndexKey, Query, GroupBy, Refresh, Sort, Offset, Limit),
     ?assertEqual([], Response).
 
 t_disk_size(_, {_, _, Path}) ->
@@ -171,7 +209,12 @@ t_rename(_, {DbName, _, _}) ->
     ?assertEqual(ok, clouseau_rpc:rename(DbName)).
 
 %%%%%%%%%%%%%%% Utility Functions %%%%%%%%%%%%%%%
-setupDb(Kind) ->
+setupDb(Kind0) ->
+    Kind =
+        case Kind0 of
+            {forwarded, SubKind} -> SubKind;
+            Other -> Kind0
+        end,
     ?assert(test_util:wait_healthy(), "Init service is not ready"),
     DbName = test_util:tempdb(),
     ShardsDbName = <<"shards/00000000-ffffffff/", DbName/binary, ".1730151232">>,
@@ -183,12 +226,20 @@ setup(Kind) ->
     {_, _, Path} = setupDb(Kind),
     {ok, IndexPid} = clouseau_rpc:open_index(self(), Path, ?Analyzer),
     ?assert(is_pid(IndexPid)),
-    IndexPid.
+    case Kind of
+        {forwarded, _} -> {forwarded, Path, IndexPid};
+        _ -> IndexPid
+    end.
 
+stop_indexer(Pid) ->
+    unlink(Pid),
+    exit(Pid, normal),
+    ok.
+
+teardown(_, {forwarded, _Path, IndexPid}) when is_pid(IndexPid) ->
+    stop_indexer(IndexPid);
 teardown(_, IndexPid) when is_pid(IndexPid) ->
-    unlink(IndexPid),
-    exit(IndexPid, normal),
-    ok;
+    stop_indexer(IndexPid);
 teardown(_, _) ->
     ok.
 


### PR DESCRIPTION
Clouseau maintains an LRU cache of actively managed indexes in parallel to Dreyfus (on the CouchDB side), which caches may get out of sync if the rate of eviction is too high.

Such situations may happen when there are too many indexes to manage in a relatively short period of time so that Clouseau is forced to switch between them very rapidly and therefore it becomes a subject of thrashing.  Thrashing may lead to process termination messages of indexers being closed (by the unexpected eviction) not necessarily processed in time and the subsequent search requests on the Dreyfus side will start failing via observing `noproc` errors due to the backing indexer is gone. This immediately translates to an HTTP 500 errors, which is visible to the user.

It is possible to mitigate the problem by raising the size of the LRU cache high enough (by setting the `max_indexes_open` configuration value) so that the chance of eviction becomes low enough to let the indexer termination messages propagate timely. One may consult the recently introduced set of metrics (in #132) to understand the optimal size of the cache with regard to the actual workload.

But that cannot be considered the perfect remedy.  Maintaining a shared state joined by Erlang process identifiers as keys is an inherently fragile idea due to their volatile nature when one of the sides is emulated in Java.  That is why we shall find a more stable key, the path of the index file which is less prone to change.

Indexes would be still managed by dedicated indexers processes as before, but the communication to them would happen solely through a third-party process on the Clouseau side.  This process would then keep track of the states and availability of each indexer and handle the message forwarding for them properly.

The change is implemented in a backward compatible way by incrementally extending the existing Dreyfus-Clouseau interface so that the old-style message passing would just work with CouchDB instances where the new protocol is not yet supported or disabled.