### PR TITLE
Split dependency management: Dependabot for sbt/Actions/Docker, Renovate for mise

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,54 @@
+version: 2
+
+updates:
+  # sbt — covers build.sbt and project/plugins.sbt
+  - package-ecosystem: "sbt"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    labels:
+      - "dependencies"
+    # Pin Scala to current major version; ignore sbt version updates (owned by renovate)
+    ignore:
+      - dependency-name: "org.scala-lang:scala-library"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "org.scala-lang:scala-reflect"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "org.scala-sbt:sbt"
+    groups:
+      sbt-plugins:
+        patterns:
+          - "com.eed3si9n:sbt-assembly"
+          - "com.eed3si9n:sbt-buildinfo"
+          - "io.github.siculo:sbt-bom"
+          - "net.nmoncho:sbt-dependency-check"
+          - "org.scalameta:sbt-scalafmt"
+      sbt-dependencies:
+        patterns:
+          - "dev.zio:*"
+          - "io.micrometer:micrometer-registry-jmx"
+          - "org.scala-lang:*"
+          - "org.tinylog:*"
+          - "com.github.sbt:junit-interface"
+          - "junit:junit"
+          - "org.apache.lucene:*"
+
+  # GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    labels:
+      - "dependencies"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+
+  # Docker
+  - package-ecosystem: "docker"
+    directory: "/docker"
+    schedule:
+      interval: "monthly"
+    labels:
+      - "dependencies"

--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -1,0 +1,18 @@
+name: Update Dependency Graph
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+
+jobs:
+  dependency-graph:
+    name: Update Dependency Graph
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: sbt/setup-sbt@c7d2d6258b4bd0d3ec5129e6b3453199d3c79729 # v1
+      - uses: scalacenter/sbt-dependency-submission@7b2f7e1418cb4a77fee99f9eb07c3f7577b9a867 # v3

--- a/.whitesource
+++ b/.whitesource
@@ -8,6 +8,8 @@
     "labels": ["dependencies"],
     "recreateClosed": true,
 
+    "enabledManagers": ["mise", "custom.regex"],
+
     "customDatasources": {
       "mise-java-openjdk": {
         "defaultRegistryUrlTemplate": "https://mise-java.jdx.dev/jvm/ga/linux/x86_64.json",
@@ -90,99 +92,13 @@
         "depNameTemplate": "sbt",
         "datasourceTemplate": "custom.conda-forge-sbt",
         "versioningTemplate": "semver-coerced"
-      },
-      {
-        "description": "Update zio version in versions Map",
-        "customType": "regex",
-        "fileMatch": ["^build\\.sbt$"],
-        "matchStrings": ["\"zio\"\\s*->\\s*\"(?<currentValue>[^\"]+)\""],
-        "depNameTemplate": "dev.zio:zio_2.13",
-        "datasourceTemplate": "maven",
-        "versioningTemplate": "maven"
-      },
-      {
-        "description": "Update zio-config version in versions Map",
-        "customType": "regex",
-        "fileMatch": ["^build\\.sbt$"],
-        "matchStrings": ["\"zio\\.config\"\\s*->\\s*\"(?<currentValue>[^\"]+)\""],
-        "depNameTemplate": "dev.zio:zio-config_2.13",
-        "datasourceTemplate": "maven",
-        "versioningTemplate": "maven"
-      },
-      {
-        "description": "Update zio-logging version in versions Map",
-        "customType": "regex",
-        "fileMatch": ["^build\\.sbt$"],
-        "matchStrings": ["\"zio\\.logging\"\\s*->\\s*\"(?<currentValue>[^\"]+)\""],
-        "depNameTemplate": "dev.zio:zio-logging_2.13",
-        "datasourceTemplate": "maven",
-        "versioningTemplate": "maven"
-      },
-      {
-        "description": "Update zio-metrics version in versions Map",
-        "customType": "regex",
-        "fileMatch": ["^build\\.sbt$"],
-        "matchStrings": ["\"zio\\.metrics\"\\s*->\\s*\"(?<currentValue>[^\"]+)\""],
-        "depNameTemplate": "dev.zio:zio-metrics-connectors-micrometer_2.13",
-        "datasourceTemplate": "maven",
-        "versioningTemplate": "maven"
-      },
-      {
-        "description": "Update micrometer-jmx version in versions Map",
-        "customType": "regex",
-        "fileMatch": ["^build\\.sbt$"],
-        "matchStrings": ["\"jmx\"\\s*->\\s*\"(?<currentValue>[^\"]+)\""],
-        "depNameTemplate": "io.micrometer:micrometer-registry-jmx",
-        "datasourceTemplate": "maven",
-        "versioningTemplate": "maven"
-      },
-      {
-        "description": "Update scala-reflect version in versions Map",
-        "customType": "regex",
-        "fileMatch": ["^build\\.sbt$"],
-        "matchStrings": ["\"reflect\"\\s*->\\s*\"(?<currentValue>[^\"]+)\""],
-        "depNameTemplate": "org.scala-lang:scala-reflect",
-        "datasourceTemplate": "maven",
-        "versioningTemplate": "maven"
-      },
-      {
-        "description": "Update tinylog version in versions Map",
-        "customType": "regex",
-        "fileMatch": ["^build\\.sbt$"],
-        "matchStrings": ["\"tinylog\"\\s*->\\s*\"(?<currentValue>[^\"]+)\""],
-        "depNameTemplate": "org.tinylog:tinylog-api",
-        "datasourceTemplate": "maven",
-        "versioningTemplate": "maven"
-      },
-      {
-        "description": "Update junit-interface version in versions Map",
-        "customType": "regex",
-        "fileMatch": ["^build\\.sbt$"],
-        "matchStrings": ["\"junit\\.interface\"\\s*->\\s*\"(?<currentValue>[^\"]+)\""],
-        "depNameTemplate": "com.github.sbt:junit-interface",
-        "datasourceTemplate": "maven",
-        "versioningTemplate": "maven"
-      },
-      {
-        "description": "Update junit version in versions Map",
-        "customType": "regex",
-        "fileMatch": ["^build\\.sbt$"],
-        "matchStrings": ["\"junit\"\\s*->\\s*\"(?<currentValue>[^\"]+)\""],
-        "depNameTemplate": "junit:junit",
-        "datasourceTemplate": "maven",
-        "versioningTemplate": "maven"
       }
     ],
 
     "packageRules": [
       {
-        "description": "Pin scala to 2.13.x",
-        "matchPackageNames": ["scala"],
-        "allowedVersions": "/^2\\.13\\./"
-      },
-      {
         "description": "Pin sbt to 1.x",
-        "matchPackageNames": ["sbt", "sbt/sbt"],
+        "matchPackageNames": ["sbt"],
         "allowedVersions": "/^1\\./"
       },
       {
@@ -223,23 +139,6 @@
         "enabled": false
       },
       {
-        "description": "Disable sbt/sbt in project/build.properties from sbt manager (handled via regex instead)",
-        "matchPackageNames": ["sbt/sbt"],
-        "matchManagers": ["sbt"],
-        "matchFileNames": ["project/build.properties"],
-        "enabled": false
-      },
-      {
-        "description": "Disable scalafmt built-in manager (handled via regex customManagers)",
-        "matchManagers": ["scalafmt"],
-        "enabled": false
-      },
-      {
-        "description": "Disable typst dependencies (not part of the application)",
-        "matchManagers": ["typst"],
-        "enabled": false
-      },
-      {
         "description": "Group all mise tool updates into a single PR",
         "matchManagers": ["mise"],
         "groupName": "mise tools",
@@ -251,22 +150,6 @@
         "matchManagers": ["custom.regex"],
         "groupName": "mise tools",
         "groupSlug": "mise-tools"
-      },
-      {
-        "description": "Group sbt from mise.toml into dedicated sbt version PR",
-        "matchPackageNames": ["sbt"],
-        "matchManagers": ["regex"],
-        "matchFileNames": ["mise.toml"],
-        "groupName": "sbt version",
-        "groupSlug": "sbt-version"
-      },
-      {
-        "description": "Group sbt from project/build.properties into dedicated sbt version PR",
-        "matchPackageNames": ["sbt"],
-        "matchManagers": ["regex"],
-        "matchFileNames": ["project/build.properties"],
-        "groupName": "sbt version",
-        "groupSlug": "sbt-version"
       },
       {
         "description": "Group scalafmt from mise.toml and .scalafmt.conf into single PR",
@@ -281,51 +164,6 @@
         "matchManagers": ["custom.regex"],
         "groupName": "editorconfig-checker version",
         "groupSlug": "editorconfig-checker-version"
-      },
-      {
-        "description": "Group all sbt plugin updates from project/plugins.sbt into single PR",
-        "matchManagers": ["sbt"],
-        "matchFileNames": ["project/plugins.sbt"],
-        "groupName": "project/plugins.sbt dependencies",
-        "groupSlug": "sbt-plugins",
-        "prBodyNotes": ["❗ **Remember to keep `clouseau-ci/Dockerfile` in sync with these plugin version changes.**"]
-      },
-      {
-        "description": "Group inline sbt library dependencies from build.sbt",
-        "matchManagers": ["sbt"],
-        "matchFileNames": ["build.sbt"],
-        "groupName": "build.sbt dependencies",
-        "groupSlug": "sbt-dependencies"
-      },
-      {
-        "description": "Group versions Map dependencies (from build.sbt) with sbt dependencies PR",
-        "matchManagers": ["regex"],
-        "matchPackageNames": [
-          "dev.zio:zio_2.13",
-          "dev.zio:zio-config_2.13",
-          "dev.zio:zio-logging_2.13",
-          "dev.zio:zio-metrics-connectors-micrometer_2.13",
-          "io.micrometer:micrometer-registry-jmx",
-          "org.scala-lang:scala-reflect",
-          "org.tinylog:tinylog-api",
-          "com.github.sbt:junit-interface",
-          "junit:junit"
-        ],
-        "groupName": "build.sbt dependencies",
-        "groupSlug": "sbt-dependencies"
-      },
-      {
-        "description": "Block major java updates",
-        "matchPackageNames": ["openjdk"],
-        "matchManagers": ["custom.regex"],
-        "matchUpdateTypes": ["major"],
-        "enabled": false
-      },
-      {
-        "description": "Block major scala updates",
-        "matchPackageNames": ["scala", "org.scala-lang:scala-library"],
-        "matchUpdateTypes": ["major"],
-        "enabled": false
       }
     ]
   }

--- a/build.sbt
+++ b/build.sbt
@@ -19,34 +19,22 @@ ThisBuild / version := s"${readVersion}"
 
 updateOptions := updateOptions.value.withCachedResolution(true)
 
-val versions: Map[String, String] = Map(
-  "zio"             -> "2.1.16",
-  "zio.config"      -> "4.0.4",
-  "zio.logging"     -> "2.5.0",
-  "zio.metrics"     -> "2.3.1",
-  "jmx"             -> "1.14.5",
-  "reflect"         -> "2.13.16",
-  "lucene"          -> "4.6.1-cloudant1",
-  "tinylog"         -> "2.7.0",
-  "junit"           -> "4.13.2",
-  "junit.interface" -> "0.13.3",
-  // If you add here a new dependency with a version, ensure you add it to customManagers in renovate.json
-)
+val vLucene       = "4.6.1-cloudant1"
 
 lazy val luceneComponents = Seq(
   // The single % is for java libraries
   // the %% appends the version of scala used, and should be used for scala libraries;
   // the %%% is for scala-js (and scala native).
-  "org.apache.lucene" % "lucene-core"               % versions("lucene"),
-  "org.apache.lucene" % "lucene-grouping"           % versions("lucene"),
-  "org.apache.lucene" % "lucene-queryparser"        % versions("lucene"),
-  "org.apache.lucene" % "lucene-analyzers-common"   % versions("lucene"),
-  "org.apache.lucene" % "lucene-analyzers-stempel"  % versions("lucene"),
-  "org.apache.lucene" % "lucene-analyzers-smartcn"  % versions("lucene"),
-  "org.apache.lucene" % "lucene-analyzers-kuromoji" % versions("lucene"),
-  "org.apache.lucene" % "lucene-facet"              % versions("lucene"),
-  "org.apache.lucene" % "lucene-spatial"            % versions("lucene"),
-  "org.apache.lucene" % "lucene-highlighter"        % versions("lucene")
+  "org.apache.lucene" % "lucene-core"               % vLucene,
+  "org.apache.lucene" % "lucene-grouping"           % vLucene,
+  "org.apache.lucene" % "lucene-queryparser"        % vLucene,
+  "org.apache.lucene" % "lucene-analyzers-common"   % vLucene,
+  "org.apache.lucene" % "lucene-analyzers-stempel"  % vLucene,
+  "org.apache.lucene" % "lucene-analyzers-smartcn"  % vLucene,
+  "org.apache.lucene" % "lucene-analyzers-kuromoji" % vLucene,
+  "org.apache.lucene" % "lucene-facet"              % vLucene,
+  "org.apache.lucene" % "lucene-spatial"            % vLucene,
+  "org.apache.lucene" % "lucene-highlighter"        % vLucene
 )
 
 /**
@@ -152,23 +140,23 @@ lazy val commonSettings = Seq(
     // The single % is for java libraries
     // the %% appends the version of scala used, and should be used for scala libraries;
     // the %%% is for scala-js (and scala native).
-    "dev.zio"       %% "zio"                               % versions("zio"),
-    "dev.zio"       %% "zio-config"                        % versions("zio.config"),
-    "dev.zio"       %% "zio-config-magnolia"               % versions("zio.config"),
-    "dev.zio"       %% "zio-config-typesafe"               % versions("zio.config"),
-    "dev.zio"       %% "zio-logging"                       % versions("zio.logging"),
+    "dev.zio"       %% "zio"                               % "2.1.16",
+    "dev.zio"       %% "zio-config"                        % "4.0.4",
+    "dev.zio"       %% "zio-config-magnolia"               % "4.0.4",
+    "dev.zio"       %% "zio-config-typesafe"               % "4.0.4",
+    "dev.zio"       %% "zio-logging"                       % "2.5.0",
     // This is needed because micrometer (see below) uses SLF4J
-    "dev.zio"       %% "zio-logging-slf4j-bridge"          % versions("zio.logging"),
-    "dev.zio"       %% "zio-metrics-connectors-micrometer" % versions("zio.metrics"),
-    "dev.zio"       %% "zio-streams"                       % versions("zio"),
-    "io.micrometer"  % "micrometer-registry-jmx"           % versions("jmx"),
-    "org.scala-lang" % "scala-reflect"                     % versions("reflect"),
-    "org.tinylog"    % "tinylog-api"                       % versions("tinylog"),
-    "org.tinylog"    % "tinylog-impl"                      % versions("tinylog"),
-    "dev.zio"       %% "zio-test"                          % versions("zio")              % Test,
-    "dev.zio"       %% "zio-test-junit"                    % versions("zio")              % Test,
-    "com.github.sbt" % "junit-interface"                   % versions("junit.interface")  % Test,
-    "junit"          % "junit"                             % versions("junit")            % Test
+    "dev.zio"       %% "zio-logging-slf4j-bridge"          % "2.5.0",
+    "dev.zio"       %% "zio-metrics-connectors-micrometer" % "2.3.1",
+    "dev.zio"       %% "zio-streams"                       % "2.1.16",
+    "io.micrometer"  % "micrometer-registry-jmx"           % "1.14.5",
+    "org.scala-lang" % "scala-reflect"                     % "2.13.16",
+    "org.tinylog"    % "tinylog-api"                       % "2.7.0",
+    "org.tinylog"    % "tinylog-impl"                      % "2.7.0",
+    "dev.zio"       %% "zio-test"                          % "2.1.16"    % Test,
+    "dev.zio"       %% "zio-test-junit"                    % "2.1.16"    % Test,
+    "com.github.sbt" % "junit-interface"                   % "0.13.3"    % Test,
+    "junit"          % "junit"                             % "4.13.2"    % Test
   ),
   assembly / assemblyMergeStrategy := commonMergeStrategy,
   ThisBuild / assemblyShadeRules := shadeRules,


### PR DESCRIPTION
### Why

Mend Renovate ought to handle all dependency updates using a mix of native managers and custom regex managers.
In `build.sbt`, Renovate was matching versions via custom regex managers against a `val versions: Map[String, String]` pattern getting new versions from Maven Central. This worked initially on my fork which did not use IBM flavored Mend, but for IBM flavored Mend updates stopped arriving after Maven Central introduced rate limiting.

In the meantime, GitHub added native [sbt ecosystem support to Dependabot](https://docs.github.com/en/code-security/reference/supply-chain-security/supported-ecosystems-and-repositories#sbt) ([May 2026](https://github.blog/changelog/2026-05-26-dependabot-version-updates-now-support-the-sbt-ecosystem/)). This was not available when Renovate was first considered to be adopted for this project. Dependabot resolves version lookups server-side within GitHub's own infrastructure, avoiding the Maven Central rate limiting issue entirely.

Using virtual Artifactory instance was also considered, but that brought up an unacceptable security trade-off.

We would like to still keep the `mise.toml` updates though, which [is still not supported by Dependabot](https://github.com/dependabot/dependabot-core/issues/12320) (and seems like it will not be supported soon).

This PR therefore replaces Renovate's update coverage including sbt with Dependabot, while keeping Renovate for `mise.toml`.

### How the tool split is implemented
What | Tool | Why
-- | -- | --
`build.sbt` + `project/plugins.sbt` | Dependabot (`sbt`) | Native support, no Maven Central rate limit issues
GitHub Actions | Dependabot (`github-actions`) | Native, standard
Docker | Dependabot (`docker`) | Native
`mise.toml` tool versions | Renovate | Dependabot has no mise support
sbt version (`mise.toml` + `project/build.properties`) |  Renovate | Must be updated atomically across both files
scalafmt version (`mise.toml` + `.scalafmt.conf`) |  Renovate | Must be updated atomically across both files
editorconfig-checker version (`mise.toml` + `.editorconfig-checker.json`) |  Renovate | Must be updated atomically across both files
openjdk (`mise.toml`) | Renovate | Is working only with available `mise-java.jdx.dev` datasource, pinned to 21.x LTS

### Changes

- `.github/dependabot.yml` — enables Dependabot for `sbt`, `github-actions`, and `docker` ecosystems. Updates grouped into `sbt-plugins`, `sbt-dependencies`, and `github-actions` PRs. `org.scala-sbt:sbt` is ignored because it is owned by Renovate and Scala major bumps are also ignored.

- `.github/workflows/dependency-submission.yml` - submits the resolved sbt dependency graph to GitHub's Dependency Graph API on every push to `main`, enabling Dependabot security alerts for CVEs.

- `.whitesource` — adds `"enabledManagers": ["mise", "custom.regex"]` to restrict Renovate to mise only. Removes all `build.sbt` custom regex managers and now-redundant package rules.

- `build.sbt` — replaces the `val versions: Map[String, String]` indirection with inline literal version strings, required for Dependabot's static sbt parser. The custom Lucene version (`4.6.1-cloudant1`) stays as `val vLucene` since it lives in a private Cloudant Maven repo and should not be updated automatically.

### Tests

On my fork these PRs were opened

URL | Bot | File | What
-- | -- | -- | --
https://github.com/mojito317/clouseau/pull/175 | Renovate (although it seems like it was me, but I experienced such glitches during testing) | `project/build.properties` and `mise.toml` | `sbt`:`1.12.9` → `1.13.0`
https://github.com/mojito317/clouseau/pull/174 | Renovate | `mise.toml` | `elixir`:`1.19.5-otp-27` → `1.20.3-otp-27` <br>`github-cli`:`2.92.0` → `2.98.0` <br>`jq`:`1.8.1` → `1.8.2`<br>`openjdk`:`21.0.1` → `21.0.2`<br>`python`:`3.14.5` → `3.14.7`<br>`typst`:`0.14.2` → `0.15.1`
https://github.com/mojito317/clouseau/pull/173 | Renovate | `.editorconfig-checker.json` and `mise.toml` | `editorconfig-checker`:`3.7.0` → `3.11.2`
https://github.com/mojito317/clouseau/pull/172 | Renovate | `.scalafmt.conf` and `mise.toml` | `scalafmt`:`3.11.1` → `3.11.5`
https://github.com/mojito317/clouseau/pull/170 | Dependabot  | `build.sbt` | `dev.zio:zio_2.13`:`2.1.16` → `2.1.26`<br>`dev.zio:zio-config_2.13`:`4.0.4` → `4.0.8`<br>`dev.zio:zio-logging_2.13`:`2.5.0` → `2.5.3`<br>`dev.zio:zio-metrics-connectors-micrometer_2.13`:`2.3.1` → `2.5.7`<br>`io.micrometer:micrometer-registry-jmx`:`1.14.5` → `1.17.1`<br>`org.scala-lang:scala-reflect`:`2.13.16` → `2.13.18`
https://github.com/mojito317/clouseau/pull/166 | Dependabot | `project/plugins.sbt`|`com.eed3si9n:sbt-assembly`:`2.1.5` → `2.4.2`<br>`com.eed3si9n:sbt-buildinfo`:`0.11.0` → `0.13.1`<br>`net.nmoncho:sbt-dependency-check`:`1.8.2` → `2.0.0`<br>`org.scalameta:sbt-scalafmt`:`2.5.2` → `2.6.2`
https://github.com/mojito317/clouseau/pull/165 | Dependabot | `.github/workflows/build.yaml`, `.github/workflows/dependency-submission.yml`, `.github/workflows/release.yaml` | `actions/checkout`:`v6` → `v7`