### PR TITLE
otp: move send operations out from the blocking I/O thread pool

### DIFF
--- a/otp/src/main/scala/com/cloudant/ziose/otp/OTPMailbox.scala
+++ b/otp/src/main/scala/com/cloudant/ziose/otp/OTPMailbox.scala
@@ -260,7 +260,7 @@ class OTPMailbox private (
 
   def send(message: MessageEnvelope.Send)(implicit trace: zio.Trace): UIO[Unit] = {
     // println(s"OTPMailbox.send($msg)")
-    ZIO.succeedBlocking(message.to match {
+    ZIO.succeed(message.to match {
       case PID(pid, _workerId, _workerNodeName) =>
         mbox.send(
           pid.toOtpErlangObject,


### PR DESCRIPTION
This is an experimental change to explore if marking OTP mailbox send operations non-blocking helps with running the application without getting requests timing out in a containerized or virtualized environment.