### PR TITLE
Group renovate PRs by file or by lib that must be in sync among files

### DIFF
--- a/.whitesource
+++ b/.whitesource
@@ -3,8 +3,330 @@
   "remediateSettings": {
     "branchNameStrict": true,
     "branchPrefix": "renovate-",
-    "enabledManagers": ["sbt", "github-actions"],
     "enableRenovate": true,
-    "extends": ["config:base", "mergeConfidence:all-badges"]
+    "extends": ["config:base", "mergeConfidence:all-badges"],
+    "labels": ["dependencies"],
+    "recreateClosed": true,
+
+    "customDatasources": {
+      "mise-java-openjdk": {
+        "defaultRegistryUrlTemplate": "https://mise-java.jdx.dev/jvm/ga/linux/x86_64.json",
+        "transformTemplates": [
+          "{\"releases\": $map($filter($, function($e) { $e.vendor = \"openjdk\" }), function($e) { {\"version\": $e.version} })}"
+        ]
+      },
+      "conda-forge-sbt": {
+        "defaultRegistryUrlTemplate": "https://api.anaconda.org/package/conda-forge/sbt",
+        "transformTemplates": [
+          "{\"releases\": $map(versions, function($v) { {\"version\": $v} })}"
+        ]
+      }
+    },
+
+    "customManagers": [
+      {
+        "description": "Track java (openjdk) version in mise.toml via mise-java.jdx.dev",
+        "customType": "regex",
+        "fileMatch": ["^mise\\.toml$"],
+        "matchStrings": ["java\\s*=\\s*\"openjdk-(?<currentValue>[^\"]+)\""],
+        "depNameTemplate": "openjdk",
+        "datasourceTemplate": "custom.mise-java-openjdk",
+        "versioningTemplate": "semver-coerced"
+      },
+      {
+        "description": "Track editorconfig-checker version in mise.toml",
+        "customType": "regex",
+        "fileMatch": ["^mise\\.toml$"],
+        "matchStrings": ["editorconfig-checker\\s*=\\s*\\{\\s*version\\s*=\\s*\"(?<currentValue>[^\"]+)\""],
+        "depNameTemplate": "editorconfig-checker/editorconfig-checker",
+        "datasourceTemplate": "github-releases",
+        "versioningTemplate": "semver-coerced",
+        "extractVersionTemplate": "^v?(?<version>.+)$"
+      },
+      {
+        "description": "Track editorconfig-checker version in .editorconfig-checker.json",
+        "customType": "regex",
+        "fileMatch": ["^\\.editorconfig-checker\\.json$"],
+        "matchStrings": ["\"Version\"\\s*:\\s*\"v(?<currentValue>[^\"]+)\""],
+        "depNameTemplate": "editorconfig-checker/editorconfig-checker",
+        "datasourceTemplate": "github-releases",
+        "versioningTemplate": "semver-coerced",
+        "extractVersionTemplate": "^v?(?<version>.+)$"
+      },
+      {
+        "description": "Track scalafmt version in mise.toml",
+        "customType": "regex",
+        "fileMatch": ["^mise\\.toml$"],
+        "matchStrings": ["scalafmt\\s*=\\s*\\{\\s*version\\s*=\\s*\"(?<currentValue>[^\"]+)\""],
+        "depNameTemplate": "scalameta/scalafmt",
+        "datasourceTemplate": "github-releases",
+        "versioningTemplate": "semver-coerced",
+        "extractVersionTemplate": "^v?(?<version>.+)$"
+      },
+      {
+        "description": "Track scalafmt version in .scalafmt.conf",
+        "customType": "regex",
+        "fileMatch": ["^\\.scalafmt\\.conf$"],
+        "matchStrings": ["(?m)^version\\s*=\\s*(?<currentValue>[^\\s]+)"],
+        "depNameTemplate": "scalameta/scalafmt",
+        "datasourceTemplate": "github-releases",
+        "versioningTemplate": "semver-coerced",
+        "extractVersionTemplate": "^v?(?<version>.+)$"
+      },
+      {
+        "description": "Track sbt version in mise.toml against conda-forge",
+        "customType": "regex",
+        "fileMatch": ["^mise\\.toml$"],
+        "matchStrings": ["sbt\\s*=\\s*\\{\\s*version\\s*=\\s*\"(?<currentValue>[^\"]+)\""],
+        "depNameTemplate": "sbt",
+        "datasourceTemplate": "custom.conda-forge-sbt",
+        "versioningTemplate": "semver-coerced"
+      },
+      {
+        "description": "Track sbt version in project/build.properties against conda-forge",
+        "customType": "regex",
+        "fileMatch": ["^project/build\\.properties$"],
+        "matchStrings": ["sbt\\.version=(?<currentValue>[^\\n]+)"],
+        "depNameTemplate": "sbt",
+        "datasourceTemplate": "custom.conda-forge-sbt",
+        "versioningTemplate": "semver-coerced"
+      },
+      {
+        "description": "Update zio version in versions Map",
+        "customType": "regex",
+        "fileMatch": ["^build\\.sbt$"],
+        "matchStrings": ["\"zio\"\\s*->\\s*\"(?<currentValue>[^\"]+)\""],
+        "depNameTemplate": "dev.zio:zio_2.13",
+        "datasourceTemplate": "maven",
+        "versioningTemplate": "maven"
+      },
+      {
+        "description": "Update zio-config version in versions Map",
+        "customType": "regex",
+        "fileMatch": ["^build\\.sbt$"],
+        "matchStrings": ["\"zio\\.config\"\\s*->\\s*\"(?<currentValue>[^\"]+)\""],
+        "depNameTemplate": "dev.zio:zio-config_2.13",
+        "datasourceTemplate": "maven",
+        "versioningTemplate": "maven"
+      },
+      {
+        "description": "Update zio-logging version in versions Map",
+        "customType": "regex",
+        "fileMatch": ["^build\\.sbt$"],
+        "matchStrings": ["\"zio\\.logging\"\\s*->\\s*\"(?<currentValue>[^\"]+)\""],
+        "depNameTemplate": "dev.zio:zio-logging_2.13",
+        "datasourceTemplate": "maven",
+        "versioningTemplate": "maven"
+      },
+      {
+        "description": "Update zio-metrics version in versions Map",
+        "customType": "regex",
+        "fileMatch": ["^build\\.sbt$"],
+        "matchStrings": ["\"zio\\.metrics\"\\s*->\\s*\"(?<currentValue>[^\"]+)\""],
+        "depNameTemplate": "dev.zio:zio-metrics-connectors-micrometer_2.13",
+        "datasourceTemplate": "maven",
+        "versioningTemplate": "maven"
+      },
+      {
+        "description": "Update micrometer-jmx version in versions Map",
+        "customType": "regex",
+        "fileMatch": ["^build\\.sbt$"],
+        "matchStrings": ["\"jmx\"\\s*->\\s*\"(?<currentValue>[^\"]+)\""],
+        "depNameTemplate": "io.micrometer:micrometer-registry-jmx",
+        "datasourceTemplate": "maven",
+        "versioningTemplate": "maven"
+      },
+      {
+        "description": "Update scala-reflect version in versions Map",
+        "customType": "regex",
+        "fileMatch": ["^build\\.sbt$"],
+        "matchStrings": ["\"reflect\"\\s*->\\s*\"(?<currentValue>[^\"]+)\""],
+        "depNameTemplate": "org.scala-lang:scala-reflect",
+        "datasourceTemplate": "maven",
+        "versioningTemplate": "maven"
+      },
+      {
+        "description": "Update tinylog version in versions Map",
+        "customType": "regex",
+        "fileMatch": ["^build\\.sbt$"],
+        "matchStrings": ["\"tinylog\"\\s*->\\s*\"(?<currentValue>[^\"]+)\""],
+        "depNameTemplate": "org.tinylog:tinylog-api",
+        "datasourceTemplate": "maven",
+        "versioningTemplate": "maven"
+      },
+      {
+        "description": "Update junit-interface version in versions Map",
+        "customType": "regex",
+        "fileMatch": ["^build\\.sbt$"],
+        "matchStrings": ["\"junit\\.interface\"\\s*->\\s*\"(?<currentValue>[^\"]+)\""],
+        "depNameTemplate": "com.github.sbt:junit-interface",
+        "datasourceTemplate": "maven",
+        "versioningTemplate": "maven"
+      },
+      {
+        "description": "Update junit version in versions Map",
+        "customType": "regex",
+        "fileMatch": ["^build\\.sbt$"],
+        "matchStrings": ["\"junit\"\\s*->\\s*\"(?<currentValue>[^\"]+)\""],
+        "depNameTemplate": "junit:junit",
+        "datasourceTemplate": "maven",
+        "versioningTemplate": "maven"
+      }
+    ],
+
+    "packageRules": [
+      {
+        "description": "Pin scala to 2.13.x",
+        "matchPackageNames": ["scala"],
+        "allowedVersions": "/^2\\.13\\./"
+      },
+      {
+        "description": "Pin sbt to 1.x",
+        "matchPackageNames": ["sbt", "sbt/sbt"],
+        "allowedVersions": "/^1\\./"
+      },
+      {
+        "description": "Pin java (openjdk) to 21.x LTS",
+        "matchPackageNames": ["openjdk"],
+        "matchManagers": ["custom.regex"],
+        "allowedVersions": "/^21\\./"
+      },
+      {
+        "description": "Pin elixir to otp-27 compatible versions",
+        "matchPackageNames": ["elixir"],
+        "matchManagers": ["mise"],
+        "versioning": "regex:^(?<major>\\d+)\\.(?<minor>\\d+)(\\.(?<patch>\\d+))?(-otp-(?<compatibility>\\d+))?$",
+        "allowedVersions": "/^1\\.[0-9]+(\\.[0-9]+)?-otp-27$/"
+      },
+      {
+        "description": "Disable sbt from the mise manager (handled by regex customManager instead)",
+        "matchPackageNames": ["sbt", "sbt/sbt"],
+        "matchManagers": ["mise"],
+        "enabled": false
+      },
+      {
+        "description": "Disable scalafmt from the mise manager (handled by regex customManagers)",
+        "matchDepNames": ["scalafmt"],
+        "matchManagers": ["mise"],
+        "enabled": false
+      },
+      {
+        "description": "Disable editorconfig-checker from the mise manager (handled by regex customManagers)",
+        "matchDepNames": ["editorconfig-checker"],
+        "matchManagers": ["mise"],
+        "enabled": false
+      },
+      {
+        "description": "Disable java from the mise manager (handled by regex customManager)",
+        "matchPackageNames": ["java", "java-jdk"],
+        "matchManagers": ["mise"],
+        "enabled": false
+      },
+      {
+        "description": "Disable sbt/sbt in project/build.properties from sbt manager (handled via regex instead)",
+        "matchPackageNames": ["sbt/sbt"],
+        "matchManagers": ["sbt"],
+        "matchFileNames": ["project/build.properties"],
+        "enabled": false
+      },
+      {
+        "description": "Disable scalafmt built-in manager (handled via regex customManagers)",
+        "matchManagers": ["scalafmt"],
+        "enabled": false
+      },
+      {
+        "description": "Disable typst dependencies (not part of the application)",
+        "matchManagers": ["typst"],
+        "enabled": false
+      },
+      {
+        "description": "Group all mise tool updates into a single PR",
+        "matchManagers": ["mise"],
+        "groupName": "mise tools",
+        "groupSlug": "mise-tools"
+      },
+      {
+        "description": "Group openjdk into mise tools PR",
+        "matchPackageNames": ["openjdk"],
+        "matchManagers": ["custom.regex"],
+        "groupName": "mise tools",
+        "groupSlug": "mise-tools"
+      },
+      {
+        "description": "Group sbt from mise.toml into dedicated sbt version PR",
+        "matchPackageNames": ["sbt"],
+        "matchManagers": ["regex"],
+        "matchFileNames": ["mise.toml"],
+        "groupName": "sbt version",
+        "groupSlug": "sbt-version"
+      },
+      {
+        "description": "Group sbt from project/build.properties into dedicated sbt version PR",
+        "matchPackageNames": ["sbt"],
+        "matchManagers": ["regex"],
+        "matchFileNames": ["project/build.properties"],
+        "groupName": "sbt version",
+        "groupSlug": "sbt-version"
+      },
+      {
+        "description": "Group scalafmt from mise.toml and .scalafmt.conf into single PR",
+        "matchPackageNames": ["scalameta/scalafmt"],
+        "matchManagers": ["custom.regex"],
+        "groupName": "scalafmt version",
+        "groupSlug": "scalafmt-version"
+      },
+      {
+        "description": "Group editorconfig-checker from mise.toml and .editorconfig-checker.json into single PR",
+        "matchPackageNames": ["editorconfig-checker/editorconfig-checker"],
+        "matchManagers": ["custom.regex"],
+        "groupName": "editorconfig-checker version",
+        "groupSlug": "editorconfig-checker-version"
+      },
+      {
+        "description": "Group all sbt plugin updates from project/plugins.sbt into single PR",
+        "matchManagers": ["sbt"],
+        "matchFileNames": ["project/plugins.sbt"],
+        "groupName": "project/plugins.sbt dependencies",
+        "groupSlug": "sbt-plugins",
+        "prBodyNotes": ["❗ **Remember to keep `clouseau-ci/Dockerfile` in sync with these plugin version changes.**"]
+      },
+      {
+        "description": "Group inline sbt library dependencies from build.sbt",
+        "matchManagers": ["sbt"],
+        "matchFileNames": ["build.sbt"],
+        "groupName": "build.sbt dependencies",
+        "groupSlug": "sbt-dependencies"
+      },
+      {
+        "description": "Group versions Map dependencies (from build.sbt) with sbt dependencies PR",
+        "matchManagers": ["regex"],
+        "matchPackageNames": [
+          "dev.zio:zio_2.13",
+          "dev.zio:zio-config_2.13",
+          "dev.zio:zio-logging_2.13",
+          "dev.zio:zio-metrics-connectors-micrometer_2.13",
+          "io.micrometer:micrometer-registry-jmx",
+          "org.scala-lang:scala-reflect",
+          "org.tinylog:tinylog-api",
+          "com.github.sbt:junit-interface",
+          "junit:junit"
+        ],
+        "groupName": "build.sbt dependencies",
+        "groupSlug": "sbt-dependencies"
+      },
+      {
+        "description": "Block major java updates",
+        "matchPackageNames": ["openjdk"],
+        "matchManagers": ["custom.regex"],
+        "matchUpdateTypes": ["major"],
+        "enabled": false
+      },
+      {
+        "description": "Block major scala updates",
+        "matchPackageNames": ["scala", "org.scala-lang:scala-library"],
+        "matchUpdateTypes": ["major"],
+        "enabled": false
+      }
+    ]
   }
 }

--- a/build.sbt
+++ b/build.sbt
@@ -20,14 +20,17 @@ ThisBuild / version := s"${readVersion}"
 updateOptions := updateOptions.value.withCachedResolution(true)
 
 val versions: Map[String, String] = Map(
-  "zio"         -> "2.1.16",
-  "zio.config"  -> "4.0.4",
-  "zio.logging" -> "2.5.0",
-  "zio.metrics" -> "2.3.1",
-  "jmx"         -> "1.14.5",
-  "reflect"     -> "2.13.16",
-  "lucene"      -> "4.6.1-cloudant1",
-  "tinylog"     -> "2.7.0"
+  "zio"             -> "2.1.16",
+  "zio.config"      -> "4.0.4",
+  "zio.logging"     -> "2.5.0",
+  "zio.metrics"     -> "2.3.1",
+  "jmx"             -> "1.14.5",
+  "reflect"         -> "2.13.16",
+  "lucene"          -> "4.6.1-cloudant1",
+  "tinylog"         -> "2.7.0",
+  "junit"           -> "4.13.2",
+  "junit.interface" -> "0.13.3",
+  // If you add here a new dependency with a version, ensure you add it to customManagers in renovate.json
 )
 
 lazy val luceneComponents = Seq(
@@ -162,10 +165,10 @@ lazy val commonSettings = Seq(
     "org.scala-lang" % "scala-reflect"                     % versions("reflect"),
     "org.tinylog"    % "tinylog-api"                       % versions("tinylog"),
     "org.tinylog"    % "tinylog-impl"                      % versions("tinylog"),
-    "dev.zio"       %% "zio-test"                          % versions("zio") % Test,
-    "dev.zio"       %% "zio-test-junit"                    % versions("zio") % Test,
-    "com.github.sbt" % "junit-interface"                   % "0.13.3"        % Test,
-    "junit"          % "junit"                             % "4.13.2"        % Test
+    "dev.zio"       %% "zio-test"                          % versions("zio")              % Test,
+    "dev.zio"       %% "zio-test-junit"                    % versions("zio")              % Test,
+    "com.github.sbt" % "junit-interface"                   % versions("junit.interface")  % Test,
+    "junit"          % "junit"                             % versions("junit")            % Test
   ),
   assembly / assemblyMergeStrategy := commonMergeStrategy,
   ThisBuild / assemblyShadeRules := shadeRules,


### PR DESCRIPTION
_What_
Configured Mend / Renovate automated dependency updates with grouped PR rules and refactored `build.sbt` so test library versions are managed centrally for tracking.

_How_
- **Mend / Renovate Config (`.whitesource`)**:
  - Added custom datasources (`mise-java-openjdk`, `conda-forge-sbt`) and to track Java, `sbt`. 
  - Added regex `customManagers` to track version changes in `build.sbt` because it turned out Renovate cannot see the versions if those are in nested data structures like we have.
  - Made grouping by `scalafmt` `editorconfig-checker`, and `sbt` library versions across `mise.toml` <--> `.scalafmt.conf`, `.editorconfig-checker.json`, `project/build.properties`.
  - Configured `packageRules` to pin version ranges (Scala 2.13.x, sbt 1.x, Java 21.x LTS, Elixir OTP-27) and disable unneeded built-in managers (`typst`, built-in `mise`/`scalafmt`).
  - Grouped PRs by filescope (`mise tools`, `sbt-plugins`, `sbt-dependencies`).
  - Blocked major version updates for Java and Scala.
- **Build (`build.sbt`)**:
  - Extracted inline versions of `junit` (`4.13.2`) and `junit-interface` (`0.13.3`) in [`build.sbt`](build.sbt:20) into the `versions` Map to enable regex tracking by Renovate.

_Tests_
I tested this behavior on my own fork with a `renovate.json` file. With the last version of `renovate.json` the Renovate tool opened these 7 PRs against my repo:
https://github.com/mojito317/clouseau/pulls?q=is%3Apr+is%3Aopen+label%3Adependencies

Without custom data sources newer versions could be found for `sbt` and `java` versions in the commonly used registry, and mise step failed with newer versions, because it could not find it in its own registry.
E.g.:
renovate version | PR | result of run
-- | -- | --
[no custom data source for java](https://github.com/mojito317/clouseau/blob/914323c83140e70b3acea47165105e1611ef6d75/renovate.json#L113-L116) | https://github.com/mojito317/clouseau/pull/89 |  https://github.com/mojito317/clouseau/actions/runs/31388923800/job/93455713435 
[no custom data source for sbt](https://github.com/mojito317/clouseau/blob/939e5e61394d7e9e74ba2fc230d4eeb0b4b49cd6/renovate.json#L93-L114) | https://github.com/mojito317/clouseau/pull/69 | https://github.com/mojito317/clouseau/actions/runs/31379410414/job/93425975161