### PR TITLE
Make clouseau-ctrl production friendly by providing config file defaults

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -253,6 +253,17 @@ help:
 		| sort \
 		| awk '{printf("    %-20s", $$1); $$1=$$2=""; print "-" $$0}'
 
+.PHONY: clouseau-ctrl-smoke
+# target: clouseau-ctrl-smoke - Start clouseau1 and verify `clouseau_ctrl service list`
+clouseau-ctrl-smoke: bin/clouseau_ctrl epmd
+	@-cli stop clouseau1 >/dev/null 2>&1
+	@cli start clouseau1 sbt run -Dnode=clouseau1 $(_JAVA_COOKIE)
+	@cli await clouseau1 "$(ERLANG_COOKIE)"
+	@./clouseau-ctrl/_build/default/bin/clouseau_ctrl -config "$(BUILD_DIR)/clouseau-ctrl-config.erl" service list \
+		| tee tmp/clouseau-ctrl-smoke.out \
+		| grep -q analyzer \
+		|| ( echo '>>>>> clouseau_ctrl smoke test failed' ; exit 1 )
+	@-cli stop clouseau1 >/dev/null 2>&1
 
 ############### Tests ###############
 .PHONY: all-tests

--- a/README.md
+++ b/README.md
@@ -119,6 +119,28 @@ JConsole can be connected to a running Clouseau 3.x instance through the standar
 
 ![jmx.png](assets/jmx.png)
 
+## `clouseau_ctrl` configuration
+
+The [`clouseau_ctrl`](./clouseau-ctrl) escript supports default connection settings from a config file in addition to command-line arguments.
+
+Configuration values are looked up in this order (first found wins):
+
+1. Command-line flags: `-name`, `-host`, `-cookie`, `-format`
+2. Environment variables: `CLOUSEAU_NODE_NAME`, `CLOUSEAU_HOST`, `CLOUSEAU_COOKIE`, `CLOUSEAU_FORMAT`
+3. Config file (via `CLOUSEAU_CTRL_CONFIG` or `-config`)
+4. Built-in defaults (e.g., `~/.erlang.cookie` for cookie)
+
+The default config file path is `/etc/clouseau/clouseau-ctrl-config.erl`. A sample file is provided at [`clouseau-ctrl-config.erl`](clouseau-ctrl-config.erl):
+
+```erlang
+{name, "clouseau1"}.
+{host, "127.0.0.1"}.
+%% {cookie, "secret"}.
+{format, table}.
+```
+
+This allows wrappers to provide stable defaults without exposing the Erlang cookie on the process command line.
+
 ## Using `sbt`
 
 The Scala Built Tool `sbt` can be used directly to compile and start up the service, or to run individual unit tests, e.g.

--- a/clouseau-ctrl-config.erl
+++ b/clouseau-ctrl-config.erl
@@ -1,0 +1,6 @@
+{name, "clouseau1"}.
+{host, "127.0.0.1"}.
+%% By default ~/.erlang.cookie is used when cookie is not configured here
+%% or via the CLOUSEAU_COOKIE environment variable.
+%% {cookie, "secret"}.
+{format, table}.

--- a/clouseau-ctrl/src/clouseau_cli.erl
+++ b/clouseau-ctrl/src/clouseau_cli.erl
@@ -5,69 +5,25 @@
     run/2
 ]).
 
+-ifdef(TEST).
+-export([
+    normalize_args/1,
+    read_config/1,
+    resolve_value/3,
+    to_format/1
+]).
+-endif.
+
 parser_options() ->
     #{progname => clouseau_cli}.
 
 spec(Services) ->
+    spec(Services, runtime).
+
+spec(Services, Mode) ->
     #{
         help => "Utility to control 'clouseau' process",
-        arguments => [
-            #{
-                name => script_name,
-                long => "script_name",
-                type => string,
-                default => "clouseau_cli",
-                help => hidden
-            },
-            #{
-                name => script_path,
-                long => "script_path",
-                type => string,
-                default => escript:script_name(),
-                help => hidden
-            },
-            #{
-                name => script_dir,
-                long => "script_dir",
-                type => string,
-                default => filename:dirname(escript:script_name()),
-                help => hidden
-            },
-            #{
-                name => name,
-                short => $n,
-                long => "name",
-                type => string,
-                default => getenv("CLOUSEAU_NODE_NAME"),
-                help => "The name of clouseau node (e.g. 'clouseau1')"
-            },
-            #{
-                name => cookie,
-                short => $c,
-                long => "cookie",
-                type => string,
-                default => getenv("CLOUSEAU_COOKIE"),
-                help => "Erlang cookie to use for connecting"
-            },
-            #{
-                name => host,
-                short => $h,
-                long => "host",
-                type => string,
-                default => "127.0.0.1",
-                help => "Host name of the clouseau node (e.g. '127.0.0.1')"
-            },
-            #{
-                name => format,
-                short => $f,
-                long => "format",
-                type => atom,
-                default => table,
-                help => "Output format: 'json' or 'table'",
-                choices => [json, table]
-            }
-        ],
-
+        arguments => arguments(Mode),
         commands => #{
             "service" => #{
                 help => "Service management",
@@ -116,24 +72,194 @@ spec(Services) ->
         }
     }.
 
+arguments(Mode) ->
+    [
+        #{
+            name => script_name,
+            long => "script_name",
+            type => string,
+            default => "clouseau_cli",
+            help => hidden
+        },
+        #{
+            name => script_path,
+            long => "script_path",
+            type => string,
+            default => script_path(),
+            help => hidden
+        },
+        #{
+            name => script_dir,
+            long => "script_dir",
+            type => string,
+            default => filename:dirname(script_path()),
+            help => hidden
+        },
+        #{
+            name => config,
+            long => "config",
+            type => string,
+            default => default_config_path(),
+            help => "Path to clouseau-ctrl config file. Can also be set via CLOUSEAU_CTRL_CONFIG."
+        },
+        maybe_default(
+            #{
+                name => name,
+                long => "name",
+                type => string,
+                help =>
+                    "The name of clouseau node (e.g. 'clouseau1'). Resolution order: CLI, CLOUSEAU_NODE_NAME, config file."
+            },
+            false,
+            Mode
+        ),
+        maybe_default(
+            #{
+                name => cookie,
+                long => "cookie",
+                type => string,
+                help =>
+                    "Erlang cookie to use for connecting. Resolution order: CLI, CLOUSEAU_COOKIE, config file, ~/.erlang.cookie."
+            },
+            false,
+            Mode
+        ),
+        maybe_default(
+            #{
+                name => host,
+                long => "host",
+                type => string,
+                help =>
+                    "Host name of the clouseau node (e.g. '127.0.0.1'). Resolution order: CLI, CLOUSEAU_HOST, config file, 127.0.0.1."
+            },
+            false,
+            Mode
+        ),
+        maybe_default(
+            #{
+                name => format,
+                long => "format",
+                type => atom,
+                help =>
+                    "Output format: 'json' or 'table'. Resolution order: CLI, CLOUSEAU_FORMAT, config file, table.",
+                choices => [json, table]
+            },
+            false,
+            Mode
+        )
+    ].
+
 help(Services) ->
-    argparse:help(spec(Services), parser_options()).
+    argparse:help(spec(Services, help), parser_options()).
 
 run(["--help"], Services) ->
     io:format("~s", [help(Services)]);
 run(["help"], Services) ->
     io:format("~s", [help(Services)]);
 run(Args, Services) ->
-    argparse:run(Args, spec(Services), parser_options()).
+    {ok, ParsedArgs, _Path, CommandSpec} = argparse:parse(Args, spec(Services), parser_options()),
+    clouseau_utils:dispatch(
+        normalize_args(
+            maps:merge(ParsedArgs, maps:with([handler], CommandSpec))
+        )
+    ).
 
 %%====================================================================
 %% Internal functions
 %%====================================================================
 
-getenv(Name) ->
-    case os:getenv(Name) of
+default_config_path() ->
+    case os:getenv("CLOUSEAU_CTRL_CONFIG") of
         false ->
-            undefined;
-        Value ->
-            Value
+            filename:join("/etc/clouseau", "clouseau-ctrl-config.erl");
+        Path ->
+            Path
+    end.
+
+maybe_default(Argument, Default, runtime) ->
+    Argument#{default => Default};
+maybe_default(Argument, _Default, help) ->
+    Argument.
+
+script_path() ->
+    case catch escript:script_name() of
+        {'EXIT', _} ->
+            "clouseau_cli";
+        [] ->
+            "clouseau_cli";
+        Path ->
+            Path
+    end.
+
+normalize_args(ParsedArgs) ->
+    ConfigPath = maps:get(config, ParsedArgs, default_config_path()),
+    Config = read_config(ConfigPath),
+    Defaults = #{
+        config => ConfigPath,
+        name => resolve_value(
+            maps:get(name, ParsedArgs, false),
+            os:getenv("CLOUSEAU_NODE_NAME"),
+            maps:get(name, Config, undefined)
+        ),
+        cookie => resolve_value(
+            maps:get(cookie, ParsedArgs, false),
+            os:getenv("CLOUSEAU_COOKIE"),
+            maps:get(cookie, Config, undefined)
+        ),
+        host => resolve_value(
+            maps:get(host, ParsedArgs, false),
+            os:getenv("CLOUSEAU_HOST"),
+            maps:get(host, Config, "127.0.0.1")
+        ),
+        format => to_format(
+            resolve_value(
+                maps:get(format, ParsedArgs, false),
+                os:getenv("CLOUSEAU_FORMAT"),
+                maps:get(format, Config, table)
+            )
+        )
+    },
+    FilteredParsedArgs = maps:filter(fun(_K, V) -> V =/= false end, ParsedArgs),
+    maps:merge(Defaults, FilteredParsedArgs).
+
+to_format("json") ->
+    json;
+to_format("table") ->
+    table;
+to_format(json) ->
+    json;
+to_format(table) ->
+    table;
+to_format(_) ->
+    table.
+
+resolve_value(false, false, Default) ->
+    Default;
+resolve_value(false, undefined, Default) ->
+    Default;
+resolve_value(false, EnvValue, _Default) ->
+    EnvValue;
+resolve_value(undefined, false, Default) ->
+    Default;
+resolve_value(undefined, undefined, Default) ->
+    Default;
+resolve_value(undefined, EnvValue, _Default) ->
+    EnvValue;
+resolve_value(Value, _EnvValue, _Default) ->
+    Value.
+
+read_config(Path) ->
+    case file:consult(Path) of
+        {ok, [{_, _} | _] = Config} ->
+            maps:from_list(
+                [{Key, Value} || {Key, Value} <- Config]
+            );
+        {error, enoent} ->
+            #{};
+        {error, Reason} ->
+            io:format(standard_error, "Error: Unable to read config file ~s: ~p~n", [Path, Reason]),
+            halt(1);
+        {ok, _} ->
+            io:format(standard_error, "Error: Invalid config file format: ~s~n", [Path]),
+            halt(1)
     end.

--- a/clouseau-ctrl/src/clouseau_utils.erl
+++ b/clouseau-ctrl/src/clouseau_utils.erl
@@ -4,6 +4,7 @@
 
 -export([
     init/1,
+    dispatch/1,
     check_node_ping/1,
     concurrent_retry/2,
     random_string/1,
@@ -19,6 +20,9 @@
 -define(NODE_TIMEOUT_IN_MS, 60_000).
 -define(PING_TIMEOUT_IN_MS, 10_000).
 -define(RETRY_DELAY, 300).
+
+dispatch(#{handler := {Module, Function}} = Args) ->
+    apply(Module, Function, [maps:remove(handler, Args)]).
 
 set_custom_cookie(#clouseau_ctx{cookie = undefined}) ->
     ok;


### PR DESCRIPTION
Make clouseau-ctrl production friendly by providing default parameters through a config file.

Related issue: https://github.ibm.com/cloudant/dbcore/issues/659