### PR TITLE
chore: schedule Renovate to run monthly, set limit of concurrent PRs to 20

### DIFF
--- a/.whitesource
+++ b/.whitesource
@@ -7,6 +7,8 @@
     "extends": ["config:base", "mergeConfidence:all-badges"],
     "labels": ["dependencies"],
     "recreateClosed": true,
+    "schedule": ["0 0 1 * *"],
+    "prConcurrentLimit": 20,
 
     "enabledManagers": ["mise", "custom.regex"],
 


### PR DESCRIPTION
- Restrict PR creation to the 1st of each month (schedule)
- Set prConcurrentLimit to 20 (default was 10)

The schedule keeps us less busy with the updates. In an ideal case https://github.com/cloudant-labs/clouseau/pull/210 would not show up the day after https://github.com/cloudant-labs/clouseau/pull/208 was merged, but on 1st of October. Dependabot is also set to monthly schedule.
We would get the security updates out of the schedule based on this conversation: https://github.com/renovatebot/renovate/discussions/34923.

I touched the limit because it counts the other opened PRs too, not only the ones Renovate created. That's why it happened 3 PRs out of 5 were not instantly opened once I enabled the new Mend configuration. 20 should be enough for now in my opinion. If it does not turn to be enough, we can always modify on the number.