### PR TITLE
[Clouseau-ctrl] Print help for subcommands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -146,7 +146,7 @@ check-fmt: $(ARTIFACTS_DIR)
 .PHONY: erlfmt-format
 # target: erlfmt-format - Format Erlang code automatically
 erlfmt-format:
-	@erlfmt --write -- $(ERL_SRCS)
+	@rebar3 fmt --verbose --write -- $(ERL_SRCS)
 
 .PHONY: scalafmt-format
 # target: scalafmt-format - Format Scala code automatically

--- a/clouseau-ctrl/src/clouseau_cli.erl
+++ b/clouseau-ctrl/src/clouseau_cli.erl
@@ -15,7 +15,7 @@
 -endif.
 
 parser_options() ->
-    #{progname => clouseau_cli}.
+    #{progname => clouseau_ctrl}.
 
 spec(Services) ->
     spec(Services, runtime).

--- a/clouseau-ctrl/src/clouseau_cli.erl
+++ b/clouseau-ctrl/src/clouseau_cli.erl
@@ -150,19 +150,34 @@ arguments(Mode) ->
     ].
 
 help(Services) ->
-    argparse:help(spec(Services, help), parser_options()).
+    help(Services, []).
+help(Services, Path) ->
+    try
+        io:format("~s~n", [
+            argparse:help(spec(Services, help), (parser_options())#{command => Path})
+        ])
+    catch
+        error:_ ->
+            io:format("Invalid argument '~s'~n", [lists:concat(lists:join(" ", Path))]),
+            argparse:help(spec(Services, help), (parser_options()))
+    end.
 
-run(["--help"], Services) ->
-    io:format("~s", [help(Services)]);
-run(["help"], Services) ->
-    io:format("~s", [help(Services)]);
+run(["--help" | Path], Services) ->
+    help(Services, Path);
+run(["help" | Path], Services) ->
+    help(Services, Path);
 run(Args, Services) ->
-    {ok, ParsedArgs, _Path, CommandSpec} = argparse:parse(Args, spec(Services), parser_options()),
-    clouseau_utils:dispatch(
-        normalize_args(
-            maps:merge(ParsedArgs, maps:with([handler], CommandSpec))
-        )
-    ).
+    case argparse:parse(Args, spec(Services), parser_options()) of
+        {ok, ParsedArgs, _Path, CommandSpec} ->
+            clouseau_utils:dispatch(
+                normalize_args(
+                    maps:merge(ParsedArgs, maps:with([handler], CommandSpec))
+                )
+            );
+        {error, Error} ->
+            io:format("~s~n", [argparse:format_error(Error)]),
+            help(Services)
+    end.
 
 %%====================================================================
 %% Internal functions


### PR DESCRIPTION
Erlang's argparse module can print formatted help message of nested subcommands.

Instead of failing with an exception for invalid subcommands or incomplete argument lists, the subcommand's usage help is printed on screen.

## Comparison
### Case 1 - Empty argument list
#### Upstream
```
$ bin/clouseau_ctrl 
escript: exception error: no match of right hand side value 
                 {error,{["clouseau_cli"],
                         undefined,undefined,<<"subcommand expected">>}}
  in function  clouseau_cli:run/2 (/Users/arturpoor/repo/clouseau/clouseau-ctrl/src/clouseau_cli.erl, line 160)
  in call from escript:run/2 (escript.erl, line 904)
  in call from escript:start/1 (escript.erl, line 418)
  in call from init:start_it/1 
  in call from init:start_em/1 
  in call from init:do_boot/3 
```
#### Fork
````
$ bin/clouseau_ctrl
clouseau_cli: subcommand expected
Usage:
  clouseau_cli {service} [-config <config>] [-name <name>] [-cookie <cookie>]
               [-host <host>] [-format <format>]

Utility to control 'clouseau' process

Subcommands:
  service Service management

Optional arguments:
  -config Path to clouseau-ctrl config file. Can also be set via
          CLOUSEAU_CTRL_CONFIG. (string), default:
          /etc/clouseau/clouseau-ctrl-config.erl
  -name   The name of clouseau node (e.g. 'clouseau1'). Resolution order: CLI,
          CLOUSEAU_NODE_NAME, config file. (string)
  -cookie Erlang cookie to use for connecting. Resolution order: CLI,
          CLOUSEAU_COOKIE, config file, ~/.erlang.cookie. (string)
  -host   Host name of the clouseau node (e.g. '127.0.0.1'). Resolution order:
          CLI, CLOUSEAU_HOST, config file, 127.0.0.1. (string)
  -format Output format: 'json' or 'table'. Resolution order: CLI,
          CLOUSEAU_FORMAT, config file, table. (existing atom)
````

### Case 2 - Help message for `service`
#### Upstream

````
$ bin/clouseau_ctrl help service
escript: exception error: no match of right hand side value 
                 {error,{["clouseau_cli"],undefined,"help",<<>>}}
  in function  clouseau_cli:run/2 (/Users/arturpoor/repo/clouseau/clouseau-ctrl/src/clouseau_cli.erl, line 160)
  in call from escript:run/2 (escript.erl, line 904)
  in call from escript:start/1 (escript.erl, line 418)
  in call from init:start_it/1 
  in call from init:start_em/1 
  in call from init:do_boot/3 
````

#### Fork

````
$ bin/clouseau_ctrl help service
Usage:
  clouseau_cli service <command> [-config <config>] [-name <name>]
               [-cookie <cookie>] [-host <host>] [-format <format>]

Service management

Subcommands:
  check   Check status of a service
  info    Get info about a service
  list    List all services
  metrics Get metrics of a service
  report  Print health report of a service
  restart Restart a service

Optional arguments:
  -config Path to clouseau-ctrl config file. Can also be set via
          CLOUSEAU_CTRL_CONFIG. (string), default:
          /etc/clouseau/clouseau-ctrl-config.erl
  -name   The name of clouseau node (e.g. 'clouseau1'). Resolution order: CLI,
          CLOUSEAU_NODE_NAME, config file. (string)
  -cookie Erlang cookie to use for connecting. Resolution order: CLI,
          CLOUSEAU_COOKIE, config file, ~/.erlang.cookie. (string)
  -host   Host name of the clouseau node (e.g. '127.0.0.1'). Resolution order:
          CLI, CLOUSEAU_HOST, config file, 127.0.0.1. (string)
  -format Output format: 'json' or 'table'. Resolution order: CLI,
          CLOUSEAU_FORMAT, config file, table. (existing atom)
````

