### PR TITLE
Fix CI using force checkout

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -328,7 +328,7 @@ COUCHDB_DIR = $(COUCHDB_ROOT).$(COUCHDB_COMMIT)
 
 $(COUCHDB_DIR)/.checked_out:
 	@git clone $(COUCHDB_REPO) $(COUCHDB_DIR)
-	@cd $(COUCHDB_DIR) && git checkout $(COUCHDB_COMMIT)
+	@cd $(COUCHDB_DIR) && git checkout -f $(COUCHDB_COMMIT)
 	@touch $(COUCHDB_DIR)/.checked_out
 
 $(COUCHDB_DIR)/.configured: $(COUCHDB_DIR)/.checked_out


### PR DESCRIPTION
CI failed while checking out the CouchDB 3.5.1 branch. Therefore, use force checkout to ignore unmerged changes.

Error logs:
```
Cloning into 'deps/couchdb.3.5.1'...
error: Your local changes to the following files would be overwritten by checkout:
	extra/nouveau/gradlew.bat
Please commit your changes or stash them before you switch branches.
Aborting
make: *** [Makefile:331: deps/couchdb.3.5.1/.checked_out] Error 1
Warning: Attempt 1 failed. Reason: Child_process exited with error code 2
```