### PR TITLE
fix(`scripts`): find the Clouseau process more reliably for restart test

### DIFF
--- a/scripts/restart-test
+++ b/scripts/restart-test
@@ -31,7 +31,7 @@ for i in $(seq 1 "$RETRY"); do
       break
     fi
   done
-  jcmd | grep clouseau | cut -d' ' -f1 >"$TMP_DIR/t$i.pid"
+  pgrep -f "^java -jar (.*/)?clouseau.*\.jar$" >"$TMP_DIR/t$i.pid"
   before_kill_timestamp=$(date +%s)
   pkill -F "$TMP_DIR/t$i.pid"
 


### PR DESCRIPTION
In `restart-test`, the process to kill is selected via filtering the Java processes discovered by `jcmd`.  This may not always be reliable, and for example, if the tests are run in a container hosted atop Kubernetes in a pod with `clouseau` in its name, equipped with a Jenkins agent (which has the pod name as a command-line argument), the agent itself might get killed instead of Clouseau in result.

Make the discovery of the Clouseau process more robust by tightening the regular expression used for filtering so that the chance of similar mishaps becomes lower.