### PR TITLE
chore(`ci`): upgrade to a recent CouchDB `main` for testing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ ARTIFACTS_DIR=$(BUILD_DIR)/artifacts
 CI_ARTIFACTS_DIR=$(BUILD_DIR)/ci-artifacts
 
 COUCHDB_REPO?=https://github.com/apache/couchdb
-COUCHDB_COMMIT?=3.5.1
+COUCHDB_COMMIT?=d0a509b3f215c0a8379cc1e22183e740ff435927
 COUCHDB_ROOT?=deps/couchdb
 COUCHDB_CONFIGURE_ARGS?=--dev --disable-spidermonkey
 


### PR DESCRIPTION
There was [a commit in last December](https://github.com/apache/couchdb/commit/856c4a729b76b029e283a66cadc35e42bf974162) that broke the CI.  The fix has been identified for that and now pull in that version to catch up with the recent changes in the upstream integration tests (basically Elixir and Mango).