### PR TITLE
Cleanup Configuration

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -19,6 +19,6 @@ bat 0.24.0
 spotbugs 4.8.6
 # CouchDB tests
 elixir 1.17.3-otp-26
-python 3.12.7
+python 3.14.3
 # documentation
 typst 0.14.0

--- a/clouseau/src/main/scala/com/cloudant/ziose/clouseau/Configuration.scala
+++ b/clouseau/src/main/scala/com/cloudant/ziose/clouseau/Configuration.scala
@@ -1,8 +1,8 @@
 package com.cloudant.ziose.clouseau
 
-import _root_.com.cloudant.ziose.core.Exponent
-import _root_.com.cloudant.ziose.macros.CheckEnv
-import _root_.com.cloudant.ziose.otp.OTPNodeConfig
+import com.cloudant.ziose.core.Exponent
+import com.cloudant.ziose.macros.CheckEnv
+import com.cloudant.ziose.otp.OTPNodeConfig
 import zio.Config.Error
 import zio.config.magnolia.{DeriveConfig, deriveConfig}
 import zio.config.typesafe.FromConfigSourceTypesafe

--- a/clouseau/src/main/scala/com/cloudant/ziose/clouseau/Configuration.scala
+++ b/clouseau/src/main/scala/com/cloudant/ziose/clouseau/Configuration.scala
@@ -22,11 +22,6 @@ object LogFormat {
   case object JSON extends LogFormat
 }
 
-final case class WorkerConfiguration(
-  node: OTPNodeConfig,
-  clouseau: Option[ClouseauConfiguration],
-  capacity: Option[CapacityConfiguration]
-)
 final case class LogConfiguration(
   output: Option[LogOutput],
   format: Option[LogFormat],
@@ -54,6 +49,12 @@ object LogConfiguration {
     }
   }
 }
+
+final case class WorkerConfiguration(
+  node: OTPNodeConfig,
+  clouseau: Option[ClouseauConfiguration],
+  capacity: Option[CapacityConfiguration]
+)
 
 final case class RootDir(value: String) extends AnyVal
 

--- a/clouseau/src/main/scala/com/cloudant/ziose/clouseau/Configuration.scala
+++ b/clouseau/src/main/scala/com/cloudant/ziose/clouseau/Configuration.scala
@@ -81,8 +81,8 @@ final case class ClouseauConfiguration(
         case Some(RootDir(value)) => value
         case None                 => default
       }
-    case "clouseau.lock_class" => lock_class.getOrElse(default).asInstanceOf[String]
-    case "clouseau.dir_class"  => dir_class.getOrElse(default).asInstanceOf[String]
+    case "clouseau.lock_class" => lock_class.getOrElse(default)
+    case "clouseau.dir_class"  => dir_class.getOrElse(default)
     case _                     => throw new Exception(s"Unexpected String key '$key'")
   }
   def getInt(key: String, default: Int) = key match {

--- a/clouseau/src/main/scala/com/cloudant/ziose/clouseau/Configuration.scala
+++ b/clouseau/src/main/scala/com/cloudant/ziose/clouseau/Configuration.scala
@@ -154,22 +154,18 @@ final case class SyslogConfiguration(
 )
 
 /**
- * A data type to hold configured capacity exponent values
+ * A data type to hold configured capacity exponent values. Exponent must be greater than 0. If not specified
+ * backpressure wouldn't be applied.
  * @param analyzer_exponent
- *   An exponent to calculate capacity of the message queue used for `AnalyzerService`. Exponent must be greater than 0.
- *   If not specified backpressure wouldn't be applied.
+ *   An exponent to calculate capacity of the message queue used for ''AnalyzerService''.
  * @param cleanup_exponent
- *   An exponent to calculate capacity of the message queue used for `CleanupService`. Exponent must be greater than 0.
- *   If not specified backpressure wouldn't be applied.
+ *   An exponent to calculate capacity of the message queue used for ''CleanupService''.
  * @param index_exponent
- *   An exponent to calculate capacity of the message queue used for `IndexService`. Exponent must be greater than 0. If
- *   not specified backpressure wouldn't be applied.
+ *   An exponent to calculate capacity of the message queue used for ''IndexService''.
  * @param init_exponent
- *   An exponent to calculate capacity of the message queue used for `InitService`. Exponent must be greater than 0. If
- *   not specified backpressure wouldn't be applied.
+ *   An exponent to calculate capacity of the message queue used for ''InitService''.
  * @param main_exponent
- *   An exponent to calculate capacity of the message queue used for `IndexManagerService`. Exponent must be greater
- *   than 0. If not specified backpressure wouldn't be applied.
+ *   An exponent to calculate capacity of the message queue used for ''InitService''.
  */
 final case class CapacityConfiguration(
   analyzer_exponent: Option[Exponent] = None,
@@ -182,19 +178,20 @@ final case class CapacityConfiguration(
 object CapacityConfiguration {
   def readExponent(value: Int): Either[Error, Exponent] = {
     value match {
-      case 0 =>
-        Left(Error.InvalidData(message = s"Exponent cannot be 0 (got '${value}')"))
-      case v if v < 0 =>
-        Left(Error.InvalidData(message = s"Exponent cannot be negative (got '${value}')"))
-      case v if v > 16 =>
-        Left(Error.InvalidData(message = s"Exponent cannot be greater than 16 (got '${value}')"))
-      case _ =>
+      case v if (1 to 16).contains(v) =>
         Right(Exponent(value))
+      case _ =>
+        Left(
+          Error.InvalidData(
+            message = s"Exponent must be greater than 0 and less than or equal to 16 (got '${value}')"
+          )
+        )
     }
   }
 }
 
 final case class AppCfg(config: List[WorkerConfiguration], logger: LogConfiguration)
+
 object AppCfg {
   implicit val exponentDescriptor: DeriveConfig[Exponent] = {
     DeriveConfig[Int].mapOrFail(CapacityConfiguration.readExponent)

--- a/clouseau/src/main/scala/com/cloudant/ziose/clouseau/Configuration.scala
+++ b/clouseau/src/main/scala/com/cloudant/ziose/clouseau/Configuration.scala
@@ -66,7 +66,6 @@ final case class ClouseauConfiguration(
   idle_check_interval_secs: Option[Int] = None,
   lru_update_interval_msecs: Option[Int] = None,
   max_indexes_open: Option[Int] = None,
-  field_cache_metrics: Option[Boolean] = None,
   field_count_warn_threshold: Option[Int] = None,
   commit_interval_secs: Option[Int] = None,
   lock_class: Option[String] = None,
@@ -102,7 +101,6 @@ final case class ClouseauConfiguration(
     case "clouseau.count_fields"              => count_fields.getOrElse(default)
     case "clouseau.count_locks"               => count_locks.getOrElse(default)
     case "clouseau.close_if_idle"             => close_if_idle.getOrElse(default)
-    case "field_cache_metrics"                => field_cache_metrics.getOrElse(default)
     case "clouseau.concurrent_search_enabled" => concurrent_search_enabled.getOrElse(default)
     case "clouseau.track_index_atimes"        => track_index_atimes.getOrElse(default)
     case _                                    => throw new Exception(s"Unexpected Boolean key '$key'")
@@ -119,7 +117,6 @@ final case class ClouseauConfiguration(
     s"idle_check_interval_secs=$idle_check_interval_secs",
     s"lru_update_interval_msecs=$lru_update_interval_msecs",
     s"max_indexes_open=$max_indexes_open",
-    s"field_cache_metrics=$field_cache_metrics",
     s"commit_interval_secs=$commit_interval_secs",
     s"lock_class=$lock_class",
     s"dir_class=$dir_class",

--- a/clouseau/src/main/scala/com/cloudant/ziose/clouseau/Configuration.scala
+++ b/clouseau/src/main/scala/com/cloudant/ziose/clouseau/Configuration.scala
@@ -12,14 +12,14 @@ sealed abstract class LogOutput
 sealed abstract class LogFormat
 
 object LogOutput {
-  final case object Stdout extends LogOutput
-  final case object Syslog extends LogOutput
+  case object Stdout extends LogOutput
+  case object Syslog extends LogOutput
 }
 
 object LogFormat {
-  final case object Raw  extends LogFormat
-  final case object Text extends LogFormat
-  final case object JSON extends LogFormat
+  case object Raw  extends LogFormat
+  case object Text extends LogFormat
+  case object JSON extends LogFormat
 }
 
 final case class WorkerConfiguration(
@@ -142,8 +142,8 @@ final case class ConfigurationArgs(config: Configuration)
 sealed abstract class SyslogProtocol
 
 object SyslogProtocol {
-  final case object TCP extends SyslogProtocol
-  final case object UDP extends SyslogProtocol
+  case object TCP extends SyslogProtocol
+  case object UDP extends SyslogProtocol
 }
 
 final case class SyslogConfiguration(

--- a/clouseau/src/test/scala/com/cloudant/ziose/clouseau/ConfigSpec.scala
+++ b/clouseau/src/test/scala/com/cloudant/ziose/clouseau/ConfigSpec.scala
@@ -3,18 +3,17 @@ sbt 'clouseau/testOnly com.cloudant.ziose.clouseau.ConfigSpec'
  */
 package com.cloudant.ziose.clouseau
 
-import org.junit.runner.RunWith
-import zio._
-import zio.test.junit.{JUnitRunnableSpec, ZTestJUnitRunner}
-
-import zio.test._
-import zio.test.Assertion._
 import com.cloudant.ziose.core.Exponent
 import com.cloudant.ziose.test.helpers.TestRunner
+import org.junit.runner.RunWith
+import zio.test.Assertion.{equalTo, isSome}
+import zio.test.{assert, assertTrue}
+import zio.test.junit.{JUnitRunnableSpec, ZTestJUnitRunner}
+import zio.{Chunk, Config, LogLevel}
 
 @RunWith(classOf[ZTestJUnitRunner])
 class ConfigSpec extends JUnitRunnableSpec {
-  def capacityFixture(key: String, value: Int) = {
+  def capacityFixture(key: String, value: Int = 0, withCapacity: Boolean = true): String = {
     s"""
        |config: [
        |  {
@@ -23,17 +22,14 @@ class ConfigSpec extends JUnitRunnableSpec {
        |      domain: 127.0.0.1
        |      cookie: cookie
        |    }
-       |    capacity: {
-       |      ${key}: ${value}
-       |    }
+       |    ${if (withCapacity) s"capacity: { $key: $value }".stripMargin else ""}
        |  }
-       |
        |]
        |""".stripMargin
   }
 
-  def suiteForCapacity(key: String, getter: (CapacityConfiguration) => Option[Exponent]) = {
-    def getCapacity(appConfig: AppCfg) = {
+  def suiteForCapacity(key: String, getter: CapacityConfiguration => Option[Exponent]) = {
+    def getCapacity(appConfig: AppCfg): Option[Exponent] = {
       getter(appConfig.config.head.capacity.get)
     }
 
@@ -47,10 +43,10 @@ class ConfigSpec extends JUnitRunnableSpec {
       )
     })
 
-    val invalidTests = IndexedSeq(
-      test("Ensure we return 'InvalidData' error - negative value")(
+    def testInvalidCapacity(name: String, capacity: Int) = {
+      test(s"Ensure we return 'InvalidData' error - $name")(
         for {
-          error <- AppCfg.fromHoconString(capacityFixture(key, -1)).flip.exit
+          error <- AppCfg.fromHoconString(capacityFixture(key, capacity)).flip.exit
         } yield assertTrue(
           error.exists(_.isInstanceOf[Config.Error.InvalidData])
         ) ?? "Expect error of type 'Config.Error.InvalidData'"
@@ -58,56 +54,37 @@ class ConfigSpec extends JUnitRunnableSpec {
             error.exists(_.asInstanceOf[Config.Error.InvalidData].path == Chunk("config", "[0]", "capacity", key))
           ) ?? "Expect error to be for 'config.[0].capacity.${key}' path"
           && assertTrue(
-            error.exists(_.toString().contains(s"got '-1'"))
-          ) ?? s"Expect error message to include provided value ('-1')"
-          && assertTrue(
             error.exists(
-              _.toString().contains("Exponent cannot be negative")
+              _.toString.contains(s"Exponent must be greater than 0 and less than or equal to 16 (got '$capacity'")
             )
-          ) ?? "Expect error message to contain hint"
-      ),
-      test("Ensure we return 'InvalidData' error - zero value")(
+          ) ?? s"Expect error message to include provided value ('$capacity')"
+      )
+    }
+
+    val invalidTests = List(
+      ("negative value", -1),
+      ("zero value", 0),
+      ("big exponent value", 17)
+    ).map { case (name, capacity) =>
+      testInvalidCapacity(name, capacity)
+    }
+
+    val noCapacityTest = List(
+      test(s"No capacity specified in the config")(
         for {
-          error <- AppCfg.fromHoconString(capacityFixture(key, 0)).flip.exit
+          config <- AppCfg.fromHoconString(capacityFixture(key, withCapacity = false))
         } yield assertTrue(
-          error.exists(_.isInstanceOf[Config.Error.InvalidData])
-        ) ?? "Expect error of type 'Config.Error.InvalidData'"
-          && assertTrue(
-            error.exists(_.asInstanceOf[Config.Error.InvalidData].path == Chunk("config", "[0]", "capacity", key))
-          ) ?? "Expect error to be for 'config.[0].capacity.${key}' path"
-          && assertTrue(
-            error.exists(_.toString().contains(s"got '0'"))
-          ) ?? s"Expect error message to include provided value ('0')"
-          && assertTrue(
-            error.exists(
-              _.toString().contains("Exponent cannot be 0")
-            )
-          ) ?? "Expect error message to contain hint"
-      ),
-      test("Ensure we return 'InvalidData' error - big exponent (17)")(
-        for {
-          error <- AppCfg.fromHoconString(capacityFixture(key, 17)).flip.exit
-        } yield assertTrue(
-          error.exists(_.isInstanceOf[Config.Error.InvalidData])
-        ) ?? "Expect error of type 'Config.Error.InvalidData'"
-          && assertTrue(
-            error.exists(_.asInstanceOf[Config.Error.InvalidData].path == Chunk("config", "[0]", "capacity", key))
-          ) ?? "Expect error to be for 'config.[0].capacity.${key}' path"
-          && assertTrue(
-            error.exists(_.toString().contains(s"got '17'"))
-          ) ?? s"Expect error message to include provided value ('17')"
-          && assertTrue(
-            error.exists(
-              _.toString().contains("Exponent cannot be greater than 16")
-            )
-          ) ?? "Expect error message to contain hint"
+          getCapacity(config).isEmpty
+        ) ?? s"Expected capacity should be None"
       )
     )
 
-    suite(s"configSuite for 'config.capacity.${key}'")(validTests ++ invalidTests)
+    suite(s"configSuite for 'config.capacity.$key'")(
+      validTests ++ invalidTests ++ noCapacityTest
+    )
   }
 
-  def logLevelFixture(level: String) = {
+  def logLevelFixture(level: String): String = {
     s"""
        |logger {
        |  level: ${level}
@@ -124,34 +101,32 @@ class ConfigSpec extends JUnitRunnableSpec {
        |""".stripMargin
   }
 
-  def suiteForLogLevel(level: LogLevel): Spec[Any, Throwable] = {
+  def suiteForLogLevel(level: LogLevel) = {
     def levelToString(level: LogLevel) = level.label.toLowerCase() match {
       case "warn"    => "warning"
       case "off"     => "none"
       case lowerCase => lowerCase
     }
+
     val levelLowerCase   = levelToString(level)
     val mixedCase        = levelLowerCase.capitalize
     val trailingSpace    = levelLowerCase + " "
     val leadingSpace     = " " + levelLowerCase
     val levelWithTypo    = levelLowerCase + "typo"
     val expectedLogLevel = s"LogLevel.${levelLowerCase.capitalize}"
+
+    def testLogLevelParsing(name: String, testCase: String) = {
+      test(s"Ensure we can parse log levels - $name")(
+        for {
+          config <- AppCfg.fromHoconString(logLevelFixture(testCase))
+        } yield assertTrue(config.logger.level.get == level) ?? s"Expected Some(${expectedLogLevel})"
+      )
+    }
+
     suite(s"configSuite for 'logger.level' - '${levelLowerCase}'")(
-      test("Ensure we can parse log levels - mixed case")(
-        for {
-          config <- AppCfg.fromHoconString(logLevelFixture(mixedCase))
-        } yield assert(config.logger.level)(isSome(equalTo(level))) ?? s"Expected Some(${expectedLogLevel})"
-      ),
-      test("Ensure we can parse log levels - trailing space")(
-        for {
-          config <- AppCfg.fromHoconString(logLevelFixture(trailingSpace))
-        } yield assert(config.logger.level)(isSome(equalTo(level))) ?? s"Expected Some(${expectedLogLevel})"
-      ),
-      test("Ensure we can parse log levels - leading space")(
-        for {
-          config <- AppCfg.fromHoconString(logLevelFixture(leadingSpace))
-        } yield assert(config.logger.level)(isSome(equalTo(level))) ?? s"Expected Some(${expectedLogLevel})"
-      ),
+      testLogLevelParsing("mixed case", mixedCase),
+      testLogLevelParsing("leading space", leadingSpace),
+      testLogLevelParsing("trailing space", trailingSpace),
       test("Ensure we return 'InvalidData' error - typo")(
         for {
           error <- AppCfg.fromHoconString(logLevelFixture(levelWithTypo)).flip.exit
@@ -162,18 +137,16 @@ class ConfigSpec extends JUnitRunnableSpec {
             error.exists(_.asInstanceOf[Config.Error.InvalidData].path == Chunk("logger", "level"))
           ) ?? "Expect error to be for 'logger.level' path"
           && assertTrue(
-            error.exists(_.toString().contains(s"got '${levelWithTypo}'"))
+            error.exists(_.toString.contains(s"got '${levelWithTypo}'"))
           ) ?? s"Expect error message to include provided value ('${levelWithTypo}')"
           && assertTrue(
-            error.exists(
-              _.toString().contains("ALL|FATAL|ERROR|WARNING|INFO|DEBUG|TRACE|NONE")
-            )
+            error.exists(_.toString.contains("ALL|FATAL|ERROR|WARNING|INFO|DEBUG|TRACE|NONE"))
           ) ?? "Expect error message to contain hint of supported levels"
       )
     )
   }
 
-  def spec: Spec[Any, Throwable] = {
+  def spec = {
     suite("ConfigSpec")(
       suiteForCapacity("analyzer_exponent", capacity => capacity.analyzer_exponent),
       suiteForCapacity("cleanup_exponent", capacity => capacity.cleanup_exponent),


### PR DESCRIPTION
- Remove `_root_` from import statements
- Remove `final` from case objects
- Remove `asInstanceOf[String]`
- Remove unused metric `field_cache_metrics`
- Reorder `WorkerConfiguration`
- Refactor `CapacityConfiguration` and extract some comments
- Update tests in `ConfigSpec.scala`