### PR TITLE
chore(`ci`): work around VM flakiness

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -552,7 +552,7 @@ ci-concurrent-zeunit: concurrent-zeunit-tests
 
 ci-mango: $(JAR_ARTIFACTS) couchdb epmd FORCE
 	@cli stop $@ || true
-	@cli start $@ "java $(_JAVA_COOKIE) -jar $<"
+	@cli start $@ "java $(_JAVA_COOKIE) -jar $< ci.app.conf"
 	@sleep 5
 	@cli await $(node_name) "$(ERLANG_COOKIE)"
 	@$(TIMEOUT) $(TIMEOUT_MANGO_TEST) $(MAKE) mango-test || $(MAKE) test-failed ID=$@
@@ -560,7 +560,7 @@ ci-mango: $(JAR_ARTIFACTS) couchdb epmd FORCE
 
 ci-elixir: $(JAR_ARTIFACTS) couchdb epmd FORCE
 	@cli stop $@ || true
-	@cli start $@ "java $(_JAVA_COOKIE) -jar $<"
+	@cli start $@ "java $(_JAVA_COOKIE) -jar $< ci.app.conf"
 	@cli await $(node_name) "$(ERLANG_COOKIE)"
 	@$(TIMEOUT) $(TIMEOUT_ELIXIR_SEARCH) $(MAKE) elixir-search || $(MAKE) test-failed ID=$@
 	@cli stop $@

--- a/ci.app.conf
+++ b/ci.app.conf
@@ -6,8 +6,6 @@ config: [
     }
     clouseau: {
       commit_interval_secs: 1
-      count_locks: true
-      track_index_atimes: true
     }
   }
 ]


### PR DESCRIPTION
Requests run in the Elixir and Mango tests tend to time out time to time due to reasons unknown at the moment, but only when they are run in virtualized or containerized environments, such as the CI for this repository, based on GitHub Actions.

Increasing the frequency of recurring commit checks seems to offer a way to mitigate the problem so that at least the resulting flakiness can be eliminated for now.