### PR TITLE
Add a log line when `close_if_idle` is enabled

### DIFF
--- a/clouseau/src/main/scala/com/cloudant/ziose/clouseau/Main.scala
+++ b/clouseau/src/main/scala/com/cloudant/ziose/clouseau/Main.scala
@@ -64,9 +64,15 @@ object Main extends ZIOAppDefault {
     metricsRegistry: ScalangMeterRegistry,
     loggerCfg: LogConfiguration
   ): Task[Unit] = {
-    val node = workerCfg.node
-    val name = s"${node.name}@${node.domain}"
+    val node               = workerCfg.node
+    val name               = s"${node.name}@${node.domain}"
+    val clouseauCfg        = workerCfg.clouseau.get
+    val closeIfIdleEnabled = clouseauCfg.getBoolean("clouseau.close_if_idle", false)
     for {
+      _ <- ZIO.when(closeIfIdleEnabled) {
+        val idleTimeout = clouseauCfg.getInt("clouseau.idle_check_interval_secs", 300)
+        ZIO.logInfo(s"Idle timeout is enabled and will check the indexer idle status every $idleTimeout seconds")
+      }
       _ <- ZIO.logInfo(s"Clouseau running as ${name} from ${entryPoint}")
       _ <- ZIO
         .scoped(main(workerCfg, metricsRegistry, loggerCfg))


### PR DESCRIPTION
To ensure consistency between Clouseau 3.x and 2.x, log `idle_check_interval_secs`
to the console when `close_if_idle` is enabled.