### PR TITLE
chore(`core`): disable tracking root fibers

### DIFF
--- a/clouseau/src/main/scala/com/cloudant/ziose/clouseau/Main.scala
+++ b/clouseau/src/main/scala/com/cloudant/ziose/clouseau/Main.scala
@@ -6,9 +6,11 @@ package com.cloudant.ziose.clouseau
 import com.cloudant.ziose.core.{ActorFactory, AddressableActor, EngineWorker, Node}
 import com.cloudant.ziose.otp.{OTPLayers, OTPNodeConfig}
 import com.cloudant.ziose.scalang.ScalangMeterRegistry
-import zio.{&, LogLevel, RIO, Scope, System, Task, ZIO, ZIOAppArgs, ZIOAppDefault}
+import zio.{&, LogLevel, RIO, Scope, System, Task, ZIO, ZIOAppArgs, ZIOAppDefault, Runtime, RuntimeFlag}
 
 object Main extends ZIOAppDefault {
+  override val bootstrap = Runtime.disableFlags(RuntimeFlag.FiberRoots)
+
   def getNodeIdx: Task[Int] = {
     for {
       prop <- System.property("node")


### PR DESCRIPTION
Root fibers are top-level fibers that are not children of any other fiber, the entry points of execution which are created on every `forkDaemon` call.  By default, the runtime keeps a record of all root fibers.  This is useful for debugging or lifecycle management but can [negatively impact performance](https://blog.pierre-ricadat.com/tuning-zio-for-high-performance/).  For example, when the application stops, ZIO attempts to interrupt root fibers — if tracking is disabled, it may only interrupt child fibers.

Clouseau actually uses a plenty of root fibers because every log event is run on those, independently of each other, possibly in an overlapping fashion.  The related performance hit is not obvious. That is only visible when the log volume is high, for example, when the log verbosity is set to `debug`.

Accept the compromise of losing the ability to keep track of root fibers in the dump and unlock the performance gain in exchange, because that is more valuable for managing the production load and testing scenarios.

This is a revisited version of #160.