### PR TITLE
Add minimal remediate settings to Mend configuration

### DIFF
--- a/.whitesource
+++ b/.whitesource
@@ -3,7 +3,7 @@
   "remediateSettings": {
     "branchNameStrict": true,
     "branchPrefix": "renovate-",
-    "enabledManagers": ["sbt"],
+    "enabledManagers": ["sbt", "github-actions"],
     "enableRenovate": true,
     "extends": ["config:base", "mergeConfidence:all-badges"]
   }

--- a/.whitesource
+++ b/.whitesource
@@ -1,3 +1,10 @@
 {
-  "settingsInheritedFrom": "ibm-mend-config/mend-config@main"
+  "settingsInheritedFrom": "ibm-mend-config/mend-config@main",
+  "remediateSettings": {
+    "branchNameStrict": true,
+    "branchPrefix": "renovate-",
+    "enabledManagers": ["sbt"],
+    "enableRenovate": true,
+    "extends": ["config:base", "mergeConfidence:all-badges"]
+  }
 }


### PR DESCRIPTION
Enable Mend Renovate for sbt dependency updates

Updates `.whitesource` to opt this repo into Mend Renovate and enable automated PRs for sbt dependency updates.

_What_

- `enableRenovate: true` — opts the repo into Mend's Renovate remediation
- `enabledManagers: ["sbt"]` — scans `build.sbt` for outdated/vulnerable dependencies
- `extends: ["config:base", "mergeConfidence:all-badges"]` — Renovate standard defaults + merge confidence badges on PRs
- `branchPrefix: "renovate-"` / `branchNameStrict: true`— consistent, clean branch naming for PRs