### PR TITLE
Package release in tar.gz

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   release:
-    name: Release of clouseau-{version}-dist.zip
+    name: Release of clouseau-{version}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/Makefile
+++ b/Makefile
@@ -611,7 +611,7 @@ $(ARTIFACTS_DIR)/%.tar.gz.chksum: $(ARTIFACTS_DIR)/%.tar.gz
 	@cd $(ARTIFACTS_DIR) && sha256sum $(<F) > $(@F)
 
 $(ARTIFACTS_DIR)/checksums.txt: $(addprefix $(ARTIFACTS_DIR)/, $(CHECKSUM_FILES))
-	@cat $? > $@
+	@cat $^ > $@
 	@cd $(ARTIFACTS_DIR)/ && sha256sum -c checksums.txt
 
 $(ARTIFACTS_DIR)/clouseau_ctrl: bin/clouseau_ctrl

--- a/Makefile
+++ b/Makefile
@@ -593,13 +593,13 @@ $(ARTIFACTS_DIR)/clouseau-$(PROJECT_VSN)-dist.zip: $(JAR_ARTIFACTS) $(ARTIFACTS_
 	@mkdir -p $(ARTIFACTS_DIR)/clouseau-$(PROJECT_VSN)
 	@cp $(JAR_ARTIFACTS) $(ARTIFACTS_DIR)/clouseau-$(PROJECT_VSN)
 	@cp $(ARTIFACTS_DIR)/clouseau_ctrl $(ARTIFACTS_DIR)/clouseau-$(PROJECT_VSN)
-	@zip -r $@ $(ARTIFACTS_DIR)/clouseau-$(PROJECT_VSN)
+	@cd $(ARTIFACTS_DIR) && zip -r $@ clouseau-$(PROJECT_VSN)
 
 $(ARTIFACTS_DIR)/clouseau-$(PROJECT_VSN)-dist.tar.gz: $(JAR_ARTIFACTS) $(ARTIFACTS_DIR)/clouseau_ctrl
 	@mkdir -p $(ARTIFACTS_DIR)/clouseau-$(PROJECT_VSN)
 	@cp $(JAR_ARTIFACTS) $(ARTIFACTS_DIR)/clouseau-$(PROJECT_VSN)
 	@cp $(ARTIFACTS_DIR)/clouseau_ctrl $(ARTIFACTS_DIR)/clouseau-$(PROJECT_VSN)
-	@tar --gzip -cf $@ $(ARTIFACTS_DIR)/clouseau-$(PROJECT_VSN)
+	@cd $(ARTIFACTS_DIR) && tar --gzip -cf $@ clouseau-$(PROJECT_VSN)
 
 $(ARTIFACTS_DIR)/%.jar.chksum: $(ARTIFACTS_DIR)/%.jar
 	@cd $(ARTIFACTS_DIR) && sha256sum $(<F) > $(@F)

--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,8 @@ JAR_PROD := clouseau_$(SCALA_VSN)_$(PROJECT_VSN).jar
 JAR_TEST := clouseau_$(SCALA_VSN)_$(PROJECT_VSN)_test.jar
 
 RELEASE_FILES := $(JAR_PROD) \
-	clouseau-$(PROJECT_VSN)-dist.zip
+	clouseau-$(PROJECT_VSN)-dist.zip \
+	clouseau-$(PROJECT_VSN)-dist.tar.gz
 
 JAR_ARTIFACTS := $(addprefix $(ARTIFACTS_DIR)/, $(JAR_PROD))
 RELEASE_ARTIFACTS := $(addprefix $(ARTIFACTS_DIR)/, $(RELEASE_FILES))
@@ -589,15 +590,24 @@ release: $(RELEASE_ARTIFACTS) $(ARTIFACTS_DIR)/checksums.txt
 		--generate-notes $(RELEASE_ARTIFACTS) $(ARTIFACTS_DIR)/checksums.txt
 
 $(ARTIFACTS_DIR)/clouseau-$(PROJECT_VSN)-dist.zip: $(JAR_ARTIFACTS) $(ARTIFACTS_DIR)/clouseau_ctrl
-	@mkdir -p $(ARTIFACTS_DIR)/clouseau-$(PROJECT_VSN)/bin
+	@mkdir -p $(ARTIFACTS_DIR)/clouseau-$(PROJECT_VSN)
 	@cp $(JAR_ARTIFACTS) $(ARTIFACTS_DIR)/clouseau-$(PROJECT_VSN)
-	@cp $(ARTIFACTS_DIR)/clouseau_ctrl $(ARTIFACTS_DIR)/clouseau-$(PROJECT_VSN)/bin
-	@zip --junk-paths -r $@ $(ARTIFACTS_DIR)/clouseau-$(PROJECT_VSN)
+	@cp $(ARTIFACTS_DIR)/clouseau_ctrl $(ARTIFACTS_DIR)/clouseau-$(PROJECT_VSN)
+	@zip -r $@ $(ARTIFACTS_DIR)/clouseau-$(PROJECT_VSN)
+
+$(ARTIFACTS_DIR)/clouseau-$(PROJECT_VSN)-dist.tar.gz: $(JAR_ARTIFACTS) $(ARTIFACTS_DIR)/clouseau_ctrl
+	@mkdir -p $(ARTIFACTS_DIR)/clouseau-$(PROJECT_VSN)
+	@cp $(JAR_ARTIFACTS) $(ARTIFACTS_DIR)/clouseau-$(PROJECT_VSN)
+	@cp $(ARTIFACTS_DIR)/clouseau_ctrl $(ARTIFACTS_DIR)/clouseau-$(PROJECT_VSN)
+	@tar --gzip -cf $@ $(ARTIFACTS_DIR)/clouseau-$(PROJECT_VSN)
 
 $(ARTIFACTS_DIR)/%.jar.chksum: $(ARTIFACTS_DIR)/%.jar
 	@cd $(ARTIFACTS_DIR) && sha256sum $(<F) > $(@F)
 
 $(ARTIFACTS_DIR)/%.zip.chksum: $(ARTIFACTS_DIR)/%.zip
+	@cd $(ARTIFACTS_DIR) && sha256sum $(<F) > $(@F)
+
+$(ARTIFACTS_DIR)/%.tar.gz.chksum: $(ARTIFACTS_DIR)/%.tar.gz
 	@cd $(ARTIFACTS_DIR) && sha256sum $(<F) > $(@F)
 
 $(ARTIFACTS_DIR)/checksums.txt: $(addprefix $(ARTIFACTS_DIR)/, $(CHECKSUM_FILES))

--- a/Makefile
+++ b/Makefile
@@ -615,7 +615,7 @@ $(ARTIFACTS_DIR)/checksums.txt: $(addprefix $(ARTIFACTS_DIR)/, $(CHECKSUM_FILES)
 	@cd $(ARTIFACTS_DIR)/ && sha256sum -c checksums.txt
 
 $(ARTIFACTS_DIR)/clouseau_ctrl: bin/clouseau_ctrl
-	@cp $? $@
+	@cp $^ $@
 
 .PHONY: ci-release
 ci-release:


### PR DESCRIPTION
The PR adds `.tar.gz` format to Clouseau release artefacts alongside the current `.zip` format. 