### PR TITLE
fix(`ci`): unbreak + resiliency enhancements

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -55,3 +55,9 @@ jobs:
           timeout_minutes: 8
           max_attempts: 3
           command: mise exec -- make metrics-tests
+      - name: Clouseau Control tests
+        uses: nick-fields/retry@v4
+        with:
+          timeout_minutes: 3
+          max_attempts: 3
+          command: mise exec -- make clouseau-ctrl-smoke

--- a/Makefile
+++ b/Makefile
@@ -177,7 +177,7 @@ jar: $(ARTIFACTS_DIR)/$(JAR_PROD)
 jartest: $(ARTIFACTS_DIR)/$(JAR_TEST)
 
 $(JMX_EXPORTER):
-	@curl -LSso $(JMX_EXPORTER) $(JMX_EXPORTER_URL)
+	@curl -fLSso $(JMX_EXPORTER) $(JMX_EXPORTER_URL)
 
 .PHONY: jmx-prometheus
 # target: jmx-prometheus - Export metrics to Prometheus

--- a/Makefile
+++ b/Makefile
@@ -432,7 +432,8 @@ metrics-tests: $(JAR_ARTIFACTS) $(JMX_EXPORTER) test/collectd/clouseau.class epm
 			-Dcom.sun.management.jmxremote.ssl=false \
 			-Dcom.sun.management.jmxremote.password.file=jmxremote.password \
 			-javaagent:$(JMX_EXPORTER)=$(JMX_EXPORTER_PORT):$(JMX_EXPORTER_CFG) \
-			-jar $(JAR_ARTIFACTS) test/conf/metrics.app.conf > /dev/null
+			$(_JAVA_COOKIE) \
+			-jar $(JAR_ARTIFACTS) test/conf/metrics.app.conf
 	@sleep 5
 	@cli await $(node_name) "$(ERLANG_COOKIE)"
 	@echo "Warming up Clouseau to expose all the metrics"

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
 # Use bash to enable `read -d ''` option
 SHELL := /bin/bash
 
+export LC_ALL := C
+
 BUILD_DIR=$(shell pwd)
 ARTIFACTS_DIR=$(BUILD_DIR)/artifacts
 CI_ARTIFACTS_DIR=$(BUILD_DIR)/ci-artifacts

--- a/Makefile
+++ b/Makefile
@@ -251,7 +251,7 @@ help:
 clouseau-ctrl-smoke: bin/clouseau_ctrl epmd
 	@-cli stop clouseau1 >/dev/null 2>&1
 	@cli start clouseau1 sbt run -Dnode=clouseau1 $(_JAVA_COOKIE)
-	@cli await clouseau1 "$(ERLANG_COOKIE)"
+	@cli await clouseau1 "$(ERLANG_COOKIE)" || $(MAKE) await-failed ID=$@
 	@./clouseau-ctrl/_build/default/bin/clouseau_ctrl -config "$(BUILD_DIR)/clouseau-ctrl-config.erl" service list \
 		| tee tmp/clouseau-ctrl-smoke.out \
 		| grep -q analyzer \
@@ -277,7 +277,7 @@ FORCE: # https://www.gnu.org/software/make/manual/html_node/Force-Targets.html
 zeunit: $(ARTIFACTS_DIR)/$(JAR_TEST) epmd FORCE
 	@cli start $@ "java $(_JAVA_COOKIE) -jar $<"
 	@sleep 5
-	@cli await $(node_name) "$(ERLANG_COOKIE)"
+	@cli await $(node_name) "$(ERLANG_COOKIE)" || $(MAKE) await-failed ID=$@
 	@cli zeunit $(node_name) "$(EUNIT_OPTS)" || $(MAKE) test-failed ID=$@
 	@$(call to_artifacts,zeunit,test-reports)
 	@cli stop $@
@@ -285,7 +285,7 @@ zeunit: $(ARTIFACTS_DIR)/$(JAR_TEST) epmd FORCE
 concurrent-zeunit-tests: $(ARTIFACTS_DIR)/$(JAR_TEST) epmd FORCE
 	@cli start $@ "java $(_JAVA_COOKIE) -jar $< test/conf/concurrent.app.conf"
 	@sleep 5
-	@cli await $(node_name) "$(ERLANG_COOKIE)"
+	@cli await $(node_name) "$(ERLANG_COOKIE)" || $(MAKE) await-failed ID=$@
 	@cli zeunit $(node_name) "$(EUNIT_OPTS)" || $(MAKE) test-failed ID=$@
 	@cli stop $@
 
@@ -304,7 +304,7 @@ syslog-test: $(JAR_ARTIFACTS) epmd FORCE
 		-e "s/%%LEVEL%%/$(LEVEL)/" \
 		test/conf/syslog.app.conf.templ > test/conf/syslog.app.conf
 	@cli start $@ "java -jar $< test/conf/syslog.app.conf"
-	@cli await $(node_name) "$(ERLANG_COOKIE)" || $(MAKE) test-failed ID=$@
+	@cli await $(node_name) "$(ERLANG_COOKIE)" || $(MAKE) await-failed ID=$@
 	@echo ">>> Waiting for Clouseau to generate logs (5 seconds)"
 	@sleep 5
 	@cli stop $@
@@ -379,6 +379,12 @@ elixir-search: couchdb
 	@#                                       v-this is a hack
 	@$(MAKE) -C $(COUCHDB_DIR) elixir-search _WITH_CLOUSEAU=-q ERLANG_COOKIE=$(ERLANG_COOKIE)
 
+.PHONY: await-failed
+await-failed:
+	@echo ">>>> FAILED: Startup failed. Below are the process logs:"
+	@cat $(shell cli logs $(ID))
+	@exit 1
+
 .PHONY: test-failed
 test-failed:
 	@echo "The thread dump before attempt to force the shutdown"
@@ -393,7 +399,7 @@ test-failed:
 # target: couchdb-tests - Run test suites from upstream CouchDB that use Clouseau
 couchdb-tests: $(JAR_ARTIFACTS) couchdb epmd FORCE
 	@cli start $@ "java $(_JAVA_COOKIE) -jar $<"
-	@cli await $(node_name) "$(ERLANG_COOKIE)"
+	@cli await $(node_name) "$(ERLANG_COOKIE)" || $(MAKE) await-failed ID=$@
 	@$(TIMEOUT) $(TIMEOUT_MANGO_TEST) $(MAKE) mango-test || $(MAKE) test-failed ID=$@
 	@$(TIMEOUT) $(TIMEOUT_ELIXIR_SEARCH) $(MAKE) elixir-search || $(MAKE) test-failed ID=$@
 	@cli stop $@
@@ -435,7 +441,7 @@ metrics-tests: $(JAR_ARTIFACTS) $(JMX_EXPORTER) test/collectd/clouseau.class epm
 			$(_JAVA_COOKIE) \
 			-jar $(JAR_ARTIFACTS) test/conf/metrics.app.conf
 	@sleep 5
-	@cli await $(node_name) "$(ERLANG_COOKIE)"
+	@cli await $(node_name) "$(ERLANG_COOKIE)" || $(MAKE) await-failed ID=$@
 	@echo "Warming up Clouseau to expose all the metrics"
 	@$(TIMEOUT) $(TIMEOUT_MANGO_TEST) $(MAKE) mango-test || $(MAKE) test-failed ID=$@
 	@$(call collect_and_compare,\
@@ -462,7 +468,7 @@ echo \"Ref = make_ref(), {sup, 'clouseau1@127.0.0.1'} ! {ping, self(), Ref}, rec
 # target: compatibility-tests - Run Clouseau 2.x compatibility tests
 compatibility-tests: $(JAR_ARTIFACTS) couchdb epmd FORCE
 	@cli start $@ "java $(_JAVA_COOKIE) -jar $<"
-	@cli await $(node_name) "$(ERLANG_COOKIE)"
+	@cli await $(node_name) "$(ERLANG_COOKIE)" || $(MAKE) await-failed ID=$@
 	@$(MAKE) sup-test || $(MAKE) test-failed ID=$@
 	@cli stop $@
 
@@ -566,14 +572,14 @@ ci-mango: $(JAR_ARTIFACTS) couchdb epmd FORCE
 	@cli stop $@ || true
 	@cli start $@ "java $(_JAVA_COOKIE) -jar $< test/conf/ci.app.conf"
 	@sleep 5
-	@cli await $(node_name) "$(ERLANG_COOKIE)"
+	@cli await $(node_name) "$(ERLANG_COOKIE)" || $(MAKE) await-failed ID=$@
 	@$(TIMEOUT) $(TIMEOUT_MANGO_TEST) $(MAKE) mango-test || $(MAKE) test-failed ID=$@
 	@cli stop $@
 
 ci-elixir: $(JAR_ARTIFACTS) couchdb epmd FORCE
 	@cli stop $@ || true
 	@cli start $@ "java $(_JAVA_COOKIE) -jar $< test/conf/ci.app.conf"
-	@cli await $(node_name) "$(ERLANG_COOKIE)"
+	@cli await $(node_name) "$(ERLANG_COOKIE)" || $(MAKE) await-failed ID=$@
 	@$(TIMEOUT) $(TIMEOUT_ELIXIR_SEARCH) $(MAKE) elixir-search || $(MAKE) test-failed ID=$@
 	@cli stop $@
 

--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,7 @@ JMX_EXPORTER_VSN ?= 1.6.0
 JMX_EXPORTER ?= jmx_prometheus_javaagent-$(JMX_EXPORTER_VSN).jar
 JMX_EXPORTER_CFG ?= test/prometheus/jmx_exporter.yaml
 JMX_EXPORTER_PORT ?= 8080
-JMX_EXPORTER_URL := https://github.com/prometheus/jmx_exporter/releases/download/v$(JMX_EXPORTER_VSN)/$(JMX_EXPORTER)
+JMX_EXPORTER_URL := https://github.com/prometheus/jmx_exporter/releases/download/$(JMX_EXPORTER_VSN)/$(JMX_EXPORTER)
 
 comma := ,
 empty :=

--- a/Makefile
+++ b/Makefile
@@ -248,21 +248,21 @@ help:
 
 .PHONY: clouseau-ctrl-smoke
 # target: clouseau-ctrl-smoke - Start clouseau1 and verify `clouseau_ctrl service list`
-clouseau-ctrl-smoke: bin/clouseau_ctrl epmd
-	@-cli stop clouseau1 >/dev/null 2>&1
-	@cli start clouseau1 sbt run -Dnode=clouseau1 $(_JAVA_COOKIE)
+clouseau-ctrl-smoke: $(JAR_ARTIFACTS) bin/clouseau_ctrl epmd FORCE
+	@cli start $@ "java $(_JAVA_COOKIE) -jar $<"
 	@cli await clouseau1 "$(ERLANG_COOKIE)" || $(MAKE) await-failed ID=$@
 	@./clouseau-ctrl/_build/default/bin/clouseau_ctrl -config "$(BUILD_DIR)/clouseau-ctrl-config.erl" service list \
 		| tee tmp/clouseau-ctrl-smoke.out \
 		| grep -q analyzer \
-		|| ( echo '>>>>> clouseau_ctrl smoke test failed' ; exit 1 )
-	@-cli stop clouseau1 >/dev/null 2>&1
+		|| ( echo '>>>>> clouseau_ctrl smoke test FAILED' ; $(MAKE) test-failed ID=$@ )
+	@echo '>>>>> clouseau_ctrl smoke test PASSED'
+	@cli stop $@ || true
 
 ############### Tests ###############
 .PHONY: all-tests
 # target: all-tests - Run all test suites
 all-tests: test zeunit concurrent-zeunit-tests restart-test syslog-tests
-all-tests: couchdb-tests metrics-tests compatibility-tests
+all-tests: couchdb-tests metrics-tests compatibility-tests clouseau-ctrl-smoke
 
 .PHONY: test
 # target: test - Run all Scala tests

--- a/Makefile
+++ b/Makefile
@@ -403,11 +403,18 @@ define collect_and_compare
 	$(2)
 	echo "Comparing $(1) metrics with expectations:"
 	DIFF=$$(diff -u $(1)/metrics.out $(1)/metrics.expected); \
+	ERR=$$?; \
+	if [[ $$ERR -gt 1 ]]; then \
+		echo -e '\tFAILED: Diff failed to run!'; \
+		cli stop $@; \
+		exit 1; \
+	fi; \
 	if [[ -z $$DIFF ]]; then \
 		echo -e "\tEverything is in order"; \
 	else \
 		echo -e '\tFAILED: Metrics is different from "$(1)/metrics.expected"!'; \
 		echo "$$DIFF"; \
+		cli stop $@; \
 		exit 1; \
 	fi
 endef
@@ -418,7 +425,6 @@ test/collectd/clouseau.class: test/collectd/clouseau.java
 .PHONY: metrics-tests
 # target: metrics-tests - Run JMX metrics collection tests
 metrics-tests: $(JAR_ARTIFACTS) $(JMX_EXPORTER) test/collectd/clouseau.class epmd
-	@cli stop $@ > /dev/null 2>&1 || true
 	@chmod 600 jmxremote.password
 	@cli start $@ \
 		java \
@@ -432,14 +438,15 @@ metrics-tests: $(JAR_ARTIFACTS) $(JMX_EXPORTER) test/collectd/clouseau.class epm
 	@echo "Warming up Clouseau to expose all the metrics"
 	@$(TIMEOUT) $(TIMEOUT_MANGO_TEST) $(MAKE) mango-test || $(MAKE) test-failed ID=$@
 	@$(call collect_and_compare,\
-			collectd,\
+			test/collectd,\
 			java -cp test/collectd clouseau "service:jmx:rmi:///jndi/rmi://localhost:9090/jmxrmi" monitorRole password | \
 			sort > test/collectd/metrics.out)
 	@$(call collect_and_compare,\
-			prometheus,\
+			test/prometheus,\
 			curl -Ss "http://localhost:$(JMX_EXPORTER_PORT)/custom_path" | \
 				sed -n 's/^\(_com_cloudant_clouseau.*\)[[:space:]].*/\1/p' | \
 				sort > test/prometheus/metrics.out)
+	@cli stop $@ || true
 
 sup-test: couchdb
 	@$(COUCHDB_DIR)/dev/run \


### PR DESCRIPTION
The CI stopped working (at the `metrics-tests` phase) because the upstream for the Prometheus JMX Exporter adjusted their tag for the 1.6.0 release retroactively.  Unfortunately, the errors coming from this change were not apparent.  So, on top of addressing the root cause, the following enhancements have been implemented to make it easier to identify similar problems in the future.

- There was an oversight in 74e2f663 where the directory names have not been adjusted for the calling the `collect_and_compare` function.  The issue was not spotted before because the command did not raise any error when `diff` could not find the files to compare.

- The (optional) Java cookie was not passed for the application in `metrics-tests`.

- Make `curl` fail for HTTP 404/500 responses explicitly, because, by default, this is not done.  This let `curl` to create a file with the `Not Found` response for the Java Agent JAR, which broke the application start-up process.

- Make the uses of `cli await` present the application log on failures on startup so that one could immediately see if the problem was related to that.

- Revamp the smoke test for `clouseau-ctrl` and make it part of the CI pipeline, because it has not been hooked up apparently.

- Externalize the assumed locale settings to make the behavior of `sort` and `grep` deterministic across different platforms.