### PR TITLE
clouseau: Abandon using root fibers for managing log events

### DIFF
--- a/clouseau/src/main/scala/com/cloudant/ziose/clouseau/LoggerFactory.scala
+++ b/clouseau/src/main/scala/com/cloudant/ziose/clouseau/LoggerFactory.scala
@@ -1,7 +1,7 @@
 package com.cloudant.ziose.clouseau
 
 import com.cloudant.ziose.scalang.Adapter
-import zio.{Cause, Runtime, LogLevel, Trace, ZIO, ZLayer, ZLogger, UIO, Unsafe, Duration}
+import zio.{Cause, Runtime, LogLevel, Trace, ZIO, ZLayer, ZLogger, UIO, Unsafe}
 import zio.ZIO.{logDebug, logError, logErrorCause, logInfo, logWarning, logWarningCause}
 import zio.logging.{
   loggerName,
@@ -116,7 +116,7 @@ object LoggerFactory {
     }
 
     def log(event: UIO[Unit])(implicit adapter: Adapter[_, _]): Unit = {
-      Unsafe.unsafe(implicit u => adapter.runtime.unsafe.run(event.timeout(Duration.fromSeconds(10)).forkDaemon))
+      Unsafe.unsafe(implicit u => adapter.runtime.unsafe.run(event))
     }
   }
 


### PR DESCRIPTION
Excessive use of root fibers has been proven to have negative impact on performance.  Creating such fibers for each log event seems to be excessive and it might be the reason for random pauses when running Clouseau in a container or on a virtual machine.