### PR TITLE
fix(`otp`): make ping configurable for monitoring the CouchDB node

### DIFF
--- a/app.conf
+++ b/app.conf
@@ -33,6 +33,10 @@ config: [
       ## Or use `-Dcookie=` to configure this from the command line.  Additionally,
       ## `-Dcookie.file=` is available for setting the file name that holds the
       ## cookie value
+      ## Ping timeout and interval when checking availability of the connected
+      ## CouchDB node
+      # ping_timeout: 1 seconds
+      # ping_interval: 60 seconds
     }
     clouseau: {
       ## Path to index directory

--- a/clouseau/src/main/scala/com/cloudant/ziose/clouseau/Main.scala
+++ b/clouseau/src/main/scala/com/cloudant/ziose/clouseau/Main.scala
@@ -41,7 +41,7 @@ object Main extends ZIOAppDefault {
       runtime  <- ZIO.runtime[EngineWorker & Node & ActorFactory]
       otp_node <- ZIO.service[Node]
       remote_node = s"node${workerCfg.node.name.last}@${workerCfg.node.domain}"
-      _      <- otp_node.monitorRemoteNode(remote_node)
+      _      <- otp_node.monitorRemoteNode(remote_node, workerCfg.node.pingTimeoutVal, workerCfg.node.pingIntervalVal)
       worker <- ZIO.service[EngineWorker]
       logLevel = loggerCfg.level.getOrElse(LogLevel.Debug)
       node       <- ZIO.succeed(new ClouseauNode()(runtime, worker, metricsRegistry, logLevel))

--- a/clouseau/src/main/scala/com/cloudant/ziose/clouseau/Main.scala
+++ b/clouseau/src/main/scala/com/cloudant/ziose/clouseau/Main.scala
@@ -41,7 +41,11 @@ object Main extends ZIOAppDefault {
       runtime  <- ZIO.runtime[EngineWorker & Node & ActorFactory]
       otp_node <- ZIO.service[Node]
       remote_node = s"node${workerCfg.node.name.last}@${workerCfg.node.domain}"
-      _      <- otp_node.monitorRemoteNode(remote_node)
+      _ <- otp_node.monitorRemoteNode(
+        remote_node,
+        workerCfg.node.pingTimeoutResolved,
+        workerCfg.node.pingIntervalResolved
+      )
       worker <- ZIO.service[EngineWorker]
       logLevel = loggerCfg.level.getOrElse(LogLevel.Debug)
       node       <- ZIO.succeed(new ClouseauNode()(runtime, worker, metricsRegistry, logLevel))

--- a/core/src/main/scala/com/cloudant/ziose/core/Node.scala
+++ b/core/src/main/scala/com/cloudant/ziose/core/Node.scala
@@ -13,7 +13,7 @@ trait Node {
   def listNames(): ZIO[Node, _ <: Node.Error, List[String]]
   // testing only
   def lookUpName(name: String): ZIO[Node, _ <: Node.Error, Option[Codec.EPid]]
-  def monitorRemoteNode(name: String, timeout: Option[Duration] = None): ZIO[Node, _ <: Node.Error, Unit]
+  def monitorRemoteNode(name: String, interval: Duration, timeout: Duration): ZIO[Node, _ <: Node.Error, Unit]
   def makeRef(): ZIO[Any, _ <: Node.Error, Codec.ERef]
   def shutdown(implicit trace: Trace): UIO[Unit]
 }

--- a/otp/src/main/scala/com/cloudant/ziose/otp/OTPNode.scala
+++ b/otp/src/main/scala/com/cloudant/ziose/otp/OTPNode.scala
@@ -15,8 +15,8 @@ import com.cloudant.ziose.core.{
 }
 import com.cloudant.ziose.macros.CheckEnv
 import com.ericsson.otp.erlang.{OtpErlangPid, OtpErlangRef, OtpMbox, OtpNode}
-import zio.stream.{UStream, ZStream}
-import zio.{&, Duration, IO, Promise, Queue, RIO, RLayer, Schedule, Scope, Trace, UIO, URIO, ZIO, ZLayer, durationInt}
+import zio.stream.ZStream
+import zio.{&, Duration, IO, Promise, Queue, RIO, RLayer, Schedule, Scope, Trace, UIO, URIO, ZIO, ZLayer}
 import com.cloudant.ziose.core.EngineWorker
 import zio.Fiber
 import com.cloudant.ziose.core.Metrics
@@ -48,8 +48,8 @@ object OTPNode {
       cookie    = cfg.cookieVal
       service <-
         for {
-          _           <- ZIO.logDebug(s"Creating OtpNode($name, ****)")
-          nodeProcess <- NodeProcess.make(name, cookie, queue, accessKey)
+          _           <- ZIO.logDebug(s"Creating OtpNode($cfg)")
+          nodeProcess <- NodeProcess.make(name, cookie, queue, accessKey, cfg.pingTimeoutVal)
           fiber       <- nodeProcess.stream.runDrain.fork
           nodeScope   <- ZIO.scope
           service = unsafeMake(fiber, queue, nodeProcess, nodeScope, factory, ctx)
@@ -115,22 +115,18 @@ object OTPNode {
   class NodeProcess private (
     private val node: OtpNode,
     private val queue: Queue[Envelope[Command[_], _, _]],
-    accessKey: AccessKey
+    accessKey: AccessKey,
+    private val pingTimeout: Duration
   ) {
-    val DEFAULT_PING_TIMEOUT: Duration                 = 61.seconds
-    val DEFAULT_REMOTE_NODE_MONITOR_INTERVAL: Duration = 61.seconds
-    def release(): Unit                                = close()
-    def createMbox(name: String): OtpMbox              = node.createMbox(name)
-    def close(): Unit                                  = node.close()
-    def stream: ZStream[Scope, Nothing, Unit]          = ZStream.fromQueueWithShutdown(queue).mapZIO(loop)
-    def monitorRemoteNode(name: String, timeout: Option[Duration]): UStream[Boolean] = {
-      ZStream((name, timeout))
-        .schedule(Schedule.spaced(DEFAULT_REMOTE_NODE_MONITOR_INTERVAL))
-        .mapZIO(checkRemoteNode)
+    def release(): Unit                       = close()
+    def createMbox(name: String): OtpMbox     = node.createMbox(name)
+    def close(): Unit                         = node.close()
+    def stream: ZStream[Scope, Nothing, Unit] = ZStream.fromQueueWithShutdown(queue).mapZIO(loop)
+
+    def pingRemoteNode(name: String, timeout: Duration): UIO[Boolean] = {
+      ZIO.succeedBlocking(node.ping(name, timeout.toMillis))
     }
-    def checkRemoteNode(spec: (String, Option[Duration])): UIO[Boolean] = {
-      ZIO.succeedBlocking(node.ping(spec._1, spec._2.getOrElse(DEFAULT_PING_TIMEOUT).toMillis))
-    }
+
     def loop(event: Envelope[Command[_], _, _]): URIO[Scope, Unit] = for {
       _ <- event.command match {
         case StartActor(actor: AddressableActor[_, _], continue) =>
@@ -152,7 +148,7 @@ object OTPNode {
           node.close()
           Success(Response.CloseNode(()))
         case cmd @ PingNode(nodeName, None) =>
-          Success(Response.PingNode(node.ping(nodeName, DEFAULT_PING_TIMEOUT.toMillis)))
+          Success(Response.PingNode(node.ping(nodeName, pingTimeout.toMillis)))
         case cmd @ PingNode(nodeName, Some(timeout)) =>
           Success(Response.PingNode(node.ping(nodeName, timeout.toMillis)))
         case CreateMbox(None)       => Success(Response.CreateMbox(node.createMbox()))
@@ -186,11 +182,12 @@ object OTPNode {
       name: String,
       cookie: String,
       queue: Queue[Envelope[Command[_], _, _]],
-      accessKey: AccessKey
+      accessKey: AccessKey,
+      pingTimeout: Duration
     )(implicit trace: Trace): RIO[Scope, NodeProcess] = {
       ZIO.acquireRelease(
         ZIO.attemptBlocking(
-          new NodeProcess(new OtpNode(name, cookie), queue, accessKey)
+          new NodeProcess(new OtpNode(name, cookie), queue, accessKey, pingTimeout)
         )
       )(node => ZIO.attemptBlockingIO(node.close()).orDie.unit) // TODO orDie could be too harsh
     }
@@ -269,13 +266,12 @@ object OTPNode {
       }
 
       // TODO prevent attempts to run multiple monitors for the same node
-      def monitorRemoteNode(name: String, timeout: Option[Duration] = None): UIO[Unit] = {
-        val loop = process.monitorRemoteNode(name, timeout).runDrain.forever
-        for {
-          _ <- (for {
-            _ <- loop.forkIn(nodeScope)
-          } yield ()).fork
-        } yield ()
+      def monitorRemoteNode(name: String, timeout: Duration, interval: Duration): UIO[Unit] = {
+        process
+          .pingRemoteNode(name, timeout)
+          .schedule(Schedule.fixed(interval))
+          .forkIn(nodeScope)
+          .unit
       }
 
       private def startActor[A <: Actor](

--- a/otp/src/main/scala/com/cloudant/ziose/otp/OTPNode.scala
+++ b/otp/src/main/scala/com/cloudant/ziose/otp/OTPNode.scala
@@ -15,8 +15,8 @@ import com.cloudant.ziose.core.{
 }
 import com.cloudant.ziose.macros.CheckEnv
 import com.ericsson.otp.erlang.{OtpErlangPid, OtpErlangRef, OtpMbox, OtpNode}
-import zio.stream.{UStream, ZStream}
-import zio.{&, Duration, IO, Promise, Queue, RIO, RLayer, Schedule, Scope, Trace, UIO, URIO, ZIO, ZLayer, durationInt}
+import zio.stream.ZStream
+import zio.{&, Duration, IO, Promise, Queue, RIO, RLayer, Schedule, Scope, Trace, UIO, URIO, ZIO, ZLayer}
 import com.cloudant.ziose.core.EngineWorker
 import zio.Fiber
 import com.cloudant.ziose.core.Metrics
@@ -45,11 +45,11 @@ object OTPNode {
       ctx = OTPProcessContext.builder(Symbol(name))
       queue <- Queue.unbounded[Envelope[Command[_], _, _]].withFinalizer(_.shutdown)
       accessKey = AccessKey.create()
-      cookie    = cfg.cookieVal
+      cookie    = cfg.cookieResolved
       service <-
         for {
-          _           <- ZIO.logDebug(s"Creating OtpNode($name, ****)")
-          nodeProcess <- NodeProcess.make(name, cookie, queue, accessKey)
+          _           <- ZIO.logDebug(s"Creating OtpNode($cfg)")
+          nodeProcess <- NodeProcess.make(name, cookie, queue, accessKey, cfg.pingTimeoutResolved)
           fiber       <- nodeProcess.stream.runDrain.fork
           nodeScope   <- ZIO.scope
           service = unsafeMake(fiber, queue, nodeProcess, nodeScope, factory, ctx)
@@ -115,22 +115,18 @@ object OTPNode {
   class NodeProcess private (
     private val node: OtpNode,
     private val queue: Queue[Envelope[Command[_], _, _]],
-    accessKey: AccessKey
+    accessKey: AccessKey,
+    private val pingTimeout: Duration
   ) {
-    val DEFAULT_PING_TIMEOUT: Duration                 = 61.seconds
-    val DEFAULT_REMOTE_NODE_MONITOR_INTERVAL: Duration = 61.seconds
-    def release(): Unit                                = close()
-    def createMbox(name: String): OtpMbox              = node.createMbox(name)
-    def close(): Unit                                  = node.close()
-    def stream: ZStream[Scope, Nothing, Unit]          = ZStream.fromQueueWithShutdown(queue).mapZIO(loop)
-    def monitorRemoteNode(name: String, timeout: Option[Duration]): UStream[Boolean] = {
-      ZStream((name, timeout))
-        .schedule(Schedule.spaced(DEFAULT_REMOTE_NODE_MONITOR_INTERVAL))
-        .mapZIO(checkRemoteNode)
+    def release(): Unit                       = close()
+    def createMbox(name: String): OtpMbox     = node.createMbox(name)
+    def close(): Unit                         = node.close()
+    def stream: ZStream[Scope, Nothing, Unit] = ZStream.fromQueueWithShutdown(queue).mapZIO(loop)
+
+    def pingRemoteNode(name: String, timeout: Duration): UIO[Boolean] = {
+      ZIO.succeedBlocking(node.ping(name, timeout.toMillis))
     }
-    def checkRemoteNode(spec: (String, Option[Duration])): UIO[Boolean] = {
-      ZIO.succeedBlocking(node.ping(spec._1, spec._2.getOrElse(DEFAULT_PING_TIMEOUT).toMillis))
-    }
+
     def loop(event: Envelope[Command[_], _, _]): URIO[Scope, Unit] = for {
       _ <- event.command match {
         case StartActor(actor: AddressableActor[_, _], continue) =>
@@ -152,7 +148,7 @@ object OTPNode {
           node.close()
           Success(Response.CloseNode(()))
         case cmd @ PingNode(nodeName, None) =>
-          Success(Response.PingNode(node.ping(nodeName, DEFAULT_PING_TIMEOUT.toMillis)))
+          Success(Response.PingNode(node.ping(nodeName, pingTimeout.toMillis)))
         case cmd @ PingNode(nodeName, Some(timeout)) =>
           Success(Response.PingNode(node.ping(nodeName, timeout.toMillis)))
         case CreateMbox(None)       => Success(Response.CreateMbox(node.createMbox()))
@@ -186,11 +182,12 @@ object OTPNode {
       name: String,
       cookie: String,
       queue: Queue[Envelope[Command[_], _, _]],
-      accessKey: AccessKey
+      accessKey: AccessKey,
+      pingTimeout: Duration
     )(implicit trace: Trace): RIO[Scope, NodeProcess] = {
       ZIO.acquireRelease(
         ZIO.attemptBlocking(
-          new NodeProcess(new OtpNode(name, cookie), queue, accessKey)
+          new NodeProcess(new OtpNode(name, cookie), queue, accessKey, pingTimeout)
         )
       )(node => ZIO.attemptBlockingIO(node.close()).orDie.unit) // TODO orDie could be too harsh
     }
@@ -269,13 +266,12 @@ object OTPNode {
       }
 
       // TODO prevent attempts to run multiple monitors for the same node
-      def monitorRemoteNode(name: String, timeout: Option[Duration] = None): UIO[Unit] = {
-        val loop = process.monitorRemoteNode(name, timeout).runDrain.forever
-        for {
-          _ <- (for {
-            _ <- loop.forkIn(nodeScope)
-          } yield ()).fork
-        } yield ()
+      def monitorRemoteNode(name: String, timeout: Duration, interval: Duration): UIO[Unit] = {
+        process
+          .pingRemoteNode(name, timeout)
+          .schedule(Schedule.fixed(interval))
+          .forkIn(nodeScope)
+          .unit
       }
 
       private def startActor[A <: Actor](

--- a/otp/src/main/scala/com/cloudant/ziose/otp/OTPNodeConfig.scala
+++ b/otp/src/main/scala/com/cloudant/ziose/otp/OTPNodeConfig.scala
@@ -1,18 +1,31 @@
 package com.cloudant.ziose.otp
 
 import com.cloudant.ziose.macros.CheckEnv
-import zio.Config
+import zio.{Config, Duration, durationInt}
 import zio.config.magnolia.deriveConfig
 
-final case class OTPNodeConfig(name: String, domain: String, cookie: Option[String]) {
-  val cookieVal: String = cookie.getOrElse(OTPCookie.findOrGenerateCookie)
+final case class OTPNodeConfig(
+  name: String,
+  domain: String,
+  cookie: Option[String],
+  ping_timeout: Option[Duration],
+  ping_interval: Option[Duration]
+) {
+  val DEFAULT_PING_TIMEOUT: Duration  = 1.seconds
+  val DEFAULT_PING_INTERVAL: Duration = 60.seconds
+
+  val cookieResolved: String         = cookie.getOrElse(OTPCookie.findOrGenerateCookie)
+  val pingTimeoutResolved: Duration  = ping_timeout.getOrElse(DEFAULT_PING_TIMEOUT)
+  val pingIntervalResolved: Duration = ping_interval.getOrElse(DEFAULT_PING_INTERVAL)
 
   @CheckEnv(System.getProperty("env"))
   def toStringMacro: List[String] = List(
     s"${getClass.getSimpleName}",
     s"name=$name",
     s"domain=$domain",
-    s"cookie=****"
+    s"cookie=****",
+    s"ping_timeout=$pingTimeoutResolved",
+    s"ping_interval=$pingIntervalResolved"
   )
 }
 

--- a/otp/src/main/scala/com/cloudant/ziose/otp/OTPNodeConfig.scala
+++ b/otp/src/main/scala/com/cloudant/ziose/otp/OTPNodeConfig.scala
@@ -1,18 +1,31 @@
 package com.cloudant.ziose.otp
 
 import com.cloudant.ziose.macros.CheckEnv
-import zio.Config
+import zio.{Config, Duration, durationInt}
 import zio.config.magnolia.deriveConfig
 
-final case class OTPNodeConfig(name: String, domain: String, cookie: Option[String]) {
-  val cookieVal: String = cookie.getOrElse(OTPCookie.findOrGenerateCookie)
+final case class OTPNodeConfig(
+  name: String,
+  domain: String,
+  cookie: Option[String],
+  ping_timeout: Option[Duration],
+  ping_interval: Option[Duration]
+) {
+  val DEFAULT_PING_TIMEOUT: Duration  = 1.seconds
+  val DEFAULT_PING_INTERVAL: Duration = 60.seconds
+
+  val cookieVal: String         = cookie.getOrElse(OTPCookie.findOrGenerateCookie)
+  val pingTimeoutVal: Duration  = ping_timeout.getOrElse(DEFAULT_PING_TIMEOUT)
+  val pingIntervalVal: Duration = ping_interval.getOrElse(DEFAULT_PING_INTERVAL)
 
   @CheckEnv(System.getProperty("env"))
   def toStringMacro: List[String] = List(
     s"${getClass.getSimpleName}",
     s"name=$name",
     s"domain=$domain",
-    s"cookie=****"
+    s"cookie=****",
+    s"ping_timeout=$pingTimeoutVal",
+    s"ping_interval=$pingIntervalVal"
   )
 }
 

--- a/otp/src/main/scala/com/cloudant/ziose/otp/Utils.scala
+++ b/otp/src/main/scala/com/cloudant/ziose/otp/Utils.scala
@@ -1,7 +1,7 @@
 package com.cloudant.ziose.otp
 
 import com.cloudant.ziose.core.{ActorFactory, Engine, EngineWorker, Node}
-import zio.{&, TaskLayer, ZLayer}
+import zio.{&, TaskLayer, ZLayer, durationInt}
 
 object Utils {
   def testEnvironment(
@@ -9,7 +9,7 @@ object Utils {
     workerId: Engine.WorkerId,
     nodeName: String = "test"
   ): TaskLayer[EngineWorker & Node & ActorFactory & OTPNodeConfig] = {
-    val nodeCfg = OTPNodeConfig(nodeName, "127.0.0.1", Some("testCookie"))
+    val nodeCfg = OTPNodeConfig(nodeName, "127.0.0.1", Some("testCookie"), Some(1.second), Some(60.seconds))
     OTPLayers.nodeLayers(engineId, workerId, nodeCfg) ++ ZLayer.succeed(nodeCfg)
   }
 }


### PR DESCRIPTION
It is not recommended to specify very long timeout when calling the [`OtpNode#ping`](https://www.erlang.org/doc/apps/jinterface/assets/java/com/ericsson/otp/erlang/OtpNode.html#ping(java.lang.String,long)) method.  There is only a single attempt is made to connect to the remote node.  This is also a blocking call where it is not so useful to keep it waiting for a long time.

Shorten the ping timeout to 1 second only by default but make it configurable by the user in case fine-tuning is required.