### PR TITLE
clouseau: make index services ping themselves to liveness

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -552,7 +552,7 @@ ci-concurrent-zeunit: concurrent-zeunit-tests
 
 ci-mango: $(JAR_ARTIFACTS) couchdb epmd FORCE
 	@cli stop $@ || true
-	@cli start $@ "java $(_JAVA_COOKIE) -jar $<"
+	@cli start $@ "java $(_JAVA_COOKIE) -jar $< ci.app.conf"
 	@sleep 5
 	@cli await $(node_name) "$(ERLANG_COOKIE)"
 	@$(TIMEOUT) $(TIMEOUT_MANGO_TEST) $(MAKE) mango-test || $(MAKE) test-failed ID=$@
@@ -560,7 +560,7 @@ ci-mango: $(JAR_ARTIFACTS) couchdb epmd FORCE
 
 ci-elixir: $(JAR_ARTIFACTS) couchdb epmd FORCE
 	@cli stop $@ || true
-	@cli start $@ "java $(_JAVA_COOKIE) -jar $<"
+	@cli start $@ "java $(_JAVA_COOKIE) -jar $< ci.app.conf"
 	@cli await $(node_name) "$(ERLANG_COOKIE)"
 	@$(TIMEOUT) $(TIMEOUT_ELIXIR_SEARCH) $(MAKE) elixir-search || $(MAKE) test-failed ID=$@
 	@cli stop $@

--- a/app.conf
+++ b/app.conf
@@ -63,6 +63,8 @@ config: [
       ## Class names to use for locks and directories
       # lock_class: org.apache.lucene.store.NativeFSLockFactory
       # dir_class: org.apache.lucene.store.NIOFSDirectory
+      ## Frequency of self-pinging requests for indexers (0: disabled)
+      # liveness: 0
     }
     ## Capacity settings differ from many other configuration settings in that
     ## there are no defaults, so leaving them unset eliminates backpressure,

--- a/ci.app.conf
+++ b/ci.app.conf
@@ -5,8 +5,6 @@ config: [
       domain: 127.0.0.1
     }
     clouseau: {
-      count_locks: true
-      track_index_atimes: true
       liveness: 10
     }
   }

--- a/clouseau/src/main/scala/com/cloudant/ziose/clouseau/Configuration.scala
+++ b/clouseau/src/main/scala/com/cloudant/ziose/clouseau/Configuration.scala
@@ -58,6 +58,8 @@ final case class WorkerConfiguration(
 
 final case class RootDir(value: String) extends AnyVal
 
+final case class Liveness(value: Int) extends AnyVal
+
 final case class ClouseauConfiguration(
   dir: Option[RootDir] = None,
   search_allowed_timeout_msecs: Option[Long] = None,
@@ -73,7 +75,8 @@ final case class ClouseauConfiguration(
   dir_class: Option[String] = None,
   concurrent_search_enabled: Option[Boolean] = None,
   concurrent_search_limit: Option[Int] = None,
-  track_index_atimes: Option[Boolean] = None
+  track_index_atimes: Option[Boolean] = None,
+  liveness: Option[Liveness] = None
 ) {
   def getString(key: String, default: String) = key match {
     case "clouseau.dir" =>
@@ -92,7 +95,12 @@ final case class ClouseauConfiguration(
     case "commit_interval_secs"                => commit_interval_secs.getOrElse(default)
     case "clouseau.concurrent_search_limit"    => concurrent_search_limit.getOrElse(default)
     case "clouseau.field_count_warn_threshold" => field_count_warn_threshold.getOrElse(default)
-    case _                                     => throw new Exception(s"Unexpected Int key '$key'")
+    case "clouseau.liveness"                   =>
+      liveness match {
+        case Some(Liveness(value)) => value
+        case None                  => default
+      }
+    case _ => throw new Exception(s"Unexpected Int key '$key'")
   }
   def getLong(key: String, default: Long) = key match {
     case "clouseau.search_allowed_timeout_msecs" => search_allowed_timeout_msecs.getOrElse(default)
@@ -123,7 +131,8 @@ final case class ClouseauConfiguration(
     s"dir_class=$dir_class",
     s"concurrent_search_enabled=$concurrent_search_enabled",
     s"concurrent_search_limit=$concurrent_search_limit",
-    s"track_index_atimes=$track_index_atimes"
+    s"track_index_atimes=$track_index_atimes",
+    s"liveness=$liveness"
   )
 }
 
@@ -190,6 +199,21 @@ object CapacityConfiguration {
   }
 }
 
+object LivenessConfiguration {
+  def readLiveness(value: Int): Either[Error, Liveness] = {
+    value match {
+      case v if (1 to 1000).contains(v) =>
+        Right(Liveness(value))
+      case _ =>
+        Left(
+          Error.InvalidData(
+            message = s"Liveness must be greater than 0 and less than or equal to 1000 (got '${value}')"
+          )
+        )
+    }
+  }
+}
+
 final case class AppCfg(config: List[WorkerConfiguration], logger: LogConfiguration)
 
 object AppCfg {
@@ -199,6 +223,10 @@ object AppCfg {
 
   implicit val logLevelDescriptor: DeriveConfig[LogLevel] = {
     DeriveConfig[String].mapOrFail(LogConfiguration.readLogLevel)
+  }
+
+  implicit val livenessDescriptor: DeriveConfig[Liveness] = {
+    DeriveConfig[Int].mapOrFail(LivenessConfiguration.readLiveness)
   }
 
   val config: Config[AppCfg] = deriveConfig[AppCfg]

--- a/clouseau/src/main/scala/com/cloudant/ziose/clouseau/IndexService.scala
+++ b/clouseau/src/main/scala/com/cloudant/ziose/clouseau/IndexService.scala
@@ -113,6 +113,7 @@ class IndexService(ctx: ServiceContext[IndexServiceArgs])(implicit adapter: Adap
   // Check if the index is idle and optionally close it if there is no activity between
   //Two consecutive idle status checks.
   val closeIfIdleEnabled = ctx.args.config.getBoolean("clouseau.close_if_idle", false)
+  val liveness = ctx.args.config.getInt("clouseau.liveness", 0)
   val idleTimeout = ctx.args.config.getInt("clouseau.idle_check_interval_secs", 300)
   val lruUpdateInterval = ctx.args.config.getInt("clouseau.lru_update_interval_msecs", 1000)
   // Set initial default to be in the past so we don't miss first LRU update
@@ -127,6 +128,10 @@ class IndexService(ctx: ServiceContext[IndexServiceArgs])(implicit adapter: Adap
 
     if (closeIfIdleEnabled) {
       sendEvery(self.pid, 'close_if_idle, idleTimeout * 1000)
+    }
+
+    if (liveness > 0) {
+      sendEvery(self.pid, 'ping, 1000 / liveness)
     }
 
     logger.debug(prefix_name("Opened at update_seq %d".format(updateSeq)))
@@ -264,6 +269,8 @@ class IndexService(ctx: ServiceContext[IndexServiceArgs])(implicit adapter: Adap
       failed.foreach(w => Service.reply(w.tag, ('error, 'commit_failed)))
       commitWaiters = waiting
       self ! 'maybe_commit
+    case 'ping =>
+      'pong
   }
 
   def countFields() = {


### PR DESCRIPTION
This is an experimental change to explore if emulated Erlang processes in ZIO could "stimulate" themselves in containerized or virtualized environment by sending messages to self.