### PR TITLE
fix(`ci`): unbreak & unify

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,4 +1,4 @@
-name: Build 3.x
+name: Build & Test
 
 on:
   pull_request:
@@ -16,48 +16,61 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - run: git config advice.detachedHead false
+
       - name: Install mise & tools
         uses: jdx/mise-action@v4
+        with:
+          env: true
+          cache: true
+          export_path: true
 
       - name: Lint
-        run: mise exec -- make ci-lint
+        run: make ci-lint
+
       - name: Unit tests
         uses: nick-fields/retry@v4
         with:
           timeout_minutes: 5
           max_attempts: 3
-          command: mise exec -- make test
+          command: make test
+
       - name: Restart test
-        run: mise exec -- make restart-test
+        run: make restart-test
+
       - name: RPC tests (zeunit)
         uses: nick-fields/retry@v4
         with:
           timeout_minutes: 5
           max_attempts: 3
-          command: mise exec -- make zeunit
+          command: make zeunit
+
       - name: Concurrent RPC tests (zeunit)
         uses: nick-fields/retry@v4
         with:
           timeout_minutes: 5
           max_attempts: 3
-          command: mise exec -- make concurrent-zeunit-tests
+          command: make concurrent-zeunit-tests
+
       - name: Syslog tests
-        run: mise exec -- make syslog-tests
+        run: make syslog-tests
+
       - name: Elixir tests
         uses: nick-fields/retry@v4
         with:
           timeout_minutes: 5
           max_attempts: 3
-          command: mise exec -- make ci-elixir
+          command: make ci-elixir
+
       - name: Metrics tests (mango)
         uses: nick-fields/retry@v4
         with:
           timeout_minutes: 8
           max_attempts: 3
-          command: mise exec -- make metrics-tests
+          command: make metrics-tests
+
       - name: Clouseau Control tests
         uses: nick-fields/retry@v4
         with:
           timeout_minutes: 3
           max_attempts: 3
-          command: mise exec -- make clouseau-ctrl-smoke
+          command: make clouseau-ctrl-smoke

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,4 +1,4 @@
-name: Release 3.x
+name: Release
 
 on:
   push:
@@ -10,25 +10,31 @@ permissions:
 
 jobs:
   release:
-    name: Release of clouseau-{version}
+    name: Prepare a Clouseau release
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
       - run: git config advice.detachedHead false
+
       - name: Set ENV for github-release
         run: |
           echo "RELEASE_TAG=${GITHUB_REF:10}" >> $GITHUB_ENV
           echo "RELEASE_NAME=$GITHUB_WORKFLOW" >> $GITHUB_ENV
+
       - name: Install mise & tools
         uses: jdx/mise-action@v4
+        with:
+          env: true
+          cache: true
+          export_path: true
 
-      - name: Test
-        run: mise exec -- make test
       - name: Generate artifacts
-        run: mise exec -- make artifacts
+        run: make artifacts
+
       - name: List artifacts
         run: ls artifacts
+
       - name: Create release
-        run: mise exec -- make release
+        run: make release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,8 @@ TIMEOUT?=timeout --foreground
 TIMEOUT_MANGO_TEST?=20m
 TIMEOUT_ELIXIR_SEARCH?=20m
 
+SBT?=sbt --java-home $(JAVA_HOME)
+
 REBAR?=rebar3
 
 ERLANG_COOKIE?= #
@@ -110,7 +112,7 @@ endef
 .PHONY: build
 # target: build - Build package, run tests and create distribution
 build: epmd
-	@sbt compile
+	@$(SBT) compile
 
 ERL_EPMD_ADDRESS?=127.0.0.1
 
@@ -123,7 +125,7 @@ epmd:
 # target: clouseau2 - Start local instance of clouseau2 node
 # target: clouseau3 - Start local instance of clouseau3 node
 clouseau1 clouseau2 clouseau3: epmd
-	@sbt run -Dnode=$@ $(_JAVA_COOKIE)
+	@$(SBT) run -Dnode=$@ $(_JAVA_COOKIE)
 
 $(ARTIFACTS_DIR):
 	@mkdir -p $@
@@ -157,7 +159,7 @@ format-code: erlfmt-format scalafmt-format
 .PHONY: check-deps
 # target: check-deps - Detect publicly disclosed vulnerabilities
 check-deps: build $(ARTIFACTS_DIR)
-	@sbt dependencyCheck \
+	@$(SBT) dependencyCheck \
 		-Dnvd_update=$(OWASP_NVD_UPDATE) \
 		-Dnvd_data_dir=$(OWASP_NVD_DATA_DIR) \
 		-Dlog4j2.level=info
@@ -196,14 +198,14 @@ clouseau-ctrl/_build/default/bin/clouseau_ctrl: clouseau-ctrl/src
 	@cd clouseau-ctrl/ && $(REBAR) escriptize
 
 $(ARTIFACTS_DIR)/$(JAR_PROD): $(ARTIFACTS_DIR)
-	@sbt assembly
+	@$(SBT) assembly
 	@cp clouseau/target/scala-$(SCALA_SHORT_VSN)/$(@F) $@
 	@javap -classpath $@ com.cloudant.ziose.clouseau.EchoService \
 		| grep -q 'public boolean isProduction' \
 		|| ( echo '>>>>> incorrect override EchoService' ; exit 1 )
 
 $(ARTIFACTS_DIR)/$(JAR_TEST): $(ARTIFACTS_DIR)
-	@sbt assembly -Djartest=true
+	@$(SBT) assembly -Djartest=true
 	@cp clouseau/target/scala-$(SCALA_SHORT_VSN)/$(@F) $@
 	@javap -classpath $@ com.cloudant.ziose.clouseau.EchoService \
 		| grep -q 'public boolean isTest' \
@@ -214,11 +216,11 @@ clean:
 	@rm -rf tmp $(ARTIFACTS_DIR)/*
 	@rm -f test/collectd/*.class test/collectd/*.out
 	@rm -rf bin/clouseau_ctrl ; cd clouseau-ctrl && $(REBAR) clean
-	@sbt clean
+	@$(SBT) clean
 
 # target: clean-all - Clean up the project to start afresh
 clean-all:
-	@sbt clean
+	@$(SBT) clean
 	@echo '==> keep in mind that some state is stored in ~/.ivy2/cache/ and ~/.sbt'
 	@echo '     and in  ~/Library/Caches/Coursier/v1/https/'
 	@echo '    to fully clean the cache use `make clean-user-cache`'
@@ -269,7 +271,7 @@ all-tests: couchdb-tests metrics-tests compatibility-tests clouseau-ctrl-smoke
 .PHONY: test
 # target: test - Run all Scala tests
 test: build $(ARTIFACTS_DIR)
-	@sbt clean test
+	@$(SBT) clean test
 	@$(call to_artifacts,$(ALL_SUBPROJECTS),test-reports)
 
 FORCE: # https://www.gnu.org/software/make/manual/html_node/Force-Targets.html


### PR DESCRIPTION
This pull request features two changes to the CI integration:

- _Set Java home explicitly for SBT._  There may be configurations where `mise` fails to properly override the Java version in use for `sbt`, which can lead to problems with the build.  A notable example of that is the `ubuntu-latest` GitHub Actions runner where Java 25 is available, while `mise` wants to use Java 21 and `sbt` somehow still falls back to the former.  This way the build may be unbroken.

- _Revamp and unify workflows._ The `jdx/mise-action` GitHub Action does not require to call `mise exec` on every step, but with the `env` and `export_path` settings, it can just propagate the necessary environment variables.  In addition to that, rename the workflows to omit the references to the major version number, as they could be re-used for testing the code and producing artifacts for the 4.x line of releases too.  Also, remove the single testing step from the release workflow as we could assume that extensive testing has happened before, on merging changes for the `main` branch.