### PR TITLE
chore: update Prometheus JMX Exporter to 1.6.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,7 @@ JMX_EXPORTER_VSN ?= 1.5.0
 JMX_EXPORTER ?= jmx_prometheus_javaagent-$(JMX_EXPORTER_VSN).jar
 JMX_EXPORTER_CFG ?= test/prometheus/jmx_exporter.yaml
 JMX_EXPORTER_PORT ?= 8080
-JMX_EXPORTER_URL := https://github.com/prometheus/jmx_exporter/releases/download/$(JMX_EXPORTER_VSN)/$(JMX_EXPORTER)
+JMX_EXPORTER_URL := https://github.com/prometheus/jmx_exporter/releases/download/v$(JMX_EXPORTER_VSN)/$(JMX_EXPORTER)
 
 comma := ,
 empty :=

--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,7 @@ RELEASE_ARTIFACTS := $(addprefix $(ARTIFACTS_DIR)/, $(RELEASE_FILES))
 
 CHECKSUM_FILES := $(foreach file, $(RELEASE_FILES), $(file).chksum)
 
-JMX_EXPORTER_VSN ?= 1.5.0
+JMX_EXPORTER_VSN ?= 1.6.0
 JMX_EXPORTER ?= jmx_prometheus_javaagent-$(JMX_EXPORTER_VSN).jar
 JMX_EXPORTER_CFG ?= test/prometheus/jmx_exporter.yaml
 JMX_EXPORTER_PORT ?= 8080
@@ -437,7 +437,7 @@ metrics-tests: $(JAR_ARTIFACTS) $(JMX_EXPORTER) test/collectd/clouseau.class epm
 			sort > test/collectd/metrics.out)
 	@$(call collect_and_compare,\
 			prometheus,\
-			curl -Ss "http://localhost:$(JMX_EXPORTER_PORT)/metrics" | \
+			curl -Ss "http://localhost:$(JMX_EXPORTER_PORT)/custom_path" | \
 				sed -n 's/^\(_com_cloudant_clouseau.*\)[[:space:]].*/\1/p' | \
 				sort > test/prometheus/metrics.out)
 

--- a/test/prometheus/jmx_exporter.yaml
+++ b/test/prometheus/jmx_exporter.yaml
@@ -1,3 +1,7 @@
+httpServer:
+  metrics:
+    path: /custom_path
+
 startDelaySeconds: 0
 rules:
   - pattern: com.cloudant.clouseau


### PR DESCRIPTION
This [version](https://github.com/prometheus/jmx_exporter/releases/tag/v1.6.0) now includes our extension that makes it possible to customize the endpoint where metrics are exposed.