### PR TITLE
build: enable native access for Lucene core functions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,16 +24,18 @@ TIMEOUT_ELIXIR_SEARCH?=20m
 
 REBAR?=rebar3
 
+JVM_FLAGS= \
+	--enable-native-access=ALL-UNNAMED
+
 ERLANG_COOKIE?= #
 ifneq ($(ERLANG_COOKIE),)
 	_DEVRUN_COOKIE=--erlang-cookie=$(ERLANG_COOKIE)
 	_ERLCALL_COOKIE=-c $(ERLANG_COOKIE)
-	_JAVA_COOKIE=-Dcookie=$(ERLANG_COOKIE)
+	JVM_FLAGS+=-Dcookie=$(ERLANG_COOKIE)
 	_REBAR_COOKIE=--setcookie=$(ERLANG_COOKIE)
 else
 	_DEVRUN_COOKIE=
 	_ERLCALL_COOKIE=
-	_JAVA_COOKIE=
 	_REBAR_COOKIE=
 endif
 
@@ -123,7 +125,7 @@ epmd:
 # target: clouseau2 - Start local instance of clouseau2 node
 # target: clouseau3 - Start local instance of clouseau3 node
 clouseau1 clouseau2 clouseau3: epmd
-	@sbt run -Dnode=$@ $(_JAVA_COOKIE)
+	@sbt run -Dnode=$@ $(JVM_FLAGS)
 
 $(ARTIFACTS_DIR):
 	@mkdir -p $@
@@ -191,6 +193,7 @@ $(JMX_EXPORTER):
 # target: jmx-prometheus - Export metrics to Prometheus
 jmx-prometheus: $(JAR_ARTIFACTS) $(JMX_EXPORTER) epmd
 	@java -javaagent:$(JMX_EXPORTER)=$(JMX_EXPORTER_PORT):$(JMX_EXPORTER_CFG) \
+		$(JVM_FLAGS) \
 		-jar $(JAR_ARTIFACTS)
 
 .PHONY: bin/clouseau_ctrl
@@ -271,7 +274,7 @@ FORCE: # https://www.gnu.org/software/make/manual/html_node/Force-Targets.html
 .PHONY: zeunit
 # target: zeunit - Run integration tests: `<ERLANG_COOKIE=cookie> make zeunit`
 zeunit: $(ARTIFACTS_DIR)/$(JAR_TEST) epmd FORCE
-	@cli start $@ "java $(_JAVA_COOKIE) -jar $<"
+	@cli start $@ "java $(JVM_FLAGS) -jar $<"
 	@sleep 5
 	@cli await $(node_name) "$(ERLANG_COOKIE)"
 	@cli zeunit $(node_name) "$(EUNIT_OPTS)" || $(MAKE) test-failed ID=$@
@@ -279,7 +282,7 @@ zeunit: $(ARTIFACTS_DIR)/$(JAR_TEST) epmd FORCE
 	@cli stop $@
 
 concurrent-zeunit-tests: $(ARTIFACTS_DIR)/$(JAR_TEST) epmd FORCE
-	@cli start $@ "java $(_JAVA_COOKIE) -jar $< concurrent.app.conf"
+	@cli start $@ "java $(JVM_FLAGS) -jar $< concurrent.app.conf"
 	@sleep 5
 	@cli await $(node_name) "$(ERLANG_COOKIE)"
 	@cli zeunit $(node_name) "$(EUNIT_OPTS)" || $(MAKE) test-failed ID=$@
@@ -299,7 +302,7 @@ syslog-test: $(JAR_ARTIFACTS) epmd FORCE
 		-e "s/%%FACILITY%%/$(FACILITY)/" \
 		-e "s/%%LEVEL%%/$(LEVEL)/" \
 		syslog.app.conf.templ > syslog.app.conf
-	@cli start $@ "java -jar $< syslog.app.conf"
+	@cli start $@ "java $(JVM_FLAGS) -jar $< syslog.app.conf"
 	@cli await $(node_name) "$(ERLANG_COOKIE)" || $(MAKE) test-failed ID=$@
 	@echo ">>> Waiting for Clouseau to generate logs (5 seconds)"
 	@sleep 5
@@ -388,7 +391,7 @@ test-failed:
 .PHONY: couchdb-tests
 # target: couchdb-tests - Run test suites from upstream CouchDB that use Clouseau
 couchdb-tests: $(JAR_ARTIFACTS) couchdb epmd FORCE
-	@cli start $@ "java $(_JAVA_COOKIE) -jar $<"
+	@cli start $@ "java $(JVM_FLAGS) -jar $<"
 	@cli await $(node_name) "$(ERLANG_COOKIE)"
 	@$(TIMEOUT) $(TIMEOUT_MANGO_TEST) $(MAKE) mango-test || $(MAKE) test-failed ID=$@
 	@$(TIMEOUT) $(TIMEOUT_ELIXIR_SEARCH) $(MAKE) elixir-search || $(MAKE) test-failed ID=$@
@@ -422,6 +425,7 @@ metrics-tests: $(JAR_ARTIFACTS) $(JMX_EXPORTER) collectd/clouseau.class epmd
 			-Dcom.sun.management.jmxremote.ssl=false \
 			-Dcom.sun.management.jmxremote.password.file=jmxremote.password \
 			-javaagent:$(JMX_EXPORTER)=$(JMX_EXPORTER_PORT):$(JMX_EXPORTER_CFG) \
+			$(JVM_FLAGS) \
 			-jar $(JAR_ARTIFACTS) metrics.app.conf > /dev/null
 	@sleep 5
 	@cli await $(node_name) "$(ERLANG_COOKIE)"
@@ -449,7 +453,7 @@ echo \"Ref = make_ref(), {sup, 'clouseau1@127.0.0.1'} ! {ping, self(), Ref}, rec
 .PHONY: compatibility-tests
 # target: compatibility-tests - Run Clouseau 2.x compatibility tests
 compatibility-tests: $(JAR_ARTIFACTS) couchdb epmd FORCE
-	@cli start $@ "java $(_JAVA_COOKIE) -jar $<"
+	@cli start $@ "java $(JVM_FLAGS) -jar $<"
 	@cli await $(node_name) "$(ERLANG_COOKIE)"
 	@$(MAKE) sup-test || $(MAKE) test-failed ID=$@
 	@cli stop $@
@@ -491,7 +495,7 @@ jstack:
 # target: tdump - Capture thread dumps
 tdump: CLOUSEAU_PID := $(shell $(clouseauPid))
 tdump: $(ARTIFACTS_DIR)/$(JAR_TEST)
-	@cli start $(node_name) "java -jar $<"
+	@cli start $(node_name) "java $(JVM_FLAGS) -jar $<"
 	@echo "Generate thread dumps..."
 	@rm -f tmp/thread_dump*.log
 	@for i in {1..3}; do \
@@ -552,7 +556,7 @@ ci-concurrent-zeunit: concurrent-zeunit-tests
 
 ci-mango: $(JAR_ARTIFACTS) couchdb epmd FORCE
 	@cli stop $@ || true
-	@cli start $@ "java $(_JAVA_COOKIE) -jar $< ci.app.conf"
+	@cli start $@ "java $(JVM_FLAGS) -jar $< ci.app.conf"
 	@sleep 5
 	@cli await $(node_name) "$(ERLANG_COOKIE)"
 	@$(TIMEOUT) $(TIMEOUT_MANGO_TEST) $(MAKE) mango-test || $(MAKE) test-failed ID=$@
@@ -560,7 +564,7 @@ ci-mango: $(JAR_ARTIFACTS) couchdb epmd FORCE
 
 ci-elixir: $(JAR_ARTIFACTS) couchdb epmd FORCE
 	@cli stop $@ || true
-	@cli start $@ "java $(_JAVA_COOKIE) -jar $< ci.app.conf"
+	@cli start $@ "java $(JVM_FLAGS) -jar $< ci.app.conf"
 	@cli await $(node_name) "$(ERLANG_COOKIE)"
 	@$(TIMEOUT) $(TIMEOUT_ELIXIR_SEARCH) $(MAKE) elixir-search || $(MAKE) test-failed ID=$@
 	@cli stop $@


### PR DESCRIPTION
[Leveraging memory-mapped I/O for Lucene 10 requires the invocation of the `madvise()` C library function](https://lucene.apache.org/core/10_4_0/core/org/apache/lucene/store/MMapDirectory.html), which is not unconditionally accessible but only when that is explicitly allowed for the Java Virtual Machine.

Enable that for developer and continuous integration workflows since that is something that one may want to do in production anyway.  While here, merge the injection of the required flag with how Erlang cookies are passed down to the application.