### PR TITLE
Use `boost` instead of the magic number

### DIFF
--- a/clouseau/src/main/scala/com/cloudant/ziose/clouseau/ClouseauTypeFactory.scala
+++ b/clouseau/src/main/scala/com/cloudant/ziose/clouseau/ClouseauTypeFactory.scala
@@ -88,7 +88,7 @@ object ClouseauTypeFactory extends TypeFactory {
                 case Some(field: Field) =>
                   map.get("boost") match {
                     case Some(boost: Number) =>
-                      field.setBoost(toFloat(1.2))
+                      field.setBoost(toFloat(boost))
                       'ok
                     // make the match exhaustive
                     case Some(_) =>


### PR DESCRIPTION
Clouseau 2.x is using `boost` instead of `1.2`.

See https://github.com/cloudant-labs/clouseau/blob/clouseau-2.x/src/main/scala/com/cloudant/clouseau/ClouseauTypeFactory.scala#L131