### PR TITLE
fix(`zeunit`): tighten the requirements on version reporting over EDP

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ endif
 ifeq ($(PROJECT_VSN),)
 	# technically we could use 'sbt -Dsbt.supershell=false -error "print version"'
 	# but it takes 30 seconds to run it. So we go with direct access
-	PROJECT_VSN := $(shell cat $(BUILD_DIR)/version.sbt | sed -e \
+	export PROJECT_VSN := $(shell cat $(BUILD_DIR)/version.sbt | sed -e \
 		'/ThisBuild[[:space:]]*[/][[:space:]]*version[[:space:]]*[:]=[[:space:]]*/!d' \
 		-e "s///g" \
 		-e 's/\"//g')

--- a/zeunit/test/clouseau_rpc_tests.erl
+++ b/zeunit/test/clouseau_rpc_tests.erl
@@ -154,11 +154,12 @@ t_analyze(_, _) ->
     ?assertEqual([Text], TokensKeyword).
 
 t_version(_, _) ->
+    ProjectVersion = list_to_binary(os:getenv("PROJECT_VSN")),
     {ok, Version} = clouseau_rpc:version(),
     ?assertEqual(
-        match,
-        re:run(Version, "^[0-9]+\\.[0-9]+\\.[0-9]+($|[-])", [{capture, none}]),
-        "Expected version to be in A.B.C format, where A, B and C are integers."
+        ProjectVersion,
+        Version,
+        "Expected version to be matching with that of the project."
     ).
 
 t_cleanup_1(_, {_, ShardsDbName, _}) ->


### PR DESCRIPTION
Instead of relying on a regular expression to verify if the `clouseau_rpc:version/0` call returns some semantic version number, use the Scala project version, as given in `version.sbt`, to check if that is the one that is returned actually.

This can help to avoid unsuspiciously going by the assumption that the way how the version number is extracted in Scala / Java via [`getClass.getPackage.getImplementationVersion`][1] would always report the right value.  Because, according to the documentation, there is no actual guarantee about that:

> It consists of any string assigned by the vendor of this implementation and does not have any particular syntax specified or expected by the Java runtime.

Thanks @poor-a for pointing this out.

[1]: https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/lang/Package.html#getImplementationVersion()