### PR TITLE
fix(`Makefile`): `artifacts` target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,6 +85,10 @@ EUNIT_OPTS := "$(_REBAR_COOKIE) --module=$(suites) --test=$(tests)"
 JAR_PROD := clouseau_$(SCALA_VSN)_$(PROJECT_VSN).jar
 JAR_TEST := clouseau_$(SCALA_VSN)_$(PROJECT_VSN)_test.jar
 
+CI_FILES := \
+	$(JAR_PROD) \
+	clouseau-$(PROJECT_VSN)-dist.zip
+
 RELEASE_FILES := $(CI_FILES) \
 	clouseau-$(PROJECT_VSN)-dist.tar.gz \
 	book.pdf
@@ -561,10 +565,6 @@ version:
 
 ci-lint: check-fmt $(CI_ARTIFACTS_DIR)
 	@cp $(ARTIFACTS_DIR)/*.log $(CI_ARTIFACTS_DIR)
-
-CI_FILES := \
-	$(JAR_PROD) \
-	clouseau-$(PROJECT_VSN)-dist.zip
 
 CI_ARTIFACTS := $(addprefix $(ARTIFACTS_DIR)/, $(CI_FILES))
 


### PR DESCRIPTION
The split of `RELEASE_FILES` implemented in d7514125 carried a subtle bug because the definition of `CI_FILES` shall be given before `RELEASE_FILES` is expanded.  Without that, `CI_FILES` is assumed to be empty which removes the `-dist.zip` from the list of release artifacts and then the release is created without that.

Besides addressing the issue, the change improves the readability as one does not have to search for the definition of `CI_FILES`.