### PR TITLE
Upgrade JInterface to OTP-27

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -4,7 +4,7 @@ direnv 2.37.1
 java openjdk-21.0.2
 scala 2.13.18
 # erlang needs java so it should be after it in the list
-erlang 26.2.5.20
+erlang 27.3.4.11
 rebar 3.27.0
 coursier 2.1.24
 editorconfig-checker 3.6.1
@@ -18,7 +18,7 @@ bat 0.26.0
 # static analysis tool
 spotbugs 4.8.6
 # CouchDB tests
-elixir 1.19.5-otp-26
+elixir 1.19.5-otp-27
 python 3.14.4
 # documentation
 typst 0.14.2

--- a/vendor/src/main/java/com/ericsson/otp/erlang/AbstractConnection.java
+++ b/vendor/src/main/java/com/ericsson/otp/erlang/AbstractConnection.java
@@ -428,29 +428,12 @@ public abstract class AbstractConnection extends Thread {
         header.write1(passThrough);
         header.write1(version);
 
-        if ((peer.flags & AbstractNode.dFlagUnlinkId) != 0) {
-            // header
-            header.write_tuple_head(4);
-            header.write_long(unlinkIdTag);
-            header.write_long(unlink_id);
-            header.write_any(from);
-            header.write_any(dest);
-        }
-        else {
-            /*
-             * A node that isn't capable of talking the new link protocol.
-             *
-             * Send an old unlink op, and send ourselves an unlink-ack. We may
-             * end up in an inconsistent state as we could before the new link
-             * protocol was introduced...
-             */
-            // header
-            header.write_tuple_head(3);
-            header.write_long(unlinkTag);
-            header.write_any(from);
-            header.write_any(dest);
-            deliver(new OtpMsg(unlinkIdAckTag, dest, from, unlink_id));
-        }
+        // header
+        header.write_tuple_head(4);
+        header.write_long(unlinkIdTag);
+        header.write_long(unlink_id);
+        header.write_any(from);
+        header.write_any(dest);
 
         // fix up length in preamble
         header.poke4BE(0, header.size() - 4);
@@ -474,26 +457,25 @@ public abstract class AbstractConnection extends Thread {
         if (!connected) {
             throw new IOException("Not connected");
         }
-        if ((peer.flags & AbstractNode.dFlagUnlinkId) != 0) {
-            @SuppressWarnings("resource")
-            final OtpOutputStream header = new OtpOutputStream(headerLen);
 
-            // preamble: 4 byte length + "passthrough" tag
-            header.write4BE(0); // reserve space for length
-            header.write1(passThrough);
-            header.write1(version);
+        @SuppressWarnings("resource")
+        final OtpOutputStream header = new OtpOutputStream(headerLen);
 
-            // header
-            header.write_tuple_head(4);
-            header.write_long(unlinkIdAckTag);
-            header.write_long(unlink_id);
-            header.write_any(from);
-            header.write_any(dest);
-            // fix up length in preamble
-            header.poke4BE(0, header.size() - 4);
+        // preamble: 4 byte length + "passthrough" tag
+        header.write4BE(0); // reserve space for length
+        header.write1(passThrough);
+        header.write1(version);
 
-            do_send(header);
-        }
+        // header
+        header.write_tuple_head(4);
+        header.write_long(unlinkIdAckTag);
+        header.write_long(unlink_id);
+        header.write_any(from);
+        header.write_any(dest);
+        // fix up length in preamble
+        header.poke4BE(0, header.size() - 4);
+
+        do_send(header);
 
     }
 

--- a/vendor/src/main/java/com/ericsson/otp/erlang/AbstractNode.java
+++ b/vendor/src/main/java/com/ericsson/otp/erlang/AbstractNode.java
@@ -111,9 +111,14 @@ public class AbstractNode implements OtpTransportFactory {
         | dFlagBitBinaries
         | dFlagHandshake23;
 
+    /* New mandatory flags in OTP 26 */
+    static final long mandatoryFlags26 = dFlagV4PidsRefs
+        | dFlagUnlinkId;
+
     /* Mandatory flags for distribution. Keep them in sync with
        DFLAG_DIST_MANDATORY in erts/emulator/beam/dist.h. */
-    static final long mandatoryFlags = mandatoryFlags25;
+    static final long mandatoryFlags = mandatoryFlags25
+        | mandatoryFlags26;
 
     int ntype = NTYPE_R6;
     int proto = 0; // tcp/ip
@@ -123,8 +128,6 @@ public class AbstractNode implements OtpTransportFactory {
     long flags = mandatoryFlags
         | dFlagDistMonitor
         | dFlagDistMonitorName
-        | dFlagUnlinkId
-        | dFlagV4PidsRefs
         | dFlagMandatory25Digest;
 
     /* initialize hostname and default cookie */


### PR DESCRIPTION
- Upgrade Erlang to `27.3.4.11` and Elixir to `1.19.5-otp-27`.
- Update JInterface to `1.14.1 (OTP-27)`: Identify the differences between JInterface `1.13.2 (OTP-25)` and `1.14.1 (OTP-27)`, and update the codebase in vendor.