### PR TITLE
fix(`ci`): cover documentation

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -4,6 +4,8 @@ on:
   pull_request:
     branches:
       - main
+    paths-ignore:
+      - 'docs/**'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,0 +1,31 @@
+name: Build documentation
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'docs/**'
+      - '.github/workflows/docs.yml'
+      - 'mise.toml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v6
+      - run: git config advice.detachedHead false
+      - name: Install mise & tools
+        uses: jdx/mise-action@v4
+        with:
+          env: true
+          cache: true
+          export_path: true
+
+      - name: Build documentation
+        run: make docs

--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,8 @@ JAR_TEST := clouseau_$(SCALA_VSN)_$(PROJECT_VSN)_test.jar
 
 RELEASE_FILES := $(JAR_PROD) \
 	clouseau-$(PROJECT_VSN)-dist.zip \
-	clouseau-$(PROJECT_VSN)-dist.tar.gz
+	clouseau-$(PROJECT_VSN)-dist.tar.gz \
+	book.pdf
 
 JAR_ARTIFACTS := $(addprefix $(ARTIFACTS_DIR)/, $(JAR_PROD))
 RELEASE_ARTIFACTS := $(addprefix $(ARTIFACTS_DIR)/, $(RELEASE_FILES))


### PR DESCRIPTION
Documentation was sitting in the `docs` sub-directory but we did not have a coverage for that in the CI.  Create a separate workflow that could be run independently and therefore in parallel to regular build workflow (when required) to address this gap, based on the existing `docs` `make` target.

Make the documentation officially part of the releases.