### PR TITLE
Add `mise` postinstall hook to update tool versions in `mise.toml` and config files

### DIFF
--- a/.editorconfig-checker.json
+++ b/.editorconfig-checker.json
@@ -1,5 +1,5 @@
 {
-  "Version": "v3.6.1",
+  "Version": "v3.7.0",
   "Verbose": false,
   "Debug": false,
   "IgnoreDefaults": false,

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -4,7 +4,7 @@
 # { Braces }
 # ( Paranthesis )
 
-version = "3.11.0"
+version = 3.11.1
 maxColumn = 120
 align.preset = more
 align.multiline = false

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -4,6 +4,7 @@
 # { Braces }
 # ( Paranthesis )
 
+# Sync version with "mise.toml"
 version = 3.11.1
 maxColumn = 120
 align.preset = more

--- a/mise.toml
+++ b/mise.toml
@@ -3,16 +3,31 @@
 
 [tools]
 bat = "0.26.0"
-editorconfig-checker = "3.6.1"
+editorconfig-checker = { version = "3.6.1", postinstall = """
+jq --arg v "v$MISE_TOOL_VERSION" '.Version = $v' .editorconfig-checker.json >tmp.json &&
+mv tmp.json .editorconfig-checker.json
+""" }
 elixir = "1.19.5-otp-27"
 erlang = "27.3.4.11"
 github-cli = "2.91.0"
 java = "openjdk-21.0.2"
 python = "3.14.4"
 rebar = "3.27.0"
-sbt = "1.12.9"
+sbt = { version = "1.12.9", postinstall = """
+if [[ $OSTYPE == "darwin"* ]]; then
+  sed -i "" "s/sbt.version=.*/sbt.version=$MISE_TOOL_VERSION/" ./project/build.properties
+else
+  sed -i "s/sbt.version=.*/sbt.version=$MISE_TOOL_VERSION/" ./project/build.properties
+fi
+""" }
 scala = "2.13.18"
-scalafmt = "3.11.0"
+scalafmt = { version = "3.11.0", postinstall = """
+if [[ $OSTYPE == "darwin"* ]]; then
+  sed -i "" "s/version = .*/version = $MISE_TOOL_VERSION/" .scalafmt.conf
+else
+  sed -i "s/version = .*/version = $MISE_TOOL_VERSION/" .scalafmt.conf
+fi
+""" }
 typst = "0.14.2"
 
 [env]

--- a/mise.toml
+++ b/mise.toml
@@ -2,16 +2,17 @@
 # See: https://mise.jdx.dev/configuration.html
 
 [tools]
-bat = "0.26.0"
-editorconfig-checker = { version = "3.6.1", postinstall = """
+bat = "0.26.1"
+editorconfig-checker = { version = "3.7.0", postinstall = """
 jq --arg v "v$MISE_TOOL_VERSION" '.Version = $v' .editorconfig-checker.json >tmp.json &&
 mv tmp.json .editorconfig-checker.json
 """ }
 elixir = "1.19.5-otp-27"
 erlang = "27.3.4.11"
-github-cli = "2.91.0"
+github-cli = "2.92.0"
 java = "openjdk-21.0.2"
-python = "3.14.4"
+jq = "1.8.1"
+python = "3.14.5"
 rebar = "3.27.0"
 sbt = { version = "1.12.9", postinstall = """
 if [[ $OSTYPE == "darwin"* ]]; then
@@ -21,7 +22,7 @@ else
 fi
 """ }
 scala = "2.13.18"
-scalafmt = { version = "3.11.0", postinstall = """
+scalafmt = { version = "3.11.1", postinstall = """
 if [[ $OSTYPE == "darwin"* ]]; then
   sed -i "" "s/version = .*/version = $MISE_TOOL_VERSION/" .scalafmt.conf
 else

--- a/mise.toml
+++ b/mise.toml
@@ -3,6 +3,7 @@
 
 [tools]
 bat = "0.26.1"
+# Sync version with ".editorconfig-checker.json"
 editorconfig-checker = { version = "3.7.0", postinstall = """
 jq --arg v "v$MISE_TOOL_VERSION" '.Version = $v' .editorconfig-checker.json >tmp.json &&
 mv tmp.json .editorconfig-checker.json
@@ -14,6 +15,7 @@ java = "openjdk-21.0.2"
 jq = "1.8.1"
 python = "3.14.5"
 rebar = "3.27.0"
+# Sync version with "./project/build.properties"
 sbt = { version = "1.12.9", postinstall = """
 if [[ $OSTYPE == "darwin"* ]]; then
   sed -i "" "s/sbt.version=.*/sbt.version=$MISE_TOOL_VERSION/" ./project/build.properties
@@ -22,6 +24,7 @@ else
 fi
 """ }
 scala = "2.13.18"
+# Sync version with ".scalafmt.conf"
 scalafmt = { version = "3.11.1", postinstall = """
 if [[ $OSTYPE == "darwin"* ]]; then
   sed -i "" "s/version = .*/version = $MISE_TOOL_VERSION/" .scalafmt.conf

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,2 @@
+# Sync version with "mise.toml"
 sbt.version=1.12.9


### PR DESCRIPTION
When updating tools in `mise.toml`, we need to remember to update the version information within their own respective configuration files simultaneously. For example:

- editorconfig-checker: `.editorconfig-checker.json`
- sbt: `./project/build.properties`
- scalafmt: `.scalafmt.conf`

After adding the `mise` postinstall hook, we can manually update `mise.toml` and then run `mise install`; subsequently, the config file will automatically update to the new version.