### PR TITLE
fix: correct Renovate schedule cron syntax

### DIFF
--- a/.whitesource
+++ b/.whitesource
@@ -7,7 +7,7 @@
     "extends": ["config:base", "mergeConfidence:all-badges"],
     "labels": ["dependencies"],
     "recreateClosed": true,
-    "schedule": ["0 0 1 * *"],
+    "schedule": ["* * 1 * *"],
     "prConcurrentLimit": 20,
 
     "enabledManagers": ["mise", "custom.regex"],


### PR DESCRIPTION
Fixes https://github.com/cloudant-labs/clouseau/issues/213

I missed this in the documentation: https://docs.renovatebot.com/configuration-options/#schedule:~:text=For%20Cron%20schedules%2C%20you%20must%20use%20the%20%2A%20wildcard

Now I have changed the hour to `*` too, so Renovate can pick the ideal time for running it during the day.